### PR TITLE
6 -- feat: teacher/grade selection, admin full_name, observation stats on cards

### DIFF
--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       deploy_type:
@@ -104,10 +104,10 @@ jobs:
       - name: Set preview branch name
         id: preview
         run: |
-          # Use the actual git branch name from the PR
-          GIT_BRANCH="${{ github.event.pull_request.head.ref }}"
-          PREVIEW_URL="https://${GIT_BRANCH}.${AMPLIFY_APP_ID}.amplifyapp.com"
-          echo "branch=${GIT_BRANCH}" >> $GITHUB_OUTPUT
+          # All PRs deploy to the same stable staging URL
+          BRANCH="staging"
+          PREVIEW_URL="https://${BRANCH}.${AMPLIFY_APP_ID}.amplifyapp.com"
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
           echo "url=${PREVIEW_URL}" >> $GITHUB_OUTPUT
           echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
@@ -186,31 +186,6 @@ jobs:
                 body: body
               });
             }
-
-  # Cleanup preview when PR is closed
-  cleanup-preview:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Delete preview branch
-        run: |
-          # Use the actual git branch name from the PR
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-
-          aws amplify delete-branch \
-            --app-id ${{ env.AMPLIFY_APP_ID }} \
-            --branch-name "$BRANCH" \
-            2>/dev/null || echo "Branch $BRANCH not found or already deleted"
-
-          echo "Cleaned up preview branch: $BRANCH"
 
   # Deploy to production when merged to main
   deploy-production:

--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -94,6 +94,13 @@ jobs:
     environment: Preview
 
     steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+
+      - name: Push PR code to staging branch
+        run: |
+          git push origin HEAD:refs/heads/staging --force
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ npm run test:unit:coverage # Run with V8 coverage report
 - GitHub Actions workflow (`.github/workflows/unit-coverage-comment.yml`) posts a coverage table as a PR comment
 - Developer workflow: run tests locally, commit `unit-coverage/coverage-summary.json`, push
 
-### Test files (74 files, 1100 tests as of 2026-02-23)
+### Test files (75 files, 1142 tests as of 2026-03-01)
 
 **Library tests** (high-signal):
 - `src/lib/permissions.test.ts` — sync helpers + async DB-dependent functions (getUserPermission, canAccessSchool, isAdmin, etc.)
@@ -166,6 +166,7 @@ npm run test:unit:coverage # Run with V8 coverage report
 - `src/app/api/admin/users/[id]/route.test.ts` — DELETE/PATCH user management
 - `src/app/api/curriculum/chapters/route.test.ts` — GET chapters with topics (uses NextRequest)
 - `src/app/api/students/search/route.test.ts` — GET student search with school access control
+- `src/app/api/pm/teachers/route.test.ts` — GET teachers for a school (role/access filtering)
 - `src/app/api/pm/visits/route.test.ts` — GET/POST visits list + create with GPS
 - `src/app/api/pm/visits/[id]/route.test.ts` — GET visit + actions (no PATCH/PUT)
 - `src/app/api/pm/visits/[id]/actions/route.test.ts` — GET list / POST create action

--- a/src/app/admin/users/AddUserModal.test.tsx
+++ b/src/app/admin/users/AddUserModal.test.tsx
@@ -24,6 +24,7 @@ const editUser = {
   regions: ["North"],
   program_ids: [1, 2],
   read_only: false,
+  full_name: null as string | null,
 };
 
 function renderModal(overrides: Partial<typeof defaultProps> = {}) {
@@ -497,6 +498,7 @@ describe("AddUserModal — form submission (create)", () => {
           role: "teacher",
           read_only: false,
           program_ids: [1],
+          full_name: null,
           email: "new@example.com",
           school_codes: [],
           regions: null,

--- a/src/app/admin/users/AddUserModal.tsx
+++ b/src/app/admin/users/AddUserModal.tsx
@@ -11,6 +11,7 @@ interface UserPermission {
   regions: string[] | null;
   program_ids: number[] | null;
   read_only: boolean;
+  full_name: string | null;
 }
 
 // Program definitions
@@ -38,6 +39,7 @@ const labelClassName = "block text-sm font-medium text-gray-700";
 
 export default function AddUserModal({ user, regions, onClose, onSave }: AddUserModalProps) {
   const [email, setEmail] = useState(user?.email || "");
+  const [fullName, setFullName] = useState(user?.full_name || "");
   const [level, setLevel] = useState(user?.level || 1);
   const [role, setRole] = useState(user?.role || "teacher");
   const [selectedRegions, setSelectedRegions] = useState<string[]>(user?.regions || []);
@@ -98,6 +100,7 @@ export default function AddUserModal({ user, regions, onClose, onSave }: AddUser
         role,
         read_only: isAdminRole ? false : readOnly,
         program_ids: isAdminRole ? PROGRAMS.map((p) => p.id) : selectedPrograms,
+        full_name: fullName.trim() || null,
       };
 
       if (!isEditing) {
@@ -189,6 +192,20 @@ export default function AddUserModal({ user, regions, onClose, onSave }: AddUser
                 required
                 className={`${inputClassName} ${isEditing ? "bg-gray-100" : ""}`}
               />
+            </div>
+
+            <div>
+              <label className={labelClassName}>Full Name</label>
+              <input
+                type="text"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                placeholder="e.g. Priya Sharma"
+                className={inputClassName}
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Display name shown in teacher dropdowns and reports
+              </p>
             </div>
 
             <div>

--- a/src/app/admin/users/UserList.tsx
+++ b/src/app/admin/users/UserList.tsx
@@ -12,6 +12,7 @@ interface UserPermission {
   regions: string[] | null;
   program_ids: number[] | null;
   read_only: boolean;
+  full_name: string | null;
 }
 
 interface UserListProps {
@@ -120,6 +121,9 @@ export default function UserList({ initialUsers, regions, currentUserEmail }: Us
                 Email
               </th>
               <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                Name
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                 Role
               </th>
               <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
@@ -144,6 +148,9 @@ export default function UserList({ initialUsers, regions, currentUserEmail }: Us
                   {user.email.toLowerCase() === currentUserEmail.toLowerCase() && (
                     <span className="ml-2 text-xs text-gray-400">(you)</span>
                   )}
+                </td>
+                <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {user.full_name || "\u2014"}
                 </td>
                 <td className="whitespace-nowrap px-3 py-4 text-sm">
                   <span className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${ROLE_COLORS[user.role] || ROLE_COLORS.teacher}`}>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -15,6 +15,7 @@ interface UserPermission {
   regions: string[] | null;
   program_ids: number[] | null;
   read_only: boolean;
+  full_name: string | null;
 }
 
 interface Region {
@@ -24,7 +25,7 @@ interface Region {
 
 async function getUsers(): Promise<UserPermission[]> {
   return query<UserPermission>(
-    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only
+    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name
      FROM user_permission
      ORDER BY level DESC, role, email`
   );

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -56,7 +56,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
   try {
     const body = await request.json();
-    const { level, role, school_codes, regions, program_ids, read_only } = body;
+    const { level, role, school_codes, regions, program_ids, read_only, full_name } = body;
 
     if (level && (level < 1 || level > 3)) {
       return NextResponse.json(
@@ -86,9 +86,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
            regions = $4,
            program_ids = COALESCE($5, program_ids),
            read_only = COALESCE($6, read_only),
+           full_name = $7,
            updated_at = NOW()
-       WHERE id = $7`,
-      [level, userRole, school_codes || null, regions || null, program_ids || null, read_only, id]
+       WHERE id = $8`,
+      [level, userRole, school_codes || null, regions || null, program_ids || null, read_only, full_name ?? null, id]
     );
 
     return NextResponse.json({ success: true });

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -29,10 +29,11 @@ export async function GET() {
     regions: string[] | null;
     program_ids: number[] | null;
     read_only: boolean;
+    full_name: string | null;
     inserted_at: string;
     updated_at: string;
   }>(
-    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, inserted_at, updated_at
+    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name, inserted_at, updated_at
      FROM user_permission
      ORDER BY level DESC, role, email`
   );
@@ -55,7 +56,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { email, level, role, school_codes, regions, program_ids, read_only } = body;
+    const { email, level, role, school_codes, regions, program_ids, read_only, full_name } = body;
 
     if (!email || !level) {
       return NextResponse.json(
@@ -83,8 +84,8 @@ export async function POST(request: NextRequest) {
     const userRole = validRoles.includes(role) ? role : "teacher";
 
     const result = await query<{ id: number }>(
-      `INSERT INTO user_permission (email, level, role, school_codes, regions, program_ids, read_only)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `INSERT INTO user_permission (email, level, role, school_codes, regions, program_ids, read_only, full_name)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        ON CONFLICT (email) DO UPDATE SET
          level = EXCLUDED.level,
          role = EXCLUDED.role,
@@ -92,9 +93,10 @@ export async function POST(request: NextRequest) {
          regions = EXCLUDED.regions,
          program_ids = EXCLUDED.program_ids,
          read_only = EXCLUDED.read_only,
+         full_name = EXCLUDED.full_name,
          updated_at = NOW()
        RETURNING id`,
-      [email, level, userRole, school_codes || null, regions || null, program_ids, read_only || false]
+      [email, level, userRole, school_codes || null, regions || null, program_ids, read_only || false, full_name || null]
     );
 
     return NextResponse.json({ id: result[0].id, success: true });

--- a/src/app/api/pm/teachers/route.test.ts
+++ b/src/app/api/pm/teachers/route.test.ts
@@ -1,0 +1,151 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ADMIN_SESSION, NO_SESSION, PASSCODE_SESSION, PM_SESSION } from "@/app/api/__test-utils__/api-test-helpers";
+
+vi.mock("next-auth");
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db");
+
+import { getServerSession } from "next-auth";
+import { query } from "@/lib/db";
+
+import { GET } from "./route";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockQuery = vi.mocked(query);
+
+function teachersRequest(schoolCode?: string): NextRequest {
+  const url = schoolCode
+    ? `http://localhost/api/pm/teachers?school_code=${schoolCode}`
+    : "http://localhost/api/pm/teachers";
+  return new NextRequest(new URL(url));
+}
+
+// Stub getUserPermission for role-based checks
+function stubPermission(overrides: Record<string, unknown> = {}) {
+  const defaultPermission = {
+    role: "program_manager",
+    level: 3,
+    school_codes: [],
+    regions: [],
+    program_ids: [1],
+    read_only: false,
+    ...overrides,
+  };
+  mockQuery.mockResolvedValueOnce([defaultPermission] as never);
+}
+
+describe("GET /api/pm/teachers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValueOnce(NO_SESSION);
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for passcode users", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PASSCODE_SESSION);
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 for users without PM feature access", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      user: { email: "teacher@avantifellows.org", name: "Teacher" },
+      expires: "2099-01-01",
+    });
+    // getUserPermission returns a teacher-role permission (no visits access)
+    mockQuery.mockResolvedValueOnce([
+      { role: "teacher", level: 1, school_codes: ["SCH001"], regions: [], program_ids: [] },
+    ] as never);
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when school_code is missing", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission();
+    const response = await GET(teachersRequest());
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("school_code query parameter is required");
+  });
+
+  it("returns teachers for a valid school_code", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission();
+    // 2nd query: school region lookup
+    mockQuery.mockResolvedValueOnce([{ region: "Jaipur" }] as never);
+    // 3rd query: teachers
+    mockQuery.mockResolvedValueOnce([
+      { id: 1, email: "teacher1@school.com", full_name: "Alice Teacher" },
+      { id: 2, email: "teacher2@school.com", full_name: null },
+    ] as never);
+
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.teachers).toEqual([
+      { id: 1, email: "teacher1@school.com", full_name: "Alice Teacher" },
+      { id: 2, email: "teacher2@school.com", full_name: null },
+    ]);
+
+    // Verify teachers query includes both school_code and region
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining("role = 'teacher'"),
+      ["SCH001", "Jaipur"]
+    );
+  });
+
+  it("passes null region when school not found", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission();
+    // school region lookup returns empty
+    mockQuery.mockResolvedValueOnce([] as never);
+    // teachers query
+    mockQuery.mockResolvedValueOnce([
+      { id: 1, email: "t@school.com", full_name: "Only Direct" },
+    ] as never);
+
+    const response = await GET(teachersRequest("UNKNOWN"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.teachers).toHaveLength(1);
+
+    // Region param is null when school not found
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining("role = 'teacher'"),
+      ["UNKNOWN", null]
+    );
+  });
+
+  it("returns empty array when no teachers found", async () => {
+    mockGetServerSession.mockResolvedValueOnce(ADMIN_SESSION);
+    stubPermission({ role: "admin" });
+    mockQuery.mockResolvedValueOnce([{ region: "Patna" }] as never);
+    mockQuery.mockResolvedValueOnce([] as never);
+
+    const response = await GET(teachersRequest("EMPTY_SCHOOL"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.teachers).toEqual([]);
+  });
+
+  it("works for admin users", async () => {
+    mockGetServerSession.mockResolvedValueOnce(ADMIN_SESSION);
+    stubPermission({ role: "admin" });
+    mockQuery.mockResolvedValueOnce([{ region: "Lucknow" }] as never);
+    mockQuery.mockResolvedValueOnce([
+      { id: 10, email: "t@school.com", full_name: "Bob" },
+    ] as never);
+
+    const response = await GET(teachersRequest("SCH002"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.teachers).toHaveLength(1);
+  });
+});

--- a/src/app/api/pm/teachers/route.test.ts
+++ b/src/app/api/pm/teachers/route.test.ts
@@ -75,6 +75,27 @@ describe("GET /api/pm/teachers", () => {
     expect(body.error).toBe("school_code query parameter is required");
   });
 
+  it("returns 403 when PM cannot access the requested school", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    // Level 1 PM with access to SCH999 only
+    stubPermission({ level: 1, school_codes: ["SCH999"] });
+    // school region lookup
+    mockQuery.mockResolvedValueOnce([{ region: "Jaipur" }] as never);
+
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 when level-2 PM region does not match school", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission({ level: 2, regions: ["Patna"] });
+    // school region is Jaipur, PM only has Patna
+    mockQuery.mockResolvedValueOnce([{ region: "Jaipur" }] as never);
+
+    const response = await GET(teachersRequest("SCH001"));
+    expect(response.status).toBe(403);
+  });
+
   it("returns teachers for a valid school_code", async () => {
     mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
     stubPermission();

--- a/src/app/api/pm/teachers/route.ts
+++ b/src/app/api/pm/teachers/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { apiError, requireVisitsAccess } from "@/lib/visits-policy";
+
+interface TeacherRow {
+  id: number;
+  email: string;
+  full_name: string | null;
+}
+
+// GET /api/pm/teachers?school_code=XXXXX
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireVisitsAccess(session, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
+  if (!schoolCode) {
+    return apiError(400, "school_code query parameter is required");
+  }
+
+  // Find the school's region so we can include region-level teachers
+  const schoolRows = await query<{ region: string | null }>(
+    `SELECT region FROM school WHERE code = $1`,
+    [schoolCode]
+  );
+  const schoolRegion = schoolRows[0]?.region ?? null;
+
+  // Match teachers who either:
+  // 1. Have this school_code in their school_codes array (level 1), OR
+  // 2. Have the school's region in their regions array (level 2), OR
+  // 3. Have level 3 (all-schools access)
+  const teachers = await query<TeacherRow>(
+    `SELECT id, email, full_name
+     FROM user_permission
+     WHERE role = 'teacher'
+       AND (
+         school_codes @> ARRAY[$1]::TEXT[]
+         OR ($2::TEXT IS NOT NULL AND regions @> ARRAY[$2]::TEXT[])
+         OR level = 3
+       )
+     ORDER BY full_name NULLS LAST, email`,
+    [schoolCode, schoolRegion]
+  );
+
+  return NextResponse.json({ teachers });
+}

--- a/src/app/api/pm/teachers/route.ts
+++ b/src/app/api/pm/teachers/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
-import { apiError, requireVisitsAccess } from "@/lib/visits-policy";
+import { apiError, canAccessVisitSchoolScope, requireVisitsAccess } from "@/lib/visits-policy";
 
 interface TeacherRow {
   id: number;
@@ -30,6 +30,11 @@ export async function GET(request: NextRequest) {
     [schoolCode]
   );
   const schoolRegion = schoolRows[0]?.region ?? null;
+
+  // Check if the user can access this school
+  if (!canAccessVisitSchoolScope(access.actor, schoolCode, schoolRegion)) {
+    return apiError(403, "Forbidden");
+  }
 
   // Match teachers who either:
   // 1. Have this school_code in their school_codes array (level 1), OR

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
@@ -109,6 +109,9 @@ function buildValidClassroomData() {
   return {
     rubric_version: CURRENT_RUBRIC_VERSION,
     params,
+    teacher_id: 1,
+    teacher_name: "Test Teacher",
+    grade: "10",
   };
 }
 
@@ -383,7 +386,7 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
     expect(json.action.end_lng).toBeUndefined();
 
     const [updateQueryText, updateParams] = mockQuery.mock.calls[2] as [string, unknown[]];
-    expect(updateQueryText).toContain("UPDATE lms_pm_visit_actions");
+    expect(updateQueryText).toContain("UPDATE lms_pm_school_visit_actions");
     expect(updateQueryText).toContain("status = 'completed'");
     expect(updateQueryText).toContain("ended_at = (NOW() AT TIME ZONE 'UTC')");
     expect(updateQueryText).toContain("updated_at = (NOW() AT TIME ZONE 'UTC')");

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
@@ -96,6 +96,9 @@ function buildValidClassroomData() {
   return {
     rubric_version: CURRENT_RUBRIC_VERSION,
     params,
+    teacher_id: 1,
+    teacher_name: "Test Teacher",
+    grade: "10",
   };
 }
 
@@ -584,7 +587,7 @@ describe("PATCH /api/pm/visits/[id]/actions/[actionId]", () => {
     await expect(res.json()).resolves.toEqual({ action: updated });
 
     const [updateQueryText, updateParams] = mockQuery.mock.calls[2] as [string, unknown[]];
-    expect(updateQueryText).toContain("UPDATE lms_pm_visit_actions");
+    expect(updateQueryText).toContain("UPDATE lms_pm_school_visit_actions");
     expect(updateQueryText).toContain("SET data = $3::jsonb");
     expect(updateQueryText).toContain("updated_at = (NOW() AT TIME ZONE 'UTC')");
     expect(updateQueryText).not.toContain("status =");
@@ -701,7 +704,7 @@ describe("DELETE /api/pm/visits/[id]/actions/[actionId]", () => {
     await expect(res.json()).resolves.toEqual({ success: true });
 
     const [deleteQueryText, deleteParams] = mockQuery.mock.calls[2] as [string, unknown[]];
-    expect(deleteQueryText).toContain("UPDATE lms_pm_visit_actions");
+    expect(deleteQueryText).toContain("UPDATE lms_pm_school_visit_actions");
     expect(deleteQueryText).toContain("deleted_at = (NOW() AT TIME ZONE 'UTC')");
     expect(deleteQueryText).toContain("updated_at = (NOW() AT TIME ZONE 'UTC')");
     expect(deleteQueryText).toContain("deleted_at IS NULL");

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/start/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/start/route.test.ts
@@ -221,7 +221,7 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/start", () => {
     expect(json.action.end_lng).toBeUndefined();
 
     const [updateQueryText, updateParams] = mockQuery.mock.calls[2] as [string, unknown[]];
-    expect(updateQueryText).toContain("UPDATE lms_pm_visit_actions");
+    expect(updateQueryText).toContain("UPDATE lms_pm_school_visit_actions");
     expect(updateQueryText).toContain("status = 'in_progress'");
     expect(updateQueryText).toContain("started_at = (NOW() AT TIME ZONE 'UTC')");
     expect(updateQueryText).toContain("updated_at = (NOW() AT TIME ZONE 'UTC')");

--- a/src/app/api/pm/visits/[id]/actions/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/route.test.ts
@@ -148,7 +148,7 @@ describe("GET /api/pm/visits/[id]/actions", () => {
     await expect(res.json()).resolves.toEqual({ actions: ACTION_ROWS });
 
     const [actionsQueryText, actionsParams] = mockQuery.mock.calls[1] as [string, unknown[]];
-    expect(actionsQueryText).toContain("FROM lms_pm_visit_actions");
+    expect(actionsQueryText).toContain("FROM lms_pm_school_visit_actions");
     expect(actionsQueryText).toContain("deleted_at IS NULL");
     expect(actionsQueryText).toContain("ORDER BY inserted_at ASC, id ASC");
     expect(actionsQueryText).not.toContain("start_lat");
@@ -357,7 +357,7 @@ describe("POST /api/pm/visits/[id]/actions", () => {
     await expect(res.json()).resolves.toEqual({ action: createdAction });
 
     const [insertQueryText, insertParams] = mockQuery.mock.calls[1] as [string, unknown[]];
-    expect(insertQueryText).toContain("INSERT INTO lms_pm_visit_actions");
+    expect(insertQueryText).toContain("INSERT INTO lms_pm_school_visit_actions");
     expect(insertQueryText).toContain("(visit_id, action_type, status, data)");
     expect(insertQueryText).toContain("'pending'");
     expect(insertQueryText).toContain("'{}'::jsonb");

--- a/src/app/api/pm/visits/[id]/complete/route.test.ts
+++ b/src/app/api/pm/visits/[id]/complete/route.test.ts
@@ -97,6 +97,9 @@ function buildValidClassroomData() {
   return {
     rubric_version: CURRENT_RUBRIC_VERSION,
     params,
+    teacher_id: 1,
+    teacher_name: "Test Teacher",
+    grade: "10",
   };
 }
 

--- a/src/app/api/pm/visits/[id]/route.test.ts
+++ b/src/app/api/pm/visits/[id]/route.test.ts
@@ -177,7 +177,7 @@ describe("GET /api/pm/visits/[id]", () => {
     expect(visitParams).toEqual(["10"]);
 
     const [actionsQueryText, actionsParams] = mockQuery.mock.calls[1] as [string, unknown[]];
-    expect(actionsQueryText).toContain("FROM lms_pm_visit_actions");
+    expect(actionsQueryText).toContain("FROM lms_pm_school_visit_actions");
     expect(actionsQueryText).toContain("deleted_at IS NULL");
     expect(actionsQueryText).toContain("ORDER BY inserted_at ASC, id ASC");
     expect(actionsQueryText).not.toContain("start_lat");

--- a/src/app/visits/[id]/actions/[actionId]/page.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.tsx
@@ -174,6 +174,7 @@ export default async function VisitActionDetailPage({ params }: PageProps) {
           initialAction={detail.action}
           canWrite={canWrite}
           isAdmin={permission.role === "admin"}
+          schoolCode={detail.visit.school_code}
         />
       </div>
     </main>

--- a/src/app/visits/[id]/page.test.tsx
+++ b/src/app/visits/[id]/page.test.tsx
@@ -267,7 +267,7 @@ describe("VisitDetailPage", () => {
     expect(visitParams).toEqual(["42"]);
 
     const [actionsSql, actionsParams] = mockQuery.mock.calls[1] as [string, unknown[]];
-    expect(actionsSql).toContain("FROM lms_pm_visit_actions");
+    expect(actionsSql).toContain("FROM lms_pm_school_visit_actions");
     expect(actionsSql).toContain("deleted_at IS NULL");
     expect(actionsSql).toContain("ORDER BY inserted_at ASC, id ASC");
     expect(actionsParams).toEqual(["42"]);

--- a/src/app/visits/[id]/page.tsx
+++ b/src/app/visits/[id]/page.tsx
@@ -27,6 +27,7 @@ interface VisitAction {
   visit_id: number;
   action_type: string;
   status: string;
+  data?: Record<string, unknown>;
   started_at: string | null;
   ended_at: string | null;
   inserted_at: string;
@@ -54,7 +55,7 @@ async function getVisitDetail(id: string): Promise<VisitDetail> {
   }
 
   const actions = await query<VisitAction>(
-    `SELECT id, visit_id, action_type, status,
+    `SELECT id, visit_id, action_type, status, data,
             started_at, ended_at, inserted_at, updated_at
      FROM lms_pm_school_visit_actions
      WHERE visit_id = $1

--- a/src/components/visits/ActionDetailForm.tsx
+++ b/src/components/visits/ActionDetailForm.tsx
@@ -29,6 +29,7 @@ interface ActionDetailFormProps {
   initialAction: ActionRecord;
   canWrite: boolean;
   isAdmin: boolean;
+  schoolCode: string;
 }
 
 type FormState = "idle" | "saving" | "acquiring" | "ending";
@@ -310,6 +311,18 @@ function sanitizeClassroomPayload(data: unknown): Record<string, unknown> {
     sanitized.observer_summary_improvements = data.observer_summary_improvements;
   }
 
+  if (typeof data.teacher_id === "number" && Number.isFinite(data.teacher_id) && data.teacher_id > 0) {
+    sanitized.teacher_id = data.teacher_id;
+  }
+
+  if (typeof data.teacher_name === "string") {
+    sanitized.teacher_name = data.teacher_name;
+  }
+
+  if (typeof data.grade === "string") {
+    sanitized.grade = data.grade;
+  }
+
   return sanitized;
 }
 
@@ -442,6 +455,7 @@ export default function ActionDetailForm({
   initialAction,
   canWrite,
   isAdmin,
+  schoolCode,
 }: ActionDetailFormProps) {
   const [action, setAction] = useState<ActionRecord>(() => normalizeActionForState(initialAction));
   const [formData, setFormData] = useState<Record<string, unknown>>(() =>
@@ -717,6 +731,7 @@ export default function ActionDetailForm({
             data={formData}
             setData={setFormData}
             disabled={!canSave || isBusy}
+            schoolCode={schoolCode}
           />
         ) : (
           config.fields.map((field) => (

--- a/src/components/visits/ClassroomObservationForm.test.tsx
+++ b/src/components/visits/ClassroomObservationForm.test.tsx
@@ -1,29 +1,82 @@
 import { StrictMode, useState } from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ClassroomObservationForm from "./ClassroomObservationForm";
 import { CURRENT_RUBRIC_VERSION } from "@/lib/classroom-observation-rubric";
 
+const MOCK_TEACHERS = [
+  { id: 1, email: "alice@school.com", full_name: "Alice Teacher" },
+  { id: 2, email: "bob@school.com", full_name: "Bob Instructor" },
+  { id: 3, email: "noname@school.com", full_name: null },
+];
+
+function mockFetchTeachers(teachers = MOCK_TEACHERS) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ teachers }),
+    })
+  );
+}
+
+function mockFetchTeachersError() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "Failed" }),
+    })
+  );
+}
+
 interface HarnessProps {
   disabled?: boolean;
   initialData?: Record<string, unknown>;
+  schoolCode?: string;
 }
 
-function Harness({ disabled = false, initialData = {} }: HarnessProps) {
+function Harness({ disabled = false, initialData = {}, schoolCode = "SCH001" }: HarnessProps) {
   const [data, setData] = useState<Record<string, unknown>>(initialData);
 
-  return <ClassroomObservationForm data={data} setData={setData} disabled={disabled} />;
+  return (
+    <ClassroomObservationForm
+      data={data}
+      setData={setData}
+      disabled={disabled}
+      schoolCode={schoolCode}
+    />
+  );
+}
+
+/** Initial data with teacher + grade already set so rubric is visible */
+function withTeacherAndGrade(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    rubric_version: CURRENT_RUBRIC_VERSION,
+    teacher_id: 1,
+    teacher_name: "Alice Teacher",
+    grade: "10",
+    ...extra,
+  };
 }
 
 describe("ClassroomObservationForm", () => {
+  beforeEach(() => {
+    mockFetchTeachers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("stamps missing rubric_version via idempotent updater in strict mode", async () => {
     const setData = vi.fn();
 
     render(
       <StrictMode>
-        <ClassroomObservationForm data={{}} setData={setData} disabled={false} />
+        <ClassroomObservationForm data={{}} setData={setData} disabled={false} schoolCode="SCH001" />
       </StrictMode>
     );
 
@@ -47,100 +100,371 @@ describe("ClassroomObservationForm", () => {
     expect(firstUpdater?.(alreadyVersioned)).toBe(alreadyVersioned);
   });
 
-  it("renders all 19 rubric cards with score summary and session summaries", () => {
-    render(<Harness initialData={{ rubric_version: CURRENT_RUBRIC_VERSION }} />);
+  describe("teacher dropdown", () => {
+    it("shows loading state while fetching teachers", () => {
+      // Use a never-resolving promise to keep loading state
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockReturnValue(new Promise(() => {}))
+      );
 
-    expect(screen.getAllByTestId(/rubric-param-/)).toHaveLength(19);
-    expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 0/45");
-    expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 0/19");
+      render(<Harness />);
 
-    expect(screen.getByLabelText("Observer Summary (Strengths)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Observer Summary (Points of Improvement)")).toBeInTheDocument();
+      expect(screen.getByTestId("teacher-loading")).toHaveTextContent("Loading teachers...");
+    });
+
+    it("shows teacher dropdown after loading", async () => {
+      render(<Harness />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId("teacher-select") as HTMLSelectElement;
+      // 3 teachers + placeholder option
+      expect(select.options).toHaveLength(4);
+      expect(select.options[1].textContent).toBe("Alice Teacher");
+      expect(select.options[2].textContent).toBe("Bob Instructor");
+      // Teacher with null full_name falls back to email
+      expect(select.options[3].textContent).toBe("noname@school.com");
+    });
+
+    it("shows error state when fetch fails", async () => {
+      mockFetchTeachersError();
+      render(<Harness />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-error")).toHaveTextContent("Failed to load teachers");
+      });
+    });
+
+    it("fetches teachers with correct school_code", async () => {
+      render(<Harness schoolCode="MY_SCHOOL" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      expect(fetch).toHaveBeenCalledWith("/api/pm/teachers?school_code=MY_SCHOOL");
+    });
+
+    it("pre-selects existing teacher_id from data", async () => {
+      render(
+        <Harness
+          initialData={{
+            teacher_id: 2,
+            teacher_name: "Bob Instructor",
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId("teacher-select") as HTMLSelectElement;
+      expect(select.value).toBe("2");
+    });
+
+    it("shows teacher name as non-editable when teacher_id is not in list (removed teacher)", async () => {
+      render(
+        <Harness
+          initialData={{
+            teacher_id: 999,
+            teacher_name: "Removed Teacher",
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-removed-display")).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId("teacher-removed-display")).toHaveTextContent(
+        "Removed Teacher (no longer at this school)"
+      );
+    });
+
+    it("shows empty state when no teachers found", async () => {
+      mockFetchTeachers([]);
+      render(<Harness />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId("teacher-select") as HTMLSelectElement;
+      expect(select.options).toHaveLength(1);
+      expect(select.options[0].textContent).toBe("No teachers found");
+    });
+
+    it("shows teacher name as text when disabled", () => {
+      render(
+        <Harness
+          disabled
+          initialData={{
+            teacher_id: 1,
+            teacher_name: "Alice Teacher",
+            grade: "10",
+            rubric_version: CURRENT_RUBRIC_VERSION,
+          }}
+        />
+      );
+
+      expect(screen.getByTestId("teacher-display")).toHaveTextContent("Alice Teacher");
+      expect(screen.queryByTestId("teacher-select")).not.toBeInTheDocument();
+    });
   });
 
-  it("respects disabled prop for rubric controls and summaries", () => {
-    render(
-      <Harness
-        disabled
-        initialData={{
-          rubric_version: CURRENT_RUBRIC_VERSION,
-          observer_summary_strengths: "existing",
-        }}
-      />
-    );
+  describe("grade dropdown", () => {
+    it("is hidden when no teacher is selected", async () => {
+      render(<Harness />);
 
-    const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
-    expect(within(firstCard).getByRole("radio", { name: /yes/i })).toBeDisabled();
-    expect(within(firstCard).getByRole("button", { name: "Add remarks" })).toBeDisabled();
-    expect(screen.getByLabelText("Observer Summary (Strengths)")).toBeDisabled();
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId("grade-selection")).not.toBeInTheDocument();
+      expect(screen.getByTestId("select-teacher-prompt")).toHaveTextContent(
+        "Select a teacher to begin the observation."
+      );
+    });
+
+    it("appears after teacher is selected", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      await user.selectOptions(screen.getByTestId("teacher-select"), "1");
+
+      expect(screen.getByTestId("grade-selection")).toBeInTheDocument();
+      expect(screen.getByTestId("grade-select")).toBeInTheDocument();
+      expect(screen.getByTestId("select-grade-prompt")).toHaveTextContent(
+        "Select a grade to continue."
+      );
+    });
+
+    it("pre-selects existing grade from data", async () => {
+      render(
+        <Harness
+          initialData={{
+            teacher_id: 1,
+            teacher_name: "Alice Teacher",
+            grade: "11",
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("grade-select")).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId("grade-select") as HTMLSelectElement;
+      expect(select.value).toBe("11");
+    });
+
+    it("has options for Grade 10, 11, 12", async () => {
+      render(
+        <Harness
+          initialData={{ teacher_id: 1, teacher_name: "Alice Teacher" }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("grade-select")).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId("grade-select") as HTMLSelectElement;
+      // placeholder + 3 grades
+      expect(select.options).toHaveLength(4);
+      expect(select.options[1].textContent).toBe("Grade 10");
+      expect(select.options[2].textContent).toBe("Grade 11");
+      expect(select.options[3].textContent).toBe("Grade 12");
+    });
+
+    it("shows grade as text when disabled", () => {
+      render(
+        <Harness
+          disabled
+          initialData={{
+            teacher_id: 1,
+            teacher_name: "Alice Teacher",
+            grade: "12",
+            rubric_version: CURRENT_RUBRIC_VERSION,
+          }}
+        />
+      );
+
+      expect(screen.getByTestId("grade-display")).toHaveTextContent("Grade 12");
+      expect(screen.queryByTestId("grade-select")).not.toBeInTheDocument();
+    });
   });
 
-  it("updates live score/answered counts from valid selected scores only", async () => {
-    const user = userEvent.setup();
+  describe("rubric gating", () => {
+    it("hides rubric when only teacher is selected (no grade)", async () => {
+      render(
+        <Harness
+          initialData={{
+            rubric_version: CURRENT_RUBRIC_VERSION,
+            teacher_id: 1,
+            teacher_name: "Alice Teacher",
+          }}
+        />
+      );
 
-    render(
-      <Harness
-        initialData={{
-          rubric_version: CURRENT_RUBRIC_VERSION,
-          params: {
-            time_management: { score: 0 },
-          },
-        }}
-      />
-    );
+      await waitFor(() => {
+        expect(screen.getByTestId("grade-select")).toBeInTheDocument();
+      });
 
-    expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 0/45");
-    expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 0/19");
+      expect(screen.queryByTestId("rubric-score-summary")).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId(/rubric-param-/)).toHaveLength(0);
+    });
 
-    const teacherOnTimeCard = screen.getByTestId("rubric-param-teacher_on_time");
-    await user.click(within(teacherOnTimeCard).getByRole("radio", { name: /yes/i }));
+    it("shows rubric when both teacher and grade are selected", async () => {
+      render(<Harness initialData={withTeacherAndGrade()} />);
 
-    const recallCard = screen.getByTestId("rubric-param-recall_test");
-    await user.click(within(recallCard).getByRole("radio", { name: /student interaction within time/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
 
-    expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 3/45");
-    expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 2/19");
+      expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 0/45");
+      expect(screen.getAllByTestId(/rubric-param-/)).toHaveLength(19);
+    });
 
-    await user.type(screen.getByLabelText("Observer Summary (Strengths)"), "Good pace");
-    await user.type(screen.getByLabelText("Observer Summary (Points of Improvement)"), "Board clarity");
+    it("shows rubric after selecting teacher and grade interactively", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
 
-    expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 3/45");
-    expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 2/19");
+      await waitFor(() => {
+        expect(screen.getByTestId("teacher-select")).toBeInTheDocument();
+      });
+
+      // No rubric yet
+      expect(screen.queryByTestId("rubric-score-summary")).not.toBeInTheDocument();
+
+      // Select teacher
+      await user.selectOptions(screen.getByTestId("teacher-select"), "1");
+      expect(screen.queryByTestId("rubric-score-summary")).not.toBeInTheDocument();
+
+      // Select grade
+      await user.selectOptions(screen.getByTestId("grade-select"), "10");
+      expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
+      expect(screen.getAllByTestId(/rubric-param-/)).toHaveLength(19);
+    });
   });
 
-  it("keeps remarks visible after reveal even when cleared", async () => {
-    const user = userEvent.setup();
+  describe("rubric behavior (with teacher + grade set)", () => {
+    it("renders all 19 rubric cards with score summary and session summaries", async () => {
+      render(<Harness initialData={withTeacherAndGrade()} />);
 
-    render(<Harness initialData={{ rubric_version: CURRENT_RUBRIC_VERSION }} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
+      });
 
-    const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
+      expect(screen.getAllByTestId(/rubric-param-/)).toHaveLength(19);
+      expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 0/45");
+      expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 0/19");
 
-    expect(within(firstCard).queryByLabelText("Remarks")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Observer Summary (Strengths)")).toBeInTheDocument();
+      expect(screen.getByLabelText("Observer Summary (Points of Improvement)")).toBeInTheDocument();
+    });
 
-    await user.click(within(firstCard).getByRole("button", { name: "Add remarks" }));
+    it("respects disabled prop for rubric controls and summaries", () => {
+      render(
+        <Harness
+          disabled
+          initialData={withTeacherAndGrade({
+            observer_summary_strengths: "existing",
+          })}
+        />
+      );
 
-    const remarks = within(firstCard).getByLabelText("Remarks");
-    await user.type(remarks, "Observed clear instructions");
-    await user.clear(remarks);
+      const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
+      expect(within(firstCard).getByRole("radio", { name: /yes/i })).toBeDisabled();
+      expect(within(firstCard).getByRole("button", { name: "Add remarks" })).toBeDisabled();
+      expect(screen.getByLabelText("Observer Summary (Strengths)")).toBeDisabled();
+    });
 
-    expect(within(firstCard).getByLabelText("Remarks")).toBeInTheDocument();
-    expect(within(firstCard).queryByRole("button", { name: "Add remarks" })).not.toBeInTheDocument();
-  });
+    it("updates live score/answered counts from valid selected scores only", async () => {
+      const user = userEvent.setup();
 
-  it("shows remarks textarea by default when remarks already exist", () => {
-    render(
-      <Harness
-        initialData={{
-          rubric_version: CURRENT_RUBRIC_VERSION,
-          params: {
-            teacher_on_time: { score: 1, remarks: "Already filled" },
-          },
-        }}
-      />
-    );
+      render(
+        <Harness
+          initialData={withTeacherAndGrade({
+            params: {
+              time_management: { score: 0 },
+            },
+          })}
+        />
+      );
 
-    const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
-    expect(within(firstCard).getByLabelText("Remarks")).toBeInTheDocument();
-    expect(within(firstCard).queryByRole("button", { name: "Add remarks" })).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 0/45");
+      expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 0/19");
+
+      const teacherOnTimeCard = screen.getByTestId("rubric-param-teacher_on_time");
+      await user.click(within(teacherOnTimeCard).getByRole("radio", { name: /yes/i }));
+
+      const recallCard = screen.getByTestId("rubric-param-recall_test");
+      await user.click(within(recallCard).getByRole("radio", { name: /student interaction within time/i }));
+
+      expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 3/45");
+      expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 2/19");
+
+      await user.type(screen.getByLabelText("Observer Summary (Strengths)"), "Good pace");
+      await user.type(screen.getByLabelText("Observer Summary (Points of Improvement)"), "Board clarity");
+
+      expect(screen.getByTestId("rubric-score-summary")).toHaveTextContent("Score: 3/45");
+      expect(screen.getByTestId("rubric-answered-summary")).toHaveTextContent("Answered: 2/19");
+    });
+
+    it("keeps remarks visible after reveal even when cleared", async () => {
+      const user = userEvent.setup();
+
+      render(<Harness initialData={withTeacherAndGrade()} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
+      });
+
+      const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
+
+      expect(within(firstCard).queryByLabelText("Remarks")).not.toBeInTheDocument();
+
+      await user.click(within(firstCard).getByRole("button", { name: "Add remarks" }));
+
+      const remarks = within(firstCard).getByLabelText("Remarks");
+      await user.type(remarks, "Observed clear instructions");
+      await user.clear(remarks);
+
+      expect(within(firstCard).getByLabelText("Remarks")).toBeInTheDocument();
+      expect(within(firstCard).queryByRole("button", { name: "Add remarks" })).not.toBeInTheDocument();
+    });
+
+    it("shows remarks textarea by default when remarks already exist", async () => {
+      render(
+        <Harness
+          initialData={withTeacherAndGrade({
+            params: {
+              teacher_on_time: { score: 1, remarks: "Already filled" },
+            },
+          })}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
+      });
+
+      const firstCard = screen.getByTestId("rubric-param-teacher_on_time");
+      expect(within(firstCard).getByLabelText("Remarks")).toBeInTheDocument();
+      expect(within(firstCard).queryByRole("button", { name: "Add remarks" })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/visits/ClassroomObservationForm.tsx
+++ b/src/components/visits/ClassroomObservationForm.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
 import {
   CLASSROOM_OBSERVATION_RUBRIC,
   CURRENT_RUBRIC_VERSION,
+  VALID_GRADES,
   type ParamData,
   type RubricParameter,
 } from "@/lib/classroom-observation-rubric";
+
+interface Teacher {
+  id: number;
+  email: string;
+  full_name: string | null;
+}
 
 interface ClassroomObservationFormProps {
   data: Record<string, unknown>;
   setData: Dispatch<SetStateAction<Record<string, unknown>>>;
   disabled: boolean;
+  schoolCode: string;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -39,12 +47,20 @@ function isValidScore(parameter: RubricParameter, score: unknown): score is numb
   return parameter.options.some((option) => option.score === score);
 }
 
+function getTeacherDisplayName(teacher: Teacher): string {
+  return teacher.full_name || teacher.email;
+}
+
 export default function ClassroomObservationForm({
   data,
   setData,
   disabled,
+  schoolCode,
 }: ClassroomObservationFormProps) {
   const [revealedRemarks, setRevealedRemarks] = useState<Set<string>>(() => new Set());
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
+  const [teachersLoading, setTeachersLoading] = useState(true);
+  const [teachersError, setTeachersError] = useState<string | null>(null);
 
   useEffect(() => {
     setData((current) => {
@@ -55,6 +71,78 @@ export default function ClassroomObservationForm({
       return { ...current, rubric_version: CURRENT_RUBRIC_VERSION };
     });
   }, [setData]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTeachers() {
+      setTeachersLoading(true);
+      setTeachersError(null);
+
+      try {
+        const response = await fetch(`/api/pm/teachers?school_code=${encodeURIComponent(schoolCode)}`);
+        if (!response.ok) {
+          throw new Error("Failed to load teachers");
+        }
+        const body = await response.json();
+        if (!cancelled) {
+          setTeachers(Array.isArray(body.teachers) ? body.teachers : []);
+        }
+      } catch {
+        if (!cancelled) {
+          setTeachersError("Failed to load teachers");
+        }
+      } finally {
+        if (!cancelled) {
+          setTeachersLoading(false);
+        }
+      }
+    }
+
+    void fetchTeachers();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [schoolCode]);
+
+  const selectedTeacherId =
+    typeof data.teacher_id === "number" && Number.isFinite(data.teacher_id) ? data.teacher_id : null;
+  const selectedTeacherName = typeof data.teacher_name === "string" ? data.teacher_name : null;
+  const selectedGrade = typeof data.grade === "string" ? data.grade : null;
+
+  const teacherInList = selectedTeacherId !== null && teachers.some((t) => Number(t.id) === selectedTeacherId);
+
+  const teachersRef = useRef(teachers);
+  teachersRef.current = teachers;
+
+  const handleTeacherChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = Number(event.target.value);
+      const teacher = teachersRef.current.find((t) => Number(t.id) === id);
+      if (!teacher) {
+        return;
+      }
+
+      setData((current) => ({
+        ...current,
+        teacher_id: Number(teacher.id),
+        teacher_name: getTeacherDisplayName(teacher),
+      }));
+    },
+    [setData]
+  );
+
+  const handleGradeChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const grade = event.target.value;
+      setData((current) => ({
+        ...current,
+        grade,
+      }));
+    },
+    [setData]
+  );
 
   const params = getParams(data);
 
@@ -76,150 +164,238 @@ export default function ClassroomObservationForm({
     };
   }, [params]);
 
+  const hasTeacher = selectedTeacherId !== null;
+  const hasGrade = selectedGrade !== null && (VALID_GRADES as readonly string[]).includes(selectedGrade);
+  const showRubric = hasTeacher && hasGrade;
+
   return (
     <div className="space-y-4" data-testid="classroom-observation-form">
-      <div className="sticky top-2 z-10 border-2 border-border-accent bg-bg-card-alt px-3 py-2">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-primary">
-          <span className="font-mono font-bold text-accent" data-testid="rubric-score-summary">
-            Score: {totalScore}/{CLASSROOM_OBSERVATION_RUBRIC.maxScore}
-          </span>
-          <span className="font-mono" data-testid="rubric-answered-summary">
-            Answered: {answeredCount}/{CLASSROOM_OBSERVATION_RUBRIC.parameters.length}
-          </span>
-        </div>
-      </div>
-
-      {CLASSROOM_OBSERVATION_RUBRIC.parameters.map((parameter) => {
-        const paramValue = params[parameter.key];
-        const selectedScore = paramValue?.score;
-        const remarks = readString(paramValue?.remarks);
-        const remarksVisible = remarks.length > 0 || revealedRemarks.has(parameter.key);
-
-        return (
-          <section
-            key={parameter.key}
-            className="border border-border p-4"
-            data-testid={`rubric-param-${parameter.key}`}
-          >
-            <div className="mb-3">
-              <h3 className="text-sm font-semibold text-text-primary uppercase">{parameter.label}</h3>
-              {parameter.description && (
-                <p className="mt-1 text-xs text-text-secondary">{parameter.description}</p>
-              )}
-            </div>
-
-            <fieldset disabled={disabled} className="space-y-2">
-              <legend className="sr-only">{parameter.label}</legend>
-              {parameter.options.map((option) => (
-                <label
-                  key={`${parameter.key}-${option.score}`}
-                  className="flex cursor-pointer items-start gap-2 text-sm text-text-primary"
-                >
-                  <input
-                    type="radio"
-                    name={`rubric-${parameter.key}`}
-                    value={option.score}
-                    checked={selectedScore === option.score}
-                    disabled={disabled}
-                    onChange={() => {
-                      setData((current) => {
-                        const currentParams = isPlainObject(current.params)
-                          ? { ...current.params }
-                          : {};
-                        const currentParam = isPlainObject(currentParams[parameter.key])
-                          ? { ...(currentParams[parameter.key] as Record<string, unknown>) }
-                          : {};
-
-                        currentParams[parameter.key] = {
-                          ...currentParam,
-                          score: option.score,
-                        };
-
-                        return {
-                          ...current,
-                          params: currentParams,
-                        };
-                      });
-                    }}
-                    className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
-                  />
-                  <span>
-                    {option.label}
-                    <span className="ml-1 font-mono text-text-muted">({option.score})</span>
-                  </span>
-                </label>
-              ))}
-            </fieldset>
-
-            {!remarksVisible && (
-              <button
-                type="button"
-                disabled={disabled}
-                onClick={() => {
-                  setRevealedRemarks((current) => new Set(current).add(parameter.key));
-                }}
-                className="mt-3 text-xs font-medium text-accent underline hover:text-accent-hover disabled:cursor-not-allowed disabled:text-text-muted"
-              >
-                Add remarks
-              </button>
+      {/* Teacher selection */}
+      <section className="border border-border p-4" data-testid="teacher-selection">
+        <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Teacher</h3>
+        {disabled ? (
+          <p className="text-sm text-text-primary" data-testid="teacher-display">
+            {selectedTeacherName || "No teacher selected"}
+          </p>
+        ) : teachersLoading ? (
+          <p className="text-sm text-text-muted" data-testid="teacher-loading">Loading teachers...</p>
+        ) : teachersError ? (
+          <p className="text-sm text-danger" data-testid="teacher-error">{teachersError}</p>
+        ) : (
+          <>
+            {selectedTeacherId !== null && !teacherInList && selectedTeacherName && (
+              <p className="mb-2 text-sm text-text-primary" data-testid="teacher-removed-display">
+                {selectedTeacherName} (no longer at this school)
+              </p>
             )}
+            {(teacherInList || selectedTeacherId === null) && (
+              <select
+                value={selectedTeacherId !== null ? String(selectedTeacherId) : ""}
+                onChange={handleTeacherChange}
+                className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none"
+                data-testid="teacher-select"
+              >
+                <option value="" disabled>
+                  {teachers.length === 0 ? "No teachers found" : "Select a teacher"}
+                </option>
+                {teachers.map((teacher) => (
+                  <option key={teacher.id} value={String(teacher.id)}>
+                    {getTeacherDisplayName(teacher)}
+                  </option>
+                ))}
+              </select>
+            )}
+          </>
+        )}
+      </section>
 
-            {remarksVisible && (
-              <label className="mt-3 block">
-                <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">Remarks</span>
+      {/* Grade selection — visible only after teacher is selected */}
+      {hasTeacher && (
+        <section className="border border-border p-4" data-testid="grade-selection">
+          <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Grade</h3>
+          {disabled ? (
+            <p className="text-sm text-text-primary" data-testid="grade-display">
+              {selectedGrade ? `Grade ${selectedGrade}` : "No grade selected"}
+            </p>
+          ) : (
+            <select
+              value={selectedGrade ?? ""}
+              onChange={handleGradeChange}
+              className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none"
+              data-testid="grade-select"
+            >
+              <option value="" disabled>
+                Select a grade
+              </option>
+              {VALID_GRADES.map((grade) => (
+                <option key={grade} value={grade}>
+                  Grade {grade}
+                </option>
+              ))}
+            </select>
+          )}
+        </section>
+      )}
+
+      {/* Gating messages */}
+      {!hasTeacher && !disabled && (
+        <p className="text-sm text-text-muted px-1" data-testid="select-teacher-prompt">
+          Select a teacher to begin the observation.
+        </p>
+      )}
+      {hasTeacher && !hasGrade && !disabled && (
+        <p className="text-sm text-text-muted px-1" data-testid="select-grade-prompt">
+          Select a grade to continue.
+        </p>
+      )}
+
+      {/* Rubric form — visible only after both teacher and grade are selected */}
+      {showRubric && (
+        <>
+          <div className="sticky top-2 z-10 border-2 border-border-accent bg-bg-card-alt px-3 py-2">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-primary">
+              <span className="font-mono font-bold text-accent" data-testid="rubric-score-summary">
+                Score: {totalScore}/{CLASSROOM_OBSERVATION_RUBRIC.maxScore}
+              </span>
+              <span className="font-mono" data-testid="rubric-answered-summary">
+                Answered: {answeredCount}/{CLASSROOM_OBSERVATION_RUBRIC.parameters.length}
+              </span>
+            </div>
+          </div>
+
+          {CLASSROOM_OBSERVATION_RUBRIC.parameters.map((parameter) => {
+            const paramValue = params[parameter.key];
+            const selectedScore = paramValue?.score;
+            const remarks = readString(paramValue?.remarks);
+            const remarksVisible = remarks.length > 0 || revealedRemarks.has(parameter.key);
+
+            return (
+              <section
+                key={parameter.key}
+                className="border border-border p-4"
+                data-testid={`rubric-param-${parameter.key}`}
+              >
+                <div className="mb-3">
+                  <h3 className="text-sm font-semibold text-text-primary uppercase">{parameter.label}</h3>
+                  {parameter.description && (
+                    <p className="mt-1 text-xs text-text-secondary">{parameter.description}</p>
+                  )}
+                </div>
+
+                <fieldset disabled={disabled} className="space-y-2">
+                  <legend className="sr-only">{parameter.label}</legend>
+                  {parameter.options.map((option) => (
+                    <label
+                      key={`${parameter.key}-${option.score}`}
+                      className="flex cursor-pointer items-start gap-2 text-sm text-text-primary"
+                    >
+                      <input
+                        type="radio"
+                        name={`rubric-${parameter.key}`}
+                        value={option.score}
+                        checked={selectedScore === option.score}
+                        disabled={disabled}
+                        onChange={() => {
+                          setData((current) => {
+                            const currentParams = isPlainObject(current.params)
+                              ? { ...current.params }
+                              : {};
+                            const currentParam = isPlainObject(currentParams[parameter.key])
+                              ? { ...(currentParams[parameter.key] as Record<string, unknown>) }
+                              : {};
+
+                            currentParams[parameter.key] = {
+                              ...currentParam,
+                              score: option.score,
+                            };
+
+                            return {
+                              ...current,
+                              params: currentParams,
+                            };
+                          });
+                        }}
+                        className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+                      />
+                      <span>
+                        {option.label}
+                        <span className="ml-1 font-mono text-text-muted">({option.score})</span>
+                      </span>
+                    </label>
+                  ))}
+                </fieldset>
+
+                {!remarksVisible && (
+                  <button
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => {
+                      setRevealedRemarks((current) => new Set(current).add(parameter.key));
+                    }}
+                    className="mt-3 text-xs font-medium text-accent underline hover:text-accent-hover disabled:cursor-not-allowed disabled:text-text-muted"
+                  >
+                    Add remarks
+                  </button>
+                )}
+
+                {remarksVisible && (
+                  <label className="mt-3 block">
+                    <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">Remarks</span>
+                    <textarea
+                      rows={3}
+                      value={remarks}
+                      disabled={disabled}
+                      onChange={(event) => {
+                        const nextRemarks = event.target.value;
+                        setData((current) => {
+                          const currentParams = isPlainObject(current.params)
+                            ? { ...current.params }
+                            : {};
+                          const currentParam = isPlainObject(currentParams[parameter.key])
+                            ? { ...(currentParams[parameter.key] as Record<string, unknown>) }
+                            : {};
+
+                          currentParams[parameter.key] = {
+                            ...currentParam,
+                            remarks: nextRemarks,
+                          };
+
+                          return {
+                            ...current,
+                            params: currentParams,
+                          };
+                        });
+                      }}
+                      placeholder="Optional remarks"
+                      className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:bg-bg-card-alt"
+                    />
+                  </label>
+                )}
+              </section>
+            );
+          })}
+
+          <section className="border border-border p-4 space-y-3">
+            <h3 className="text-sm font-semibold text-text-primary uppercase">Session Summary (Optional)</h3>
+            {CLASSROOM_OBSERVATION_RUBRIC.sessionFields.map((field) => (
+              <label key={field.key} className="block">
+                <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">{field.label}</span>
                 <textarea
-                  rows={3}
-                  value={remarks}
+                  rows={4}
+                  value={readString(data[field.key])}
                   disabled={disabled}
+                  placeholder={field.placeholder}
                   onChange={(event) => {
-                    const nextRemarks = event.target.value;
-                    setData((current) => {
-                      const currentParams = isPlainObject(current.params)
-                        ? { ...current.params }
-                        : {};
-                      const currentParam = isPlainObject(currentParams[parameter.key])
-                        ? { ...(currentParams[parameter.key] as Record<string, unknown>) }
-                        : {};
-
-                      currentParams[parameter.key] = {
-                        ...currentParam,
-                        remarks: nextRemarks,
-                      };
-
-                      return {
-                        ...current,
-                        params: currentParams,
-                      };
-                    });
+                    const nextValue = event.target.value;
+                    setData((current) => ({ ...current, [field.key]: nextValue }));
                   }}
-                  placeholder="Optional remarks"
                   className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:bg-bg-card-alt"
                 />
               </label>
-            )}
+            ))}
           </section>
-        );
-      })}
-
-      <section className="border border-border p-4 space-y-3">
-        <h3 className="text-sm font-semibold text-text-primary uppercase">Session Summary (Optional)</h3>
-        {CLASSROOM_OBSERVATION_RUBRIC.sessionFields.map((field) => (
-          <label key={field.key} className="block">
-            <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">{field.label}</span>
-            <textarea
-              rows={4}
-              value={readString(data[field.key])}
-              disabled={disabled}
-              placeholder={field.placeholder}
-              onChange={(event) => {
-                const nextValue = event.target.value;
-                setData((current) => ({ ...current, [field.key]: nextValue }));
-              }}
-              className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:bg-bg-card-alt"
-            />
-          </label>
-        ))}
-      </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Classroom observation form**: Teacher dropdown (region-aware via new `GET /api/pm/teachers` endpoint) and grade picker, rubric gated behind both selections
- **Admin UI**: `full_name` field added to create/edit user modal and user list table
- **Action point cards**: Show teacher, grade, score, and progress % for classroom observation actions
- **Bug fixes**: pg driver returns IDs as strings — added `Number()` coercion in teacher selection

## Dependencies
- **db-service**: avantifellows/db-service#436 (adds `full_name` column to `user_permission` + visit actions table rename)

## Test plan
- [x] All 1142 unit tests pass
- [ ] Manual: select teacher + grade in classroom observation, verify rubric appears
- [ ] Manual: complete observation, verify stats (teacher, grade, score, progress) show on action card
- [ ] Manual: admin UI — create/edit user with full_name, verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)