### PR TITLE
0 -- Remove level=4, use role for admin checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ src/
 
 ### Permission Levels
 Defined in `src/lib/permissions.ts`:
-- **Level 3**: All schools access (admin)
+- **Level 3**: All schools access
 - **Level 2**: Region-based access (not fully implemented)
 - **Level 1**: Specific school codes only
+- Admin status is determined by `role = "admin"`, not by level
 
 ### Database Schema (External PostgreSQL)
 Tables queried:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Admin interface for managing JNV (Jawahar Navodaya Vidyalaya) student enrollment
 - **School Dashboard**: Browse schools with search and filtering
 - **Student Search**: Search students across accessible schools by name, ID, or phone
 - **Grade Filtering**: Filter students by grade within a school
-- **User Permissions**: Role-based access control with 4 levels:
-  - Level 4 (Admin): Full access + user management
+- **User Permissions**: Role-based access control with 3 school scope levels:
   - Level 3 (All Schools): Access to all JNV schools
   - Level 2 (Region): Access to schools in specific regions
   - Level 1 (School): Access to specific schools only
+  - Admin status is determined by role, not level
 - **Read-only Mode**: Optional view-only access for any permission level
 
 ## Tech Stack
@@ -199,7 +199,7 @@ This is intentional technical debt for rapid development. The DB Service is Avan
 
 Permissions are stored in `user_permission` table:
 - `email`: User's email (unique)
-- `level`: Access level (1-4)
+- `level`: School scope level (1-3)
 - `school_codes`: Array of school codes (for level 1)
 - `regions`: Array of region names (for level 2)
 - `read_only`: Boolean for view-only access

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -107,7 +107,7 @@ Stores user access permissions for this CRUD UI. See [permissions.md](permission
 | id | serial | Primary key |
 | email | varchar(255) | User email (unique) |
 | role | varchar(50) | `teacher`, `program_manager`, `program_admin`, or `admin` (default: `teacher`) |
-| level | integer | 1=School, 2=Region, 3=All Schools, 4=Admin |
+| level | integer | 1=School, 2=Region, 3=All Schools |
 | school_codes | text[] | Array of school codes (for level 1) |
 | regions | text[] | Array of region names (for level 2) |
 | program_ids | integer[] | Array of program IDs the user is assigned to (1=CoE, 2=Nodal, 64=NVS) |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -29,7 +29,7 @@ Separating scope, capabilities, and ownership keeps each concern simple. A singl
 |--------|------|---------|
 | `email` | varchar(255) | User identifier |
 | `role` | varchar(50) | `teacher`, `program_manager`, `program_admin`, or `admin` |
-| `level` | integer | 1=specific schools, 2=region, 3=all schools, 4=admin |
+| `level` | integer | 1=specific schools, 2=region, 3=all schools |
 | `school_codes` | text[] | Specific school codes (level 1) |
 | `regions` | text[] | Region names (level 2) |
 | `program_ids` | integer[] | Which programs the user is assigned to |
@@ -43,7 +43,6 @@ The `level` + `school_codes`/`regions` columns determine which schools appear in
 
 | Level | Scope | Example |
 |-------|-------|---------|
-| 4 | Admin — all schools | Tech admin |
 | 3 | All schools | CoE program admin who needs to see all CoE schools |
 | 2 | Region | SPM assigned to Pune region |
 | 1 | Specific schools | Teacher at JNV Bhavnagar |

--- a/scripts/setup-permissions.ts
+++ b/scripts/setup-permissions.ts
@@ -34,11 +34,11 @@ interface SeedUser {
 
 // Seed data - add/modify users here
 const SEED_USERS: SeedUser[] = [
-  // Level 4: Admin (can manage users + all school access)
-  { email: "pritam@avantifellows.org", level: 4, role: "admin" },
-  { email: "aman.bahuguna@avantifellows.org", level: 4, role: "admin" },
-  { email: "dhyaneshwaran@avantifellows.org", level: 4, role: "admin" },
-  { email: "vishal@avantifellows.org", level: 4, role: "admin" },
+  // Admins: role="admin" grants full access; level=3 gives all-schools scope
+  { email: "pritam@avantifellows.org", level: 3, role: "admin" },
+  { email: "aman.bahuguna@avantifellows.org", level: 3, role: "admin" },
+  { email: "dhyaneshwaran@avantifellows.org", level: 3, role: "admin" },
+  { email: "vishal@avantifellows.org", level: 3, role: "admin" },
 
   // Level 3: All schools access
   // (add level 3 users here)
@@ -59,7 +59,7 @@ async function setup() {
       CREATE TABLE IF NOT EXISTS user_permission (
         id SERIAL PRIMARY KEY,
         email VARCHAR(255) UNIQUE NOT NULL,
-        level INTEGER NOT NULL CHECK (level IN (1, 2, 3, 4)),
+        level INTEGER NOT NULL CHECK (level IN (1, 2, 3)),
         role VARCHAR(50) DEFAULT 'teacher',
         school_codes TEXT[],
         regions TEXT[],

--- a/src/app/admin/users/UserList.tsx
+++ b/src/app/admin/users/UserList.tsx
@@ -179,7 +179,7 @@ export default function UserList({ initialUsers, regions, currentUserEmail }: Us
                   )}
                 </td>
                 <td className="px-3 py-4 text-sm text-gray-500">
-                  {user.level === 4 || user.level === 3 ? (
+                  {user.level === 3 ? (
                     <span className="text-gray-400">All JNV schools</span>
                   ) : user.level === 2 ? (
                     <span>{user.regions?.join(", ") || "No regions assigned"}</span>

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -58,9 +58,9 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const body = await request.json();
     const { level, role, school_codes, regions, program_ids, read_only } = body;
 
-    if (level && (level < 1 || level > 4)) {
+    if (level && (level < 1 || level > 3)) {
       return NextResponse.json(
-        { error: "Level must be between 1 and 4" },
+        { error: "Level must be between 1 and 3" },
         { status: 400 }
       );
     }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -64,9 +64,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (level < 1 || level > 4) {
+    if (level < 1 || level > 3) {
       return NextResponse.json(
-        { error: "Level must be between 1 and 4" },
+        { error: "Level must be between 1 and 3" },
         { status: 400 }
       );
     }

--- a/src/app/api/pm/visits/route.ts
+++ b/src/app/api/pm/visits/route.ts
@@ -84,7 +84,6 @@ export async function POST(request: NextRequest) {
   // Inline school access check using permission object
   let hasSchoolAccess = false;
   switch (permission.level) {
-    case 4:
     case 3:
       hasSchoolAccess = true;
       break;

--- a/src/app/api/pm/visits/route.ts
+++ b/src/app/api/pm/visits/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { getUserPermission, getFeatureAccess } from "@/lib/permissions";
+import { getUserPermission, getFeatureAccess, canAccessSchoolSync } from "@/lib/permissions";
 import { query } from "@/lib/db";
 
 // GET /api/pm/visits - List visits for current PM
@@ -81,29 +81,20 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "No permission record" }, { status: 403 });
   }
 
-  // Inline school access check using permission object
-  let hasSchoolAccess = false;
-  switch (permission.level) {
-    case 3:
-      hasSchoolAccess = true;
-      break;
-    case 2: {
-      const schoolResult = await query<{ region: string }>(
-        `SELECT region FROM school WHERE code = $1`,
-        [school_code]
-      );
-      if (schoolResult.length === 0) {
-        return NextResponse.json({ error: "School not found" }, { status: 404 });
-      }
-      hasSchoolAccess = permission.regions?.includes(schoolResult[0].region) || false;
-      break;
+  // Fetch region only when needed for level 2 access check
+  let schoolRegion: string | undefined;
+  if (permission.level === 2) {
+    const schoolResult = await query<{ region: string }>(
+      `SELECT region FROM school WHERE code = $1`,
+      [school_code]
+    );
+    if (schoolResult.length === 0) {
+      return NextResponse.json({ error: "School not found" }, { status: 404 });
     }
-    case 1:
-      hasSchoolAccess = permission.school_codes?.includes(school_code) || false;
-      break;
+    schoolRegion = schoolResult[0].region;
   }
 
-  if (!hasSchoolAccess) {
+  if (!canAccessSchoolSync(permission, school_code, schoolRegion)) {
     return NextResponse.json(
       { error: "You do not have access to this school" },
       { status: 403 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -288,7 +288,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
             <div>
               <h1 className="text-3xl font-bold text-gray-900">Schools</h1>
               <p className="mt-1 text-sm text-gray-500">
-                {permission.level === 4
+                {permission.role === "admin"
                   ? "Admin access"
                   : permission.level === 3
                     ? "All schools access"
@@ -315,7 +315,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
             )}
           </div>
           <div className="flex items-center gap-4">
-            {permission.level === 4 && (
+            {permission.role === "admin" && (
               <Link
                 href="/admin"
                 className="text-sm text-blue-600 hover:text-blue-800"

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -222,7 +222,6 @@ export default async function SchoolPage({ params }: PageProps) {
     // Check school access using permission object directly
     let hasAccess = false;
     switch (permission.level) {
-      case 4:
       case 3:
         hasAccess = true;
         break;

--- a/src/components/StudentTable.tsx
+++ b/src/components/StudentTable.tsx
@@ -46,11 +46,9 @@ interface StudentTableProps {
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return "—";
-  return new Date(dateString).toLocaleDateString("en-IN", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
+  const d = new Date(dateString);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${String(d.getDate()).padStart(2, "0")} ${months[d.getMonth()]} ${d.getFullYear()}`;
 }
 
 function getCategoryColor(category: string | null): string {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,11 +1,10 @@
 import { query } from "./db";
 
-// Permission levels
-export type AccessLevel = 1 | 2 | 3 | 4;
+// Permission levels (school scope only)
+export type AccessLevel = 1 | 2 | 3;
 // 1 = Single school access
 // 2 = Region access (all schools in a region)
 // 3 = All schools access
-// 4 = Admin (all schools + user management)
 
 // User roles
 export type UserRole = "teacher" | "program_manager" | "program_admin" | "admin";
@@ -193,9 +192,8 @@ export async function canAccessSchool(
   if (!permission) return false;
 
   switch (permission.level) {
-    case 4:
     case 3:
-      // Admin and All schools access
+      // All schools access
       return true;
     case 2:
       // Region access
@@ -215,7 +213,7 @@ export async function getAccessibleSchoolCodes(
   const permission = existingPermission !== undefined ? existingPermission : await getUserPermission(email);
   if (!permission) return [];
 
-  if (permission.level === 4 || permission.level === 3) return "all";
+  if (permission.level === 3) return "all";
   if (permission.level === 1) return permission.school_codes || [];
 
   // Level 2: fetch all school codes in the user's assigned regions
@@ -234,7 +232,7 @@ export async function getAccessibleSchoolCodes(
 
 export async function isAdmin(email: string): Promise<boolean> {
   const permission = await getUserPermission(email);
-  return permission?.level === 4;
+  return permission?.role === "admin";
 }
 
 // Synchronous helper to get program context from a permission object


### PR DESCRIPTION
## Summary
- **Removed `level=4`** from `AccessLevel` type — level now only represents school scope (1=school, 2=region, 3=all)
- **Admin checks use `role=admin`** instead of `level=4` everywhere (`isAdmin()`, dashboard UI, school access switches)
- **Simplified user management form** — when role is set to admin, hides scope/program/read-only fields since admins bypass all those checks, and auto-sets sensible defaults on submit (level=3, all programs, read_only=false)
- **Updated API validation** to reject level > 3

## DB migration needed
```sql
UPDATE user_permission SET level = 3 WHERE level = 4;
```
All 8 existing level=4 users already have role=admin, so this is safe.

## Test plan
- [ ] Verify admin users can still access all schools and features after updating their level to 3
- [ ] Test adding a new user with role=admin — scope fields should be hidden
- [ ] Test editing an existing admin — scope fields should be hidden
- [ ] Test adding/editing non-admin users — scope fields should still appear
- [ ] Verify API rejects level=4 on create and update

🤖 Generated with [Claude Code](https://claude.com/claude-code)