### PR TITLE
feat: add dev login for local role/permission testing

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -188,6 +188,49 @@ describe("LoginPage", () => {
     expect(screen.queryByText("Invalid passcode")).not.toBeInTheDocument();
   });
 
+  // --- Dev login ---
+
+  it("renders dev login buttons in non-production", () => {
+    render(<LoginPage />);
+    expect(screen.getByText("dev login")).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Program Manager")).toBeInTheDocument();
+    expect(screen.getByText("Teacher")).toBeInTheDocument();
+    expect(screen.getByText("Read-Only")).toBeInTheDocument();
+  });
+
+  it("calls signIn('dev-login') with persona on dev button click", async () => {
+    mockSignIn.mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+    render(<LoginPage />);
+    await user.click(screen.getByText("Admin"));
+    expect(mockSignIn).toHaveBeenCalledWith("dev-login", {
+      persona: "admin",
+      redirect: false,
+    });
+  });
+
+  it("redirects to /dashboard on successful dev login", async () => {
+    mockSignIn.mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+    render(<LoginPage />);
+    await user.click(screen.getByText("Teacher"));
+    await vi.waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("does not redirect on failed dev login", async () => {
+    mockSignIn.mockResolvedValue({ error: "CredentialsSignin" });
+    const user = userEvent.setup();
+    render(<LoginPage />);
+    await user.click(screen.getByText("Admin"));
+    await vi.waitFor(() => {
+      expect(screen.getByText("Admin")).toBeInTheDocument();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   // --- Back button ---
 
   it("goes back to login options and clears passcode/error", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,12 +4,31 @@ import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+const IS_DEV = process.env.NODE_ENV !== "production";
+
+const DEV_PERSONAS = [
+  { key: "admin", label: "Admin", description: "Level 3, all schools" },
+  { key: "program_manager", label: "Program Manager", description: "Level 1, 2 schools" },
+  { key: "teacher", label: "Teacher", description: "Level 1, 1 school" },
+  { key: "read_only", label: "Read-Only", description: "Level 3, read-only flag" },
+] as const;
+
 export default function LoginPage() {
   const [showPasscode, setShowPasscode] = useState(false);
   const [passcode, setPasscode] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [devLoading, setDevLoading] = useState<string | null>(null);
   const router = useRouter();
+
+  const handleDevLogin = async (persona: string) => {
+    setDevLoading(persona);
+    const result = await signIn("dev-login", { persona, redirect: false });
+    setDevLoading(null);
+    if (result?.ok) {
+      router.push("/dashboard");
+    }
+  };
 
   const handlePasscodeSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,6 +101,33 @@ export default function LoginPage() {
             >
               Enter School Passcode
             </button>
+
+            {IS_DEV && (
+              <>
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-gray-300" />
+                  </div>
+                  <div className="relative flex justify-center text-sm">
+                    <span className="bg-white px-2 text-gray-500">dev login</span>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2">
+                  {DEV_PERSONAS.map((p) => (
+                    <button
+                      key={p.key}
+                      onClick={() => handleDevLogin(p.key)}
+                      disabled={devLoading !== null}
+                      className="rounded-lg border border-dashed border-orange-300 bg-orange-50 px-3 py-2 text-xs font-medium text-orange-700 hover:bg-orange-100 disabled:opacity-50 transition-colors"
+                    >
+                      {devLoading === p.key ? "..." : p.label}
+                      <span className="block text-[10px] font-normal text-orange-500">{p.description}</span>
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
           </div>
         ) : (
           <form onSubmit={handlePasscodeSubmit} className="mt-8 space-y-4">

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi } from "vitest";
-import { authOptions } from "./auth";
+import { authOptions, DEV_LOGIN_PERSONAS } from "./auth";
 
-// Extract the credentials provider and callbacks
-// In NextAuth v4, the user's authorize fn is under options.authorize
+// Extract providers by id
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const credentialsProvider = authOptions.providers.find((p: any) => p.type === "credentials") as any;
-const authorize = credentialsProvider.options.authorize as (
+const findProvider = (id: string) => authOptions.providers.find((p: any) => p.options?.id === id) as any;
+
+const passcodeProvider = findProvider("passcode");
+const authorize = passcodeProvider.options.authorize as (
+  credentials: Record<string, string> | undefined
+) => Promise<unknown>;
+
+const devProvider = findProvider("dev-login");
+const devAuthorize = devProvider?.options?.authorize as (
   credentials: Record<string, string> | undefined
 ) => Promise<unknown>;
 const jwtCallback = authOptions.callbacks!.jwt!;
@@ -80,5 +86,63 @@ describe("session callback", () => {
     const result = await (sessionCallback as any)({ session, token, user: undefined as any });
     expect(result.schoolCode).toBeUndefined();
     expect(result.isPasscodeUser).toBeUndefined();
+  });
+});
+
+describe("Dev login provider", () => {
+  it("is registered in non-production environment", () => {
+    expect(devProvider).toBeDefined();
+    expect(devProvider.options.id).toBe("dev-login");
+  });
+
+  it("returns user for valid admin persona", async () => {
+    const result = await devAuthorize({ persona: "admin" });
+    expect(result).toEqual({
+      id: "dev-admin",
+      email: DEV_LOGIN_PERSONAS.admin.email,
+      name: "Dev Admin",
+    });
+  });
+
+  it("returns user for valid program_manager persona", async () => {
+    const result = await devAuthorize({ persona: "program_manager" });
+    expect(result).toEqual({
+      id: "dev-program_manager",
+      email: DEV_LOGIN_PERSONAS.program_manager.email,
+      name: "Dev PM",
+    });
+  });
+
+  it("returns user for valid teacher persona", async () => {
+    const result = await devAuthorize({ persona: "teacher" });
+    expect(result).toEqual({
+      id: "dev-teacher",
+      email: DEV_LOGIN_PERSONAS.teacher.email,
+      name: "Dev Teacher",
+    });
+  });
+
+  it("returns user for valid read_only persona", async () => {
+    const result = await devAuthorize({ persona: "read_only" });
+    expect(result).toEqual({
+      id: "dev-read_only",
+      email: DEV_LOGIN_PERSONAS.read_only.email,
+      name: "Dev Read-Only",
+    });
+  });
+
+  it("returns null for unknown persona", async () => {
+    const result = await devAuthorize({ persona: "superadmin" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for missing persona", async () => {
+    const result = await devAuthorize({});
+    expect(result).toBeNull();
+  });
+
+  it("returns null for undefined credentials", async () => {
+    const result = await devAuthorize(undefined);
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,37 +1,69 @@
-import { NextAuthOptions } from "next-auth";
+import type { NextAuthOptions } from "next-auth";
+import type { Provider } from "next-auth/providers/index";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { getSchoolByPasscode } from "./permissions";
 
-export const authOptions: NextAuthOptions = {
-  secret: process.env.NEXTAUTH_SECRET,
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
+// Dev login personas — each maps to a real email in user_permission.
+// Only used when NODE_ENV !== "production".
+export const DEV_LOGIN_PERSONAS = {
+  admin: { email: "pritam@avantifellows.org", name: "Dev Admin" },
+  program_manager: { email: "svishal081995@gmail.com", name: "Dev PM" },
+  teacher: { email: "sanghamitrapatil06@gmail.com", name: "Dev Teacher" },
+  read_only: { email: "lokesh@avantifellows.org", name: "Dev Read-Only" },
+} as const;
+
+export type DevPersonaKey = keyof typeof DEV_LOGIN_PERSONAS;
+
+const providers: Provider[] = [
+  GoogleProvider({
+    clientId: process.env.GOOGLE_CLIENT_ID!,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+  }),
+  CredentialsProvider({
+    id: "passcode",
+    name: "School Passcode",
+    credentials: {
+      passcode: { label: "School Passcode", type: "text" },
+    },
+    async authorize(credentials) {
+      if (!credentials?.passcode) return null;
+
+      const schoolCode = getSchoolByPasscode(credentials.passcode);
+      if (!schoolCode) return null;
+
+      // Return a pseudo-user for passcode auth
+      return {
+        id: `passcode-${schoolCode}`,
+        email: `passcode-${schoolCode}@school.local`,
+        name: `School ${schoolCode}`,
+        schoolCode,
+      };
+    },
+  }),
+];
+
+if (process.env.NODE_ENV !== "production") {
+  providers.push(
     CredentialsProvider({
-      id: "passcode",
-      name: "School Passcode",
+      id: "dev-login",
+      name: "Dev Login",
       credentials: {
-        passcode: { label: "School Passcode", type: "text" },
+        persona: { label: "Persona", type: "text" },
       },
       async authorize(credentials) {
-        if (!credentials?.passcode) return null;
-
-        const schoolCode = getSchoolByPasscode(credentials.passcode);
-        if (!schoolCode) return null;
-
-        // Return a pseudo-user for passcode auth
-        return {
-          id: `passcode-${schoolCode}`,
-          email: `passcode-${schoolCode}@school.local`,
-          name: `School ${schoolCode}`,
-          schoolCode,
-        };
+        const key = credentials?.persona as DevPersonaKey | undefined;
+        if (!key || !(key in DEV_LOGIN_PERSONAS)) return null;
+        const persona = DEV_LOGIN_PERSONAS[key];
+        return { id: `dev-${key}`, email: persona.email, name: persona.name };
       },
-    }),
-  ],
+    })
+  );
+}
+
+export const authOptions: NextAuthOptions = {
+  secret: process.env.NEXTAUTH_SECRET,
+  providers,
   callbacks: {
     async jwt({ token, user }) {
       // Add school code to token for passcode users


### PR DESCRIPTION
## Summary
- Adds a `dev-login` CredentialsProvider gated on `NODE_ENV !== "production"` with 4 personas (Admin, PM, Teacher, Read-Only)
- Each persona maps to a real `user_permission` email, so the full auth + permission system is exercised
- Login page shows orange dashed buttons in dev mode only — dead-code-eliminated from production bundle

## Screenshot

![dev-login-screenshot](https://github.com/user-attachments/assets/placeholder)

## Security
- Provider only registers when `NODE_ENV !== "production"` — never exists server-side in production
- UI buttons gated on same check — Next.js inlines `NODE_ENV` at build time and tree-shakes the dead branch
- No env var flags to misconfigure

## Test plan
- [x] 8 new unit tests for dev-login authorize (valid personas, invalid, undefined)
- [x] 4 new unit tests for login page dev buttons (render, signIn call, redirect, failure)
- [x] All 36 tests pass
- [ ] Manual: `npm run dev` → verify dev login buttons appear and work
- [ ] Manual: `npm run build` → verify dev login buttons are NOT in production bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)