### PR TITLE
test: add quiz session coverage

### DIFF
--- a/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  routeParams,
+} from "../../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockRequireQuizSessionAccess: vi.fn(),
+  mockCanAccessQuizSessionBatches: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/quiz-session-access", () => ({
+  requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
+  canAccessQuizSessionBatches: mocks.mockCanAccessQuizSessionBatches,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockReset();
+  mocks.mockCanAccessQuizSessionBatches.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+  mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+    ok: true,
+    permission: { program_ids: [1, 64] },
+  });
+  mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("POST /api/quiz-sessions/[id]/regenerate", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([]);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Session not found" });
+  });
+
+  it("returns 403 when the user cannot edit quiz sessions", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session belongs to inaccessible class batches", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        meta_data: { batch_id: "EnableStudents_11_Engg_A" },
+      },
+    ]);
+    mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(false);
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("marks the session pending and publishes regeneration", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        meta_data: JSON.stringify({ status: "synced", extra: "keep" }),
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      message: "Regeneration requested.",
+    });
+
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(patchBody).toEqual({
+      meta_data: {
+        status: "pending",
+        extra: "keep",
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "regenerate_quiz",
+      id: 42,
+    });
+  });
+
+  it("forwards downstream failure status when regeneration cannot be queued", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([{ id: 42, meta_data: {} }]);
+    mocks.mockFetch.mockResolvedValueOnce(new Response("downstream error", { status: 502 }));
+
+    const res = await POST(new Request("http://localhost") as never, routeParams({ id: "42" }));
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to queue regeneration",
+    });
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/quiz-sessions/[id]/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/route.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  jsonRequest,
+  routeParams,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockRequireQuizSessionAccess: vi.fn(),
+  mockCanAccessQuizSessionBatches: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/quiz-session-access", () => ({
+  requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
+  canAccessQuizSessionBatches: mocks.mockCanAccessQuizSessionBatches,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockReset();
+  mocks.mockCanAccessQuizSessionBatches.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+  vi.useRealTimers();
+  mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+    ok: true,
+    permission: { program_ids: [1, 64] },
+  });
+  mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("PATCH /api/quiz-sessions/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([]);
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Session not found" });
+  });
+
+  it("returns 403 when the user cannot edit quiz sessions", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session belongs to inaccessible class batches", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Existing session",
+        start_time: "2026-04-15T05:00:00.000Z",
+        end_time: "2026-04-15T09:00:00.000Z",
+        is_active: true,
+        meta_data: { batch_id: "EnableStudents_11_Engg_A" },
+      },
+    ]);
+    mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(false);
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { name: "Updated" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks end_now when the session is not currently live", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Future session",
+        start_time: "2026-04-15T09:00:00.000Z",
+        end_time: "2026-04-15T11:00:00.000Z",
+        is_active: true,
+        meta_data: { show_scores: true },
+      },
+    ]);
+    vi.setSystemTime(new Date("2026-04-15T06:00:00.000Z"));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { action: "end_now" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Only live sessions can be ended now",
+    });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("patches editable fields and publishes a patch event", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Existing session",
+        start_time: "2026-04-15T05:00:00.000Z",
+        end_time: "2026-04-15T09:00:00.000Z",
+        is_active: true,
+        meta_data: JSON.stringify({
+          show_scores: true,
+          show_answers: false,
+          shuffle: false,
+          gurukul_format_type: "both",
+          untouched: "keep-me",
+        }),
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: {
+          name: "Updated session",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+          showAnswers: true,
+          showScores: false,
+          shuffle: true,
+          gurukulFormatType: "omr",
+          isActive: false,
+        },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: 42 });
+
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(mocks.mockFetch.mock.calls[0]?.[0]).toBe("http://db-service.local/session/42");
+    expect(patchBody).toMatchObject({
+      name: "Updated session",
+      is_active: false,
+      start_time: "2026-04-15T10:00:00.000Z",
+      end_time: "2026-04-15T14:00:00.000Z",
+      meta_data: {
+        show_answers: true,
+        show_scores: false,
+        shuffle: true,
+        gurukul_format_type: "omr",
+        untouched: "keep-me",
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "patch",
+      id: 42,
+      patch_session: expect.objectContaining({
+        name: "Updated session",
+        is_active: false,
+      }),
+    });
+  });
+
+  it("ends a live session immediately", async () => {
+    const { PATCH } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery.mockResolvedValue([
+      {
+        id: 42,
+        name: "Live session",
+        start_time: "2026-04-15T05:00:00.000Z",
+        end_time: "2026-04-15T07:00:00.000Z",
+        is_active: true,
+        meta_data: {},
+      },
+    ]);
+    mocks.mockFetch.mockResolvedValueOnce(jsonResponse({ id: 42 }));
+    vi.setSystemTime(new Date("2026-04-15T06:00:00.000Z"));
+
+    const res = await PATCH(
+      jsonRequest("http://localhost/api/quiz-sessions/42", {
+        method: "PATCH",
+        body: { action: "end_now" },
+      }) as never,
+      routeParams({ id: "42" })
+    );
+
+    expect(res.status).toBe(200);
+    const patchBody = JSON.parse(
+      String((mocks.mockFetch.mock.calls[0]?.[1] as RequestInit).body)
+    );
+    expect(patchBody.end_time).toBe("2026-04-15T11:30:00.000Z");
+  });
+});

--- a/src/app/api/quiz-sessions/batches/route.test.ts
+++ b/src/app/api/quiz-sessions/batches/route.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockRequireQuizSessionAccess: vi.fn(),
+  mockCanAccessQuizSessionSchool: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mocks.mockGetUserPermission,
+}));
+vi.mock("@/lib/quiz-session-access", () => ({
+  requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
+  canAccessQuizSessionSchool: mocks.mockCanAccessQuizSessionSchool,
+}));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockGetUserPermission.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockReset();
+  mocks.mockCanAccessQuizSessionSchool.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+    ok: true,
+    permission: { program_ids: [1] },
+  });
+  mocks.mockCanAccessQuizSessionSchool.mockResolvedValue(true);
+});
+
+describe("GET /api/quiz-sessions/batches", () => {
+  it("returns 401 when not authenticated", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 400 for an invalid school id", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=abc")
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid schoolId" });
+  });
+
+  it("returns 403 when the user cannot view quiz sessions", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user cannot access the requested school", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockCanAccessQuizSessionSchool.mockResolvedValue(false);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns school batches and appends missing parent rows", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      batches: [
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ],
+    });
+  });
+
+  it("falls back to global batches when the school has no mapped batch rows", async () => {
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 5,
+          name: "Parent Batch",
+          batch_id: "EnableStudents_11_Engg",
+          parent_id: null,
+          program_id: 1,
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/batches?schoolId=42")
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("FROM batch b"),
+      [[1]]
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      batches: expect.arrayContaining([
+        expect.objectContaining({ batch_id: "EnableStudents_11_Engg_A" }),
+      ]),
+    });
+  });
+});

--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  jsonRequest,
+} from "../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockRequireQuizSessionAccess: vi.fn(),
+  mockCanAccessQuizSessionSchool: vi.fn(),
+  mockCanAccessQuizSessionBatches: vi.fn(),
+  mockQuery: vi.fn(),
+  mockPublishMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mocks.mockGetUserPermission,
+}));
+vi.mock("@/lib/quiz-session-access", () => ({
+  requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
+  canAccessQuizSessionSchool: mocks.mockCanAccessQuizSessionSchool,
+  canAccessQuizSessionBatches: mocks.mockCanAccessQuizSessionBatches,
+}));
+vi.mock("@/lib/db", () => ({
+  query: mocks.mockQuery,
+}));
+vi.mock("@/lib/sns", () => ({
+  publishMessage: mocks.mockPublishMessage,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockGetUserPermission.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockReset();
+  mocks.mockCanAccessQuizSessionSchool.mockReset();
+  mocks.mockCanAccessQuizSessionBatches.mockReset();
+  mocks.mockQuery.mockReset();
+  mocks.mockPublishMessage.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+  mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+    ok: true,
+    permission: { program_ids: [1, 64] },
+  });
+  mocks.mockCanAccessQuizSessionSchool.mockResolvedValue(true);
+  mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("GET /api/quiz-sessions", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns paginated quiz sessions scoped to the school's class batches", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockQuery
+      .mockResolvedValueOnce([
+        {
+          id: 11,
+          name: "Class 11 Engg A",
+          batch_id: "EnableStudents_11_Engg_A",
+          parent_id: 5,
+          program_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 99,
+          name: "[LMS] Part Test 1",
+          start_time: "2026-04-15 15:00:00",
+          end_time: "2026-04-15 19:00:00",
+          is_active: true,
+          portal_link: "https://quiz.example/session/99",
+          platform: "quiz",
+          meta_data: {
+            batch_id: "EnableStudents_11_Engg_A",
+            date_created: "2026-04-15T13:30:00.000Z",
+          },
+        },
+      ]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42&page=0&per_page=10")
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      hasMore: false,
+      sessions: [
+        expect.objectContaining({
+          id: 99,
+          name: "[LMS] Part Test 1",
+          start_time: "2026-04-15T09:30:00.000Z",
+          end_time: "2026-04-15T13:30:00.000Z",
+          meta_data: expect.objectContaining({
+            batch_id: "EnableStudents_11_Engg_A",
+            date_created: "2026-04-15T08:00:00.000Z",
+          }),
+        }),
+      ],
+    });
+
+    expect(mocks.mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("FROM session s"),
+      [["EnableStudents_11_Engg_A"], 11, 0]
+    );
+    expect(mocks.mockRequireQuizSessionAccess).toHaveBeenCalledWith(
+      ADMIN_SESSION.user.email,
+      "view"
+    );
+  });
+
+  it("returns 403 when the user cannot view quiz sessions", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42")
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user cannot access the requested school", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockCanAccessQuizSessionSchool.mockResolvedValue(false);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions?schoolId=42")
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/quiz-sessions", () => {
+  it("returns 400 when selected template grade does not match the selected batches", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        id: 501,
+        type: "quiz_template",
+        code: "PT-12",
+        name: [{ resource: "Part Test 12", lang_code: "en" }],
+        type_params: {
+          grade: 12,
+          stream: "engineering",
+          test_format: "part_test",
+          test_purpose: "weekly_test",
+          test_type: "assessment",
+          cms_link: "https://cms.example/tests/pt-12",
+          question_pdf: "https://cdn.example/question.pdf",
+          solution_pdf: "https://cdn.example/solution.pdf",
+        },
+      })
+    );
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          stream: "engineering",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Selected template grade does not match selected batches",
+    });
+    expect(mocks.mockFetch).toHaveBeenCalledTimes(1);
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user cannot edit quiz sessions", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          stream: "engineering",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the selected class batches are outside the user's schools", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(false);
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          stream: "engineering",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+    expect(mocks.mockPublishMessage).not.toHaveBeenCalled();
+  });
+
+  it("creates a quiz session and queues session creation", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 501,
+          type: "quiz_template",
+          code: "PT-11",
+          name: [{ resource: "Part Test 11", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            course: "JEE",
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            optional_limits: "JEE",
+            cms_link: "https://cms.example/tests/pt-11",
+            question_pdf: "https://cdn.example/question.pdf",
+            solution_pdf: "https://cdn.example/solution.pdf",
+            ranking_cutoff_date: "2026-04-20",
+            sheet_name: "Part Tests",
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 321 }));
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          name: "Custom admin session",
+          resourceId: 501,
+          grade: 11,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A", "EnableStudents_11_Engg_B"],
+          stream: "engineering",
+          showAnswers: false,
+          showScores: true,
+          shuffle: true,
+          gurukulFormatType: "omr",
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: 321 });
+
+    expect(mocks.mockFetch).toHaveBeenCalledTimes(2);
+    expect(mocks.mockFetch.mock.calls[1]?.[0]).toBe("http://db-service.local/session");
+    const createPayload = JSON.parse(
+      String((mocks.mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(createPayload).toMatchObject({
+      name: "Custom admin session",
+      platform: "quiz",
+      start_time: "2026-04-15T10:00:00.000Z",
+      end_time: "2026-04-15T14:00:00.000Z",
+      meta_data: {
+        parent_id: "EnableStudents_11_Engg",
+        batch_id: "EnableStudents_11_Engg_A,EnableStudents_11_Engg_B",
+        grade: 11,
+        stream: "engineering",
+        resource_id: 501,
+        resource_name: "Part Test 11",
+        test_code: "PT-11",
+        show_answers: false,
+        show_scores: true,
+        shuffle: true,
+        gurukul_format_type: "omr",
+        status: "pending",
+        has_synced_to_bq: false,
+      },
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({
+      action: "db_id",
+      id: 321,
+    });
+  });
+});

--- a/src/app/api/quiz-sessions/templates/route.test.ts
+++ b/src/app/api/quiz-sessions/templates/route.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+} from "../../__test-utils__/api-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockRequireQuizSessionAccess: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.mockGetServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/quiz-session-access", () => ({
+  requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function loadRouteModule(env?: {
+  dbServiceUrl?: string;
+  dbServiceToken?: string;
+}) {
+  vi.resetModules();
+  process.env.DB_SERVICE_URL = env?.dbServiceUrl ?? "http://db-service.local";
+  process.env.DB_SERVICE_TOKEN = env?.dbServiceToken ?? "test-token";
+  return import("./route");
+}
+
+beforeEach(() => {
+  mocks.mockGetServerSession.mockReset();
+  mocks.mockRequireQuizSessionAccess.mockReset();
+  mocks.mockFetch.mockReset();
+  vi.stubGlobal("fetch", mocks.mockFetch);
+  mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+    ok: true,
+    permission: { program_ids: [1] },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DB_SERVICE_URL;
+  delete process.env.DB_SERVICE_TOKEN;
+});
+
+describe("GET /api/quiz-sessions/templates", () => {
+  it("returns 401 when not authenticated", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(NO_SESSION);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/templates?grade=11")
+    );
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("filters parsed quiz templates by grade, stream, format, search, and active state", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 501,
+          type: "quiz_template",
+          code: "PT-11",
+          name: [{ resource: "Engineering Part Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11",
+            is_active: true,
+          },
+        },
+        {
+          id: 502,
+          type: "quiz_template",
+          code: "PT-11-MED",
+          name: [{ resource: "Medical Part Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "medical",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11-med",
+            is_active: true,
+          },
+        },
+        {
+          id: 503,
+          type: "quiz_template",
+          code: "PT-11-INACTIVE",
+          name: [{ resource: "Inactive Test", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            stream: "engineering",
+            test_format: "part_test",
+            test_purpose: "weekly_test",
+            test_type: "assessment",
+            cms_link: "https://cms.example/tests/pt-11-inactive",
+            is_active: false,
+          },
+        },
+      ])
+    );
+
+    const res = await GET(
+      new NextRequest(
+        "http://localhost/api/quiz-sessions/templates?grade=11&stream=engineering&testFormat=part_test&search=engineering"
+      )
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      templates: [
+        expect.objectContaining({
+          id: 501,
+          code: "PT-11",
+          name: "Engineering Part Test",
+          stream: "engineering",
+          testFormat: "part_test",
+        }),
+      ],
+    });
+    expect(mocks.mockFetch.mock.calls[0]?.[0]).toBe(
+      "http://db-service.local/resource?type=quiz_template&limit=1000&sort_by=code&sort_order=asc"
+    );
+  });
+
+  it("returns 403 when the user cannot view quiz sessions", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockRequireQuizSessionAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/templates?grade=11")
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(mocks.mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards downstream failure status when template fetch fails", async () => {
+    const { GET } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch.mockResolvedValueOnce(new Response("service unavailable", { status: 503 }));
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/quiz-sessions/templates?grade=11")
+    );
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to fetch quiz templates",
+    });
+  });
+});

--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -164,8 +164,12 @@ vi.mock("@/components/PerformanceTab", () => ({
 
 vi.mock("@/components/quiz-sessions/QuizSessionsTab", () => ({
   __esModule: true,
-  default: ({ schoolId }: { schoolId: string }) => (
-    <div data-testid="quiz-sessions-tab" data-school-id={schoolId}>
+  default: ({ schoolId, canEdit }: { schoolId: string; canEdit?: boolean }) => (
+    <div
+      data-testid="quiz-sessions-tab"
+      data-school-id={schoolId}
+      data-can-edit={String(canEdit)}
+    >
       QuizSessionsTab
     </div>
   ),
@@ -711,6 +715,46 @@ describe("SchoolPage (server component)", () => {
       "data-school-id",
       "school-42"
     );
+    expect(screen.getByTestId("quiz-sessions-tab")).toHaveAttribute(
+      "data-can-edit",
+      "true"
+    );
+  });
+
+  it("passes view-only access to QuizSessionsTab", async () => {
+    setupAdminDefaults({ id: "school-42" });
+    mockGetFeatureAccess.mockImplementation(
+      (_perm: unknown, feature: string) => {
+        if (feature === "quiz_sessions") return featureAccess(true, false);
+        return featureAccess(true, true);
+      }
+    );
+
+    await renderPage();
+
+    expect(screen.getByTestId("quiz-sessions-tab")).toHaveAttribute(
+      "data-school-id",
+      "school-42"
+    );
+    expect(screen.getByTestId("quiz-sessions-tab")).toHaveAttribute(
+      "data-can-edit",
+      "false"
+    );
+  });
+
+  it("hides QuizSessionsTab when quiz session access is none", async () => {
+    setupAdminDefaults();
+    mockGetFeatureAccess.mockImplementation(
+      (_perm: unknown, feature: string) => {
+        if (feature === "quiz_sessions") return featureAccess(false, false);
+        return featureAccess(true, true);
+      }
+    );
+
+    await renderPage();
+
+    expect(screen.queryByTestId("tab-quiz_sessions")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("quiz-sessions-tab")).not.toBeInTheDocument();
   });
 
   // --- VisitsTab props ---

--- a/src/components/quiz-sessions/QuizSessionsTab.test.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.test.tsx
@@ -1,0 +1,446 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import QuizSessionsTab from "./QuizSessionsTab";
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+function makeBatches() {
+  return [
+    {
+      id: 5,
+      name: "Parent Batch 11 Engg",
+      batch_id: "EnableStudents_11_Engg",
+      parent_id: null,
+      program_id: 1,
+    },
+    {
+      id: 11,
+      name: "Class 11 Engg A",
+      batch_id: "EnableStudents_11_Engg_A",
+      parent_id: 5,
+      program_id: 1,
+    },
+    {
+      id: 12,
+      name: "Class 11 Engg B",
+      batch_id: "EnableStudents_11_Engg_B",
+      parent_id: 5,
+      program_id: 1,
+    },
+    {
+      id: 7,
+      name: "Parent Batch 11 Med",
+      batch_id: "EnableStudents_11_Med",
+      parent_id: null,
+      program_id: 1,
+    },
+    {
+      id: 21,
+      name: "Class 11 Med A",
+      batch_id: "EnableStudents_11_Med_A",
+      parent_id: 7,
+      program_id: 1,
+    },
+  ];
+}
+
+function makeSessions() {
+  return [
+    {
+      id: 1,
+      name: "Existing Quiz",
+      start_time: "2026-04-15T05:00:00.000Z",
+      end_time: "2026-04-15T09:00:00.000Z",
+      is_active: true,
+      portal_link: "https://quiz.example/1",
+      meta_data: {
+        batch_id: "EnableStudents_11_Engg_A",
+        test_code: "PT-ENGG-A",
+        resource_name: "Existing Quiz",
+        status: "ready",
+        etl_sync_status: "synced",
+        etl_synced_at: "2026-04-15T09:30:00.000Z",
+        has_synced_to_bq: true,
+      },
+    },
+    {
+      id: 2,
+      name: "Second Quiz",
+      start_time: "2026-04-15T05:00:00.000Z",
+      end_time: "2026-04-15T09:00:00.000Z",
+      is_active: true,
+      portal_link: "https://quiz.example/2",
+      meta_data: {
+        batch_id: "EnableStudents_11_Engg_B",
+        test_code: "PT-ENGG-B",
+        resource_name: "Second Quiz",
+        status: "ready",
+        has_synced_to_bq: false,
+      },
+    },
+    {
+      id: 3,
+      name: "Synced Quiz Without Time",
+      start_time: "2026-04-15T05:00:00.000Z",
+      end_time: "2026-04-15T09:00:00.000Z",
+      is_active: true,
+      portal_link: "https://quiz.example/3",
+      meta_data: {
+        batch_id: "EnableStudents_11_Engg_A",
+        test_code: "PT-SYNCED",
+        resource_name: "Synced Quiz Without Time",
+        status: "ready",
+        has_synced_to_bq: true,
+      },
+    },
+  ];
+}
+
+function makeTemplate() {
+  return {
+    id: 501,
+    code: "PT-11",
+    name: "Part Test 11",
+    grade: 11,
+    course: "JEE",
+    stream: "engineering",
+    testFormat: "part_test",
+    testPurpose: "weekly_test",
+    testType: "assessment",
+    optionalLimits: "JEE",
+    cmsLink: "https://cms.example/tests/pt-11",
+    cmsSourceId: "pt-11",
+    questionPdf: "https://cdn.example/question.pdf",
+    solutionPdf: "https://cdn.example/solution.pdf",
+    rankingCutoffDate: "2026-04-20",
+    sheetName: "Sheet 1",
+  };
+}
+
+function getFetchCalls(mockFetch: ReturnType<typeof vi.fn>, pathPrefix: string) {
+  return mockFetch.mock.calls.filter(([input]) => String(input).startsWith(pathPrefix));
+}
+
+describe("QuizSessionsTab", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let sessions: ReturnType<typeof makeSessions>;
+  let createdPayload: Record<string, unknown> | null;
+
+  beforeEach(() => {
+    sessions = makeSessions();
+    createdPayload = null;
+
+    mockFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.startsWith("/api/quiz-sessions/batches")) {
+        return jsonResponse({ batches: makeBatches() });
+      }
+
+      if (url.startsWith("/api/quiz-sessions/templates")) {
+        return jsonResponse({ templates: [makeTemplate()] });
+      }
+
+      if (url.startsWith("/api/quiz-sessions?")) {
+        const parsed = new URL(url, "http://localhost");
+        const classBatchId = parsed.searchParams.get("classBatchId");
+        const filtered = classBatchId
+          ? sessions.filter((session) =>
+              String(session.meta_data?.batch_id || "")
+                .split(",")
+                .includes(classBatchId)
+            )
+          : sessions;
+        return jsonResponse({ sessions: filtered, hasMore: false });
+      }
+
+      if (url === "/api/quiz-sessions" && init?.method === "POST") {
+        createdPayload = JSON.parse(String(init.body));
+        sessions = [
+          {
+            id: 99,
+            name: String(createdPayload.name || "[LMS] Part Test 11"),
+            start_time: String(createdPayload.startTime),
+            end_time: String(createdPayload.endTime),
+            is_active: true,
+            portal_link: null,
+            meta_data: {
+              batch_id: Array.isArray(createdPayload.classBatchIds)
+                ? createdPayload.classBatchIds.join(",")
+                : "",
+              test_code: "PT-11",
+              resource_name: "Part Test 11",
+              status: "pending",
+              etl_sync_status: "pending",
+              has_synced_to_bq: false,
+            },
+          },
+          ...sessions,
+        ];
+        return jsonResponse({ id: 99 });
+      }
+
+      const editSessionMatch = url.match(/^\/api\/quiz-sessions\/(\d+)$/);
+      if (editSessionMatch && init?.method === "PATCH") {
+        const sessionId = Number(editSessionMatch[1]);
+        const editPayload = JSON.parse(String(init.body)) as {
+          name?: string;
+          startTime?: string;
+          endTime?: string;
+        };
+
+        if (editPayload.name === "Server Rejected") {
+          return jsonResponse({ error: "Session overlaps an existing window" }, 409);
+        }
+
+        sessions = sessions.map((session) =>
+          session.id === sessionId
+            ? {
+                ...session,
+                name: editPayload.name ?? session.name,
+                start_time: editPayload.startTime ?? session.start_time,
+                end_time: editPayload.endTime ?? session.end_time,
+              }
+            : session
+        );
+        return jsonResponse({ id: sessionId });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("filters sessions by class batch", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+    expect(screen.getByText("Second Quiz")).toBeInTheDocument();
+    expect(screen.getByText("Synced Quiz Without Time")).toBeInTheDocument();
+    expect(
+      screen.getByText("Results sync automatically every 30 minutes. Manual sync is not needed.")
+    ).toBeInTheDocument();
+
+    await user.selectOptions(screen.getAllByRole("combobox")[0], "EnableStudents_11_Engg_B");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Existing Quiz")).not.toBeInTheDocument();
+      expect(screen.queryByText("Synced Quiz Without Time")).not.toBeInTheDocument();
+      expect(screen.getByText("Second Quiz")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("classBatchId=EnableStudents_11_Engg_B")
+    );
+  });
+
+  it("keeps view-only users away from create and edit actions", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Quiz Session" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open actions" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("View only")).toHaveLength(3);
+
+    await user.click(screen.getByText("Existing Quiz"));
+
+    expect(screen.getByRole("heading", { name: "Session Details" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("creates a pending LMS session from same-parent class batches and a selected paper", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create Quiz Session" }));
+    await user.click(screen.getByLabelText("Class 11 Engg A"));
+    await user.click(screen.getByLabelText("Class 11 Engg B"));
+    await user.selectOptions(screen.getAllByRole("combobox")[1], "part_test");
+
+    expect(await screen.findByText("Part Test 11")).toBeInTheDocument();
+    await user.click(screen.getByText("Part Test 11"));
+    await user.click(screen.getByRole("button", { name: "Create Session" }));
+
+    await waitFor(() => {
+      expect(createdPayload).toMatchObject({
+        resourceId: 501,
+        grade: 11,
+        parentBatchId: "EnableStudents_11_Engg",
+        classBatchIds: ["EnableStudents_11_Engg_A", "EnableStudents_11_Engg_B"],
+        stream: "engineering",
+        name: "[LMS] Part Test 11",
+        showAnswers: false,
+        showScores: true,
+        shuffle: false,
+        gurukulFormatType: "both",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "Create Quiz Session" })).not.toBeInTheDocument();
+      expect(screen.getByText("[LMS] Part Test 11")).toBeInTheDocument();
+      expect(screen.getByText("Processing")).toBeInTheDocument();
+      expect(screen.getByText("Queued")).toBeInTheDocument();
+    });
+
+    const templateCallUrl = String(getFetchCalls(mockFetch, "/api/quiz-sessions/templates?")[0][0]);
+    const templateParams = new URL(templateCallUrl, "http://localhost").searchParams;
+    expect(templateParams.get("grade")).toBe("11");
+    expect(templateParams.get("stream")).toBe("engineering");
+    expect(templateParams.get("testFormat")).toBe("part_test");
+  });
+
+  it("shows compact sync status without manual sync controls", async () => {
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+    expect(
+      screen.getByText("Results sync automatically every 30 minutes. Manual sync is not needed.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Results sync automatically every 30 minutes. Manual sync is not needed.")
+    ).toHaveLength(1);
+
+    const existingQuizRow = screen.getByText("Existing Quiz").closest("tr");
+    expect(existingQuizRow).not.toBeNull();
+    const secondQuizRow = screen.getByText("Second Quiz").closest("tr");
+    expect(secondQuizRow).not.toBeNull();
+    const syncedWithoutTimeRow = screen.getByText("Synced Quiz Without Time").closest("tr");
+    expect(syncedWithoutTimeRow).not.toBeNull();
+
+    expect(
+      within(existingQuizRow as HTMLTableRowElement).getByText(/Last synced:/)
+    ).toBeInTheDocument();
+    expect(
+      within(existingQuizRow as HTMLTableRowElement).queryByRole("button", { name: /sync/i })
+    ).not.toBeInTheDocument();
+    expect(
+      within(existingQuizRow as HTMLTableRowElement).queryByText(/Auto-syncs every/)
+    ).not.toBeInTheDocument();
+    expect(
+      within(secondQuizRow as HTMLTableRowElement).queryByText(/Last synced:/)
+    ).not.toBeInTheDocument();
+    expect(
+      within(secondQuizRow as HTMLTableRowElement).queryByText("Sync time not recorded")
+    ).not.toBeInTheDocument();
+    expect(
+      within(syncedWithoutTimeRow as HTMLTableRowElement).getByText("Sync time not recorded")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Last synced: -")).not.toBeInTheDocument();
+  });
+
+  it("shows create validation errors next to the submit controls", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create Quiz Session" }));
+    await user.click(screen.getByRole("button", { name: "Create Session" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("At least one class batch is required.");
+    expect(alert.parentElement?.parentElement).toContainElement(
+      screen.getByRole("button", { name: "Create Session" })
+    );
+  });
+
+  it("blocks creation when selected class batches do not share a parent batch", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create Quiz Session" }));
+    await user.click(screen.getByLabelText("Class 11 Engg A"));
+    await user.click(screen.getByLabelText("Class 11 Med A"));
+    await user.click(screen.getByRole("button", { name: "Create Session" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Selected class batches must belong to the same parent batch."
+    );
+    expect(createdPayload).toBeNull();
+    expect(getFetchCalls(mockFetch, "/api/quiz-sessions/templates?")).toHaveLength(0);
+  });
+
+  it("shows edit validation errors next to the save controls", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Existing Quiz"));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.clear(screen.getByDisplayValue("Existing Quiz"));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Session name is required.");
+    expect(alert.parentElement?.parentElement).toContainElement(
+      screen.getByRole("button", { name: "Save Changes" })
+    );
+  });
+
+  it("shows edit API errors next to the save controls without closing the modal", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Existing Quiz"));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    const nameInput = screen.getByDisplayValue("Existing Quiz");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Server Rejected");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Session overlaps an existing window");
+    expect(alert.parentElement?.parentElement).toContainElement(
+      screen.getByRole("button", { name: "Save Changes" })
+    );
+    expect(screen.getByRole("heading", { name: "Edit Quiz Session" })).toBeInTheDocument();
+  });
+
+  it("does not expose the removed sync endpoint from the UI", async () => {
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    expect(await screen.findByText("Existing Quiz")).toBeInTheDocument();
+
+    expect(screen.queryByRole("button", { name: "Sync Now" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry Sync" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sync Again" })).not.toBeInTheDocument();
+
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/quiz-sessions\/\d+\/sync/),
+      expect.anything()
+    );
+  });
+});

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -138,10 +138,26 @@ describe("getFeatureAccess", () => {
       expect(result.access).toBe("none");
     });
 
+    it("gives teachers edit on quiz sessions", () => {
+      const perm = makePermission({ role: "teacher", program_ids: [PROGRAM_IDS.COE] });
+      const result = getFeatureAccess(perm, "quiz_sessions");
+      expect(result.access).toBe("edit");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(true);
+    });
+
     it("gives PMs edit on visits", () => {
       const perm = makePermission({ role: "program_manager", program_ids: [PROGRAM_IDS.COE] });
       const result = getFeatureAccess(perm, "visits");
       expect(result.canEdit).toBe(true);
+    });
+
+    it("gives PMs view on quiz sessions", () => {
+      const perm = makePermission({ role: "program_manager", program_ids: [PROGRAM_IDS.COE] });
+      const result = getFeatureAccess(perm, "quiz_sessions");
+      expect(result.access).toBe("view");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(false);
     });
 
     it("gives program_admin view on visits", () => {
@@ -152,10 +168,26 @@ describe("getFeatureAccess", () => {
       expect(result.canEdit).toBe(false);
     });
 
+    it("gives program_admin view on quiz sessions", () => {
+      const perm = makePermission({ role: "program_admin", program_ids: [PROGRAM_IDS.COE] });
+      const result = getFeatureAccess(perm, "quiz_sessions");
+      expect(result.access).toBe("view");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(false);
+    });
+
     it("gives admin edit on visits", () => {
       const perm = makePermission({ role: "admin" });
       const result = getFeatureAccess(perm, "visits");
       expect(result.canEdit).toBe(true);
+    });
+
+    it("gives admin view on quiz sessions", () => {
+      const perm = makePermission({ role: "admin" });
+      const result = getFeatureAccess(perm, "quiz_sessions");
+      expect(result.access).toBe("view");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(false);
     });
   });
 
@@ -166,6 +198,15 @@ describe("getFeatureAccess", () => {
         program_ids: [PROGRAM_IDS.NVS],
       });
       const result = getFeatureAccess(perm, "visits");
+      expect(result.access).toBe("none");
+    });
+
+    it("blocks NVS-only user from quiz sessions", () => {
+      const perm = makePermission({
+        role: "program_manager",
+        program_ids: [PROGRAM_IDS.NVS],
+      });
+      const result = getFeatureAccess(perm, "quiz_sessions");
       expect(result.access).toBe("none");
     });
 
@@ -201,6 +242,14 @@ describe("getFeatureAccess", () => {
     it("downgrades edit to view for read_only users", () => {
       const perm = makePermission({ role: "teacher", read_only: true, program_ids: [PROGRAM_IDS.COE] });
       const result = getFeatureAccess(perm, "students");
+      expect(result.access).toBe("view");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(false);
+    });
+
+    it("downgrades quiz session edit to view for read_only teachers", () => {
+      const perm = makePermission({ role: "teacher", read_only: true, program_ids: [PROGRAM_IDS.COE] });
+      const result = getFeatureAccess(perm, "quiz_sessions");
       expect(result.access).toBe("view");
       expect(result.canView).toBe(true);
       expect(result.canEdit).toBe(false);


### PR DESCRIPTION
## Summary

Adds focused test coverage for the quiz-session feature now living in #12.

This PR is intentionally test-only relative to `feat-sess-creation`.

## Coverage Added

- Route tests for quiz-session list/create/edit/regenerate endpoints.
- Route tests for batches/templates support endpoints.
- Permission matrix tests for quiz-session role access, `read_only` downgrade, and NVS gating.
- School page tests for quiz-session tab visibility and `canEdit` pass-through.
- QuizSessionsTab tests for batch filtering, create flow, auto-sync messaging, footer-level create/edit errors, removed manual sync controls, and view-only behavior.

## Verification

- `npm test -- "src/lib/permissions.test.ts" "src/app/api/quiz-sessions/route.test.ts" "src/app/api/quiz-sessions/[id]/route.test.ts" "src/app/api/quiz-sessions/[id]/regenerate/route.test.ts" "src/app/api/quiz-sessions/batches/route.test.ts" "src/app/api/quiz-sessions/templates/route.test.ts" "src/components/quiz-sessions/QuizSessionsTab.test.tsx" "src/app/school/[udise]/page.test.tsx"`
  - 155 tests passed
- `npx eslint` on the touched test files passed

## Notes

- Product/review-response changes were moved to #12.
- This branch was rebuilt on top of the updated `feat-sess-creation`; the diff is only test files.