### PR TITLE
test: add quiz session route coverage

### DIFF
--- a/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  routeParams,
+} from "../../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("POST /api/quiz-sessions/[id]/regenerate", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([]);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Session not found" });
+  });
+
+  it("marks the session pending and publishes regeneration", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        meta_data: JSON.stringify({ status: "synced", extra: "keep" }),
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      message: "Regeneration requested.",
+    });
+
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(patchBody).toEqual({
+      meta_data: {
+        status: "pending",
+        extra: "keep",
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "regenerate_quiz",
+      id: 42,
+    });
+  });
+
+  it("forwards downstream failure status when regeneration cannot be queued", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([{ id: 42, meta_data: {} }]);
+    mocks.mockFetch.mockResolvedValueOnce(new Response("downstream error", { status: 502 }));
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to queue regeneration",
+    });
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/quiz-sessions/[id]/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/route.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  jsonRequest,
+  routeParams,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("PATCH /api/quiz-sessions/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([]);
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Session not found" });
+  });
+
+  it("blocks end_now when the session is not currently live", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Future session",
+        start_time: "2026-04-15T09:00:00.000Z",
+        end_time: "2026-04-15T11:00:00.000Z",
+        is_active: true,
+        meta_data: { show_scores: true },
+      },
+    ]);
+    vi.setSystemTime(new Date("2026-04-15T06:00:00.000Z"));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { action: "end_now" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Only live sessions can be ended now",
+    });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("patches editable fields and publishes a patch event", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Existing session",
+        start_time: "2026-04-15T05:00:00.000Z",
+        end_time: "2026-04-15T09:00:00.000Z",
+        is_active: true,
+        meta_data: JSON.stringify({
+          show_scores: true,
+          show_answers: false,
+          shuffle: false,
+          gurukul_format_type: "both",
+          untouched: "keep-me",
+        }),
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: {
+          name: "Updated session",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+          showAnswers: true,
+          showScores: false,
+          shuffle: true,
+          gurukulFormatType: "omr",
+          isActive: false,
+        },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: 42 });
+
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(mocks.mockFetch.mock.calls[0]?.[0]).toBe("http://db-service.local/session/42");
+    expect(patchBody).toMatchObject({
+      name: "Updated session",
+      is_active: false,
+      start_time: "2026-04-15T10:00:00.000Z",
+      end_time: "2026-04-15T14:00:00.000Z",
+      meta_data: {
+        show_answers: true,
+        show_scores: false,
+        shuffle: true,
+        gurukul_format_type: "omr",
+        untouched: "keep-me",
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "patch",
+      id: 42,
+      patch_session: expect.objectContaining({
+        name: "Updated session",
+        is_active: false,
+      }),
+    });
+  });
+
+  it("ends a live session immediately", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Live session",
+        start_time: "2026-04-15T05:00:00.000Z",
+        end_time: "2026-04-15T07:00:00.000Z",
+        is_active: true,
+        meta_data: {},
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+    vi.setSystemTime(new Date("2026-04-15T06:00:00.000Z"));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { action: "end_now" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(200);
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(patchBody.end_time).toBe("2026-04-15T11:30:00.000Z");
+  });
+});

--- a/src/app/api/quiz-sessions/[id]/sync/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/sync/route.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  routeParams,
+} from "../../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockQuery: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+  helperUrl?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  process.env.QUIZ_ETL_HELPER_URL = env?.helperUrl ?? "http://etl-helper.local/trigger";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+  delete process.env.QUIZ_ETL_HELPER_URL;
+});
+
+describe("POST /api/quiz-sessions/[id]/sync", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 400 when the session is missing auth-layer session_id", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([{ id: 42, session_id: null, meta_data: {} }]);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Session is missing auth-layer session_id",
+    });
+  });
+
+  it("queues sync, merge, and worker start, and persists pending sync status", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        session_id: "session-auth-42",
+        meta_data: { has_synced_to_bq: false },
+      },
+    ]);
+    mocks.mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("http://etl-helper.local/trigger")) {
+        return jsonResponse({ message: "queued" });
+      }
+      if (url === "http://db-service.local/session/42") {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      message: "Sync requested. Updated results should appear shortly.",
+    });
+
+    const helperCalls = mocks.mockFetch.mock.calls.filter(([url]) =>
+      String(url).startsWith("http://etl-helper.local/trigger")
+    );
+    expect(helperCalls).toHaveLength(3);
+    expect(helperCalls[0]?.[0]).toContain("message=session-auth-42");
+    expect(helperCalls[1]?.[0]).toContain("message=merge");
+    expect(helperCalls[2]?.[0]).toContain("message=start_worker");
+
+    const patchCall = mocks.mockFetch.mock.calls.find(
+      ([url]) => String(url) === "http://db-service.local/session/42"
+    );
+    const patchBody = JSON.parse(String((patchCall?.[1] as RequestInit).body));
+    expect(patchBody).toEqual({
+      meta_data: {
+        has_synced_to_bq: false,
+        etl_sync_status: "pending",
+      },
+    });
+  });
+
+  it("persists failed sync status when enqueueing the sync request fails", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        session_id: "session-auth-42",
+        meta_data: { has_synced_to_bq: false },
+      },
+    ]);
+    mocks.mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("http://etl-helper.local/trigger")) {
+        return jsonResponse({ error: "queue down" }, 500);
+      }
+      if (url === "http://db-service.local/session/42") {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "queue down" });
+
+    const patchCall = mocks.mockFetch.mock.calls.find(
+      ([url]) => String(url) === "http://db-service.local/session/42"
+    );
+    const patchBody = JSON.parse(String((patchCall?.[1] as RequestInit).body));
+    expect(patchBody).toEqual({
+      meta_data: {
+        has_synced_to_bq: false,
+        etl_sync_status: "failed",
+      },
+    });
+  });
+
+  it("returns a warning when the worker start call fails after sync is queued", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        session_id: "session-auth-42",
+        meta_data: { has_synced_to_bq: false },
+      },
+    ]);
+
+    let helperCallCount = 0;
+    mocks.mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("http://etl-helper.local/trigger")) {
+        helperCallCount += 1;
+        if (helperCallCount === 3) {
+          return jsonResponse({ error: "worker start failed" }, 500);
+        }
+        return jsonResponse({ message: "queued" });
+      }
+      if (url === "http://db-service.local/session/42") {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      warning: "Sync requested. It may take a little longer than usual.",
+    });
+  });
+});

--- a/src/app/api/quiz-sessions/batches/route.test.ts
+++ b/src/app/api/quiz-sessions/batches/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mocks.mockGetUserPermission,
+}));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockGetUserPermission.mockReset();
+  mocks.mockQuery.mockReset();
+});
+
+describe("GET /api/quiz-sessions/batches", () => {
+  it("returns 401 when not authenticated", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 400 for an invalid school id", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=abc")
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid schoolId" });
+  });
+
+  it("returns school batches and appends missing parent rows", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockGetUserPermission.mockResolvedValue({ program_ids: [1] });
+    mocks.mockQuery
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      batches: [
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ],
+    });
+  });
+
+  it("falls back to global batches when the school has no mapped batch rows", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockGetUserPermission.mockResolvedValue({ program_ids: [1] });
+    mocks.mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("FROM batch b"),
+      [[1]]
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      batches: expect.arrayContaining([
+        expect.objectContaining({ batch_id: "EnableStudents_11_Engg_A" }),
+      ]),
+    });
+  });
+});

--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  jsonRequest,
+} from "../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mocks.mockGetUserPermission,
+}));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockGetUserPermission.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("GET /api/quiz-sessions", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns paginated quiz sessions scoped to the school's class batches", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockGetUserPermission.mockResolvedValue({ program_ids: [1, 64] });
+    mocks.mockQuery
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 99,
+          name: "[LMS] Part Test 1",
+          start_time: "2026-04-15 15:00:00",
+          end_time: "2026-04-15 19:00:00",
+          is_active: true,
+          portal_link: "https://quiz.example/session/99",
+          platform: "quiz",
+          meta_data: {
+            batch_id: "EnableStudents_11_Engg_A",
+            date_created: "2026-04-15T13:30:00.000Z",
+          },
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42&page=0&per_page=10")
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      hasMore: false,
+      sessions: [
+        expect.objectContaining({
+          id: 99,
+          name: "[LMS] Part Test 1",
+          start_time: "2026-04-15T09:30:00.000Z",
+          end_time: "2026-04-15T13:30:00.000Z",
+          meta_data: expect.objectContaining({
+            batch_id: "EnableStudents_11_Engg_A",
+            date_created: "2026-04-15T08:00:00.000Z",
+          }),
+        }),
+      ],
+    });
+
+    expect(mocks.mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("FROM session s"),
+      [["EnableStudents_11_Engg_A"], 11, 0]
+    );
+  });
+});
+
+describe("POST /api/quiz-sessions", () => {
+  it("returns 400 when selected template grade does not match the selected batches", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        id: 501,
+        type: "quiz_template",
+        code: "PT-12",
+        name: [{ resource: "Part Test 12", lang_code: "en" }],
+        type_params: {
+          grade: 12,
+          stream: "engineering",
+          test_format: "part_test",
+          test_purpose: "weekly_test",
+          test_type: "assessment",
+          cms_link: "https://cms.example/tests/pt-12",
+          question_pdf: "https://cdn.example/question.pdf",
+          solution_pdf: "https://cdn.example/solution.pdf",
+        },
+      })
+    );
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          stream: "engineering",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Selected template grade does not match selected batches",
+    });
+    expect(mocks.mockFetch).toHaveBeenCalledTimes(1);
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("creates a quiz session, prefixes the default LMS name, and queues session creation", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 501,
+          type: "quiz_template",
+          code: "PT-11",
+          name: [{ resource: "Part Test 11", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            course: "JEE",
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            optional_limits: "JEE",
+            cms_link: "https://cms.example/tests/pt-11",
+            question_pdf: "https://cdn.example/question.pdf",
+            solution_pdf: "https://cdn.example/solution.pdf",
+            ranking_cutoff_date: "2026-04-20",
+            sheet_name: "Part Tests",
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 321 }));
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A", "EnableStudents_11_Engg_B"],
+          stream: "engineering",
+          showAnswers: false,
+          showScores: true,
+          shuffle: true,
+          gurukulFormatType: "omr",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: 321 });
+
+    expect(mocks.mockFetch).toHaveBeenCalledTimes(2);
+    expect(mocks.mockFetch.mock.calls[1]?.[0]).toBe("http://db-service.local/session");
+    const createPayload = JSON.parse(
+      String((mocks.mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(createPayload).toMatchObject({
+      name: "[LMS] Part Test 11",
+      platform: "quiz",
+      start_time: "2026-04-15T10:00:00.000Z",
+      end_time: "2026-04-15T14:00:00.000Z",
+      meta_data: {
+        parent_id: "EnableStudents_11_Engg",
+        batch_id: "EnableStudents_11_Engg_A,EnableStudents_11_Engg_B",
+        grade: 11,
+        stream: "engineering",
+        resource_id: 501,
+        resource_name: "Part Test 11",
+        test_code: "PT-11",
+        show_answers: false,
+        show_scores: true,
+        shuffle: true,
+        gurukul_format_type: "omr",
+        status: "pending",
+        has_synced_to_bq: false,
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "db_id",
+      id: 321,
+    });
+  });
+});

--- a/src/app/api/quiz-sessions/templates/route.test.ts
+++ b/src/app/api/quiz-sessions/templates/route.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("GET /api/quiz-sessions/templates", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/templates?grade=11")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("filters parsed quiz templates by grade, stream, format, search, and active state", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 501,
+          type: "quiz_template",
+          code: "PT-11",
+          name: [{ resource: "Engineering Part Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11",
+            is_active: true,
+          },
+        },
+        {
+          id: 502,
+          type: "quiz_template",
+          code: "PT-11-MED",
+          name: [{ resource: "Medical Part Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "medical",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11-med",
+            is_active: true,
+          },
+        },
+        {
+          id: 503,
+          type: "quiz_template",
+          code: "PT-11-INACTIVE",
+          name: [{ resource: "Inactive Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11-inactive",
+            is_active: false,
+          },
+        },
+      ])
+    );
+
+    const res = await GET(
+      new NextRequest(
+        "http://localhost/api/quiz-sessions/templates?grade=11&stream=engineering&testFormat=part_test&search=engineering"
+      )
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      templates: [
+        expect.objectContaining({
+          id: 501,
+          code: "PT-11",
+          name: "Engineering Part Test",
+          stream: "engineering",
+          testFormat: "part_test",
+        }),
+      ],
+    });
+    expect(mocks.mockFetch.mock.calls[0]?.[0]).toBe(
+      "http://db-service.local/resource?type=quiz_template&limit=1000&sort_by=code&sort_order=asc"
+    );
+  });
+
+  it("forwards downstream failure status when template fetch fails", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(new Response("service unavailable", { status: 503 }));
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/templates?grade=11")
+    );
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to fetch quiz templates",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused route tests for quiz session list/create/edit/regenerate/sync endpoints
- cover supporting batches/templates endpoints with light downstream mocking
- verify LMS request shaping and error handling at the API boundary

## Testing
- npm test -- 'src/app/api/quiz-sessions/route.test.ts' 'src/app/api/quiz-sessions/[id]/route.test.ts' 'src/app/api/quiz-sessions/[id]/regenerate/route.test.ts' 'src/app/api/quiz-sessions/[id]/sync/route.test.ts' 'src/app/api/quiz-sessions/batches/route.test.ts' 'src/app/api/quiz-sessions/templates/route.test.ts'