### PR TITLE
feat: multi-select checkbox dropdown for individual student interaction (#34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Student Enrollment CRUD UI for Avanti Fellows - a Next.js 16 application that allows school administrators to view and manage student enrollments. Features dual authentication (Google OAuth + school passcodes) with permission-based access control.
 
-PM school-visit flows include per-action tracking with GPS, a completed classroom-observation rubric implementation (v1, 19 scored params, max score 45), an AF team interaction checklist (9 binary questions with multiselect teacher dropdown), an individual AF teacher interaction per-teacher checklist (13 binary questions with attendance gating), a principal interaction checklist (7 binary questions, no teacher selection), a group student interaction checklist (4 binary questions with grade selection), an individual student interaction per-student checklist (2 binary questions with grade filter and student dropdown), and a school staff interaction checklist (2 binary questions, no teacher/student/grade selection).
+PM school-visit flows include per-action tracking with GPS, a completed classroom-observation rubric implementation (v1, 19 scored params, max score 45), an AF team interaction checklist (9 binary questions with multiselect teacher dropdown), an individual AF teacher interaction per-teacher checklist (13 binary questions with attendance gating), a principal interaction checklist (7 binary questions, no teacher selection), a group student interaction checklist (4 binary questions with grade selection), an individual student interaction per-student checklist (2 binary questions with grade filter and multi-select checkbox dropdown with batch-add), and a school staff interaction checklist (2 binary questions, no teacher/student/grade selection).
 
 ## Development Commands
 
@@ -147,7 +147,7 @@ Visit tables:
 - Form component: `src/components/visits/GroupStudentDiscussionForm.tsx`
 
 ### PM Visits: Individual Student Interaction (v1)
-- Per-student 2-question binary checklist with grade filter and student dropdown across 1 section — no attendance gating
+- Per-student 2-question binary checklist with grade filter and multi-select checkbox dropdown with batch-add across 1 section — no attendance gating
 - Payload: `{ students: [{ id, name, grade, questions: { [key]: { answer: boolean|null, remark?: string } } }] }`
 - Grade filter fetches students from `/api/pm/students?school_code=X&grade=N`
 - 1 section: Operational Health (2 questions) — 2 total

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,89 @@
+# AF LMS
+
+Student enrollment management and PM school-visit tracking for Avanti Fellows — a nonprofit running supplemental education programs in Indian government schools.
+
+## Language
+
+### Enrollment & School
+
+**School**:
+A government school enrolled in an Avanti Fellows program, identified by UDISE code.
+_Avoid_: Institution, center
+
+**Student**:
+A learner enrolled at a school, linked via `group_user` membership.
+_Avoid_: Learner, pupil
+
+**Batch**:
+A grouping of students within a school for program delivery.
+_Avoid_: Cohort, section
+
+**UDISE Code**:
+A unique government-issued identifier for a school.
+_Avoid_: School ID, school code (internally `school.code` is a separate field)
+
+**Passcode**:
+An 8-digit code granting single-school access without Google OAuth. Format: `{schoolCode}XXX`.
+_Avoid_: PIN, access code
+
+### Visits & Actions
+
+**Visit**:
+A PM's physical school visit record. Two-state lifecycle: `in_progress` → `completed`.
+_Avoid_: Inspection, audit, trip
+
+**Action**:
+A discrete task performed during a visit (e.g., classroom observation, teacher interaction). Has its own lifecycle: `pending` → `in_progress` → `completed`.
+_Avoid_: Task, activity, checklist
+
+**Action Type**:
+One of seven fixed types: `classroom_observation`, `af_team_interaction`, `individual_af_teacher_interaction`, `principal_interaction`, `group_student_discussion`, `individual_student_discussion`, `school_staff_interaction`.
+_Avoid_: Category, kind
+
+**Soft Delete**:
+Setting `deleted_at` timestamp instead of removing the row. Used for actions and (issue #35) visits.
+_Avoid_: Archive, deactivate
+
+### Roles & Access
+
+**PM (Program Manager)**:
+Field staff who conduct school visits. Owns their visits and actions.
+_Avoid_: Manager, field officer
+
+**Admin**:
+Has scoped read/write access to all visits (same validation rules as PM). Determined by `role = "admin"`.
+_Avoid_: Superuser, root
+
+**Program Admin**:
+Read-only access to visits within their scope. Cannot create, edit, or delete.
+_Avoid_: Viewer, observer
+
+**Permission Level**:
+Numeric access scope: Level 3 = all schools, Level 2 = region, Level 1 = specific school codes.
+_Avoid_: Access tier, role level
+
+## Relationships
+
+- A **School** has many **Students** (via `group` → `group_user`)
+- A **School** has many **Batches**
+- A **PM** creates **Visits** to a **School**
+- A **Visit** has many **Actions** (each with an **Action Type**)
+- A **Visit** can only be completed when all 7 **Action Types** have at least one completed **Action**
+- **Soft Delete** on a **Visit** cascades to its child **Actions**
+
+## Example dialogue
+
+> **Dev:** "When a **PM** deletes a **Visit**, do we also delete the **Actions**?"
+> **Domain expert:** "Yes — cascade **soft delete** all child **Actions** in the same transaction. A dangling action with no parent visit makes no sense."
+
+> **Dev:** "Can a **Program Admin** delete a **Visit**?"
+> **Domain expert:** "No — **Program Admins** are read-only. Only the **PM** owner and **Admins** can delete."
+
+> **Dev:** "Can a completed **Visit** be deleted?"
+> **Domain expert:** "No — completed visits are auditable records. Only `in_progress` visits can be deleted."
+
+## Flagged ambiguities
+
+- "school code" vs "UDISE code": `school.code` is an internal short identifier; `school.udise_code` is the government-issued UDISE. Both identify a school but in different contexts. API routes use UDISE in URLs, passcodes derive from school code.
+- "admin" vs "program_admin": These are distinct roles. `admin` has write access; `program_admin` is read-only. The naming is confusing — always use the full term.
+- "deleted" for actions vs visits: Actions already support soft delete (`deleted_at` on `lms_pm_school_visit_actions`). Issue #35 extends this to visits (`lms_pm_school_visits`).

--- a/docs/ai/student-interaction/2026-03-18-student-interaction-implementation-plan.md
+++ b/docs/ai/student-interaction/2026-03-18-student-interaction-implementation-plan.md
@@ -1,3 +1,5 @@
+# Superseded by #34
+
 # Plan: Student Interaction Action Types
 
 ## Context

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -145,19 +145,20 @@ async function fillIndividualStudentDiscussionForm(page: Page) {
   await expect(gradeFilter).toBeVisible();
   await gradeFilter.selectOption("11");
 
-  // Wait for students to load and select the first available student
-  const addSelect = page.getByTestId("add-student-select");
-  await expect(addSelect).toBeVisible({ timeout: 10_000 });
-  const options = addSelect.locator("option:not([disabled])");
-  await expect(options.first()).toBeAttached({ timeout: 10_000 });
-  await addSelect.selectOption({ index: 1 });
+  // Wait for students to load and add the first available student
+  await page.getByTestId("multi-select-student-trigger").click();
+  await expect(page.getByTestId("multi-select-student-panel")).toBeVisible({ timeout: 10_000 });
+  const firstCheckbox = page.locator('[data-testid^="student-checkbox-"]').first();
+  await expect(firstCheckbox).toBeVisible({ timeout: 10_000 });
+  await firstCheckbox.check();
+  await page.getByTestId("add-selected-students").click();
 
   // The new student section should auto-expand
-  const studentSections = page.locator('[data-testid^="student-section-"]');
-  await expect(studentSections).toHaveCount(1);
+  const section = page.locator('[data-testid^="student-section-"]').first();
+  await expect(section).toBeVisible();
 
   // Get the student ID from the section's data-testid
-  const sectionTestId = await studentSections.first().getAttribute("data-testid");
+  const sectionTestId = await section.getAttribute("data-testid");
   const studentId = sectionTestId!.replace("student-section-", "");
 
   // Answer all 2 questions with Yes
@@ -1348,6 +1349,86 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     // Both action types show as completed on the visit detail page
     await expect(refreshedGroupCard.getByRole("link", { name: "View Details" })).toBeVisible();
     await expect(refreshedIndividualCard.getByRole("link", { name: "View Details" })).toBeVisible();
+  });
+
+  test("pm-batch-adds-students-and-ends-individual-student-interaction", async ({ pmPage }) => {
+    const { visitId } = await seedTestVisit(pool, schoolCode);
+
+    await setGoodGps(pmPage);
+    await pmPage.goto(`/visits/${visitId}`);
+
+    await pmPage.getByRole("button", { name: "Add Action Point" }).click();
+    const dialog = pmPage.getByRole("dialog");
+    await dialog.getByLabel("Individual Student Interaction").click();
+    await dialog.getByRole("button", { name: "Add" }).click();
+
+    await pmPage.waitForURL(/\/visits\/\d+\/actions\/\d+/);
+    const actionId = pmPage.url().split("/actions/")[1]!;
+
+    await pmPage.getByTestId("student-grade-filter").selectOption("11");
+    await pmPage.getByTestId("multi-select-student-trigger").click();
+    await expect(pmPage.getByTestId("multi-select-student-panel")).toBeVisible();
+
+    const checkboxes = pmPage.locator('[data-testid^="student-checkbox-"]');
+    await expect(checkboxes.nth(0)).toBeVisible({ timeout: 10_000 });
+    await expect(checkboxes.nth(1)).toBeVisible({ timeout: 10_000 });
+    await checkboxes.nth(0).check();
+    await checkboxes.nth(1).check();
+    await pmPage.getByTestId("add-selected-students").click();
+
+    const sections = pmPage.locator('[data-testid^="student-section-"]');
+    await expect(sections).toHaveCount(2);
+
+    const studentIds: string[] = [];
+    for (let index = 0; index < 2; index += 1) {
+      const section = sections.nth(index);
+      const sectionTestId = await section.getAttribute("data-testid");
+      const studentId = sectionTestId!.replace("student-section-", "");
+      studentIds.push(studentId);
+
+      await pmPage.getByTestId(`student-header-${studentId}`).click();
+      for (const key of INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys) {
+        await pmPage.getByTestId(`student-${studentId}-${key}-yes`).check();
+      }
+    }
+
+    const requestOrder: string[] = [];
+    pmPage.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "PATCH" && url.pathname.includes(`/actions/${actionId}`)) {
+        requestOrder.push("patch");
+      }
+      if (request.method() === "POST" && url.pathname.includes(`/actions/${actionId}/end`)) {
+        requestOrder.push("end");
+      }
+    });
+
+    await pmPage.getByRole("button", { name: "End Action" }).click();
+    await expect(
+      pmPage.getByText("Completed actions are read-only for your role.")
+    ).toBeVisible();
+    expect(requestOrder).toEqual(["patch", "end"]);
+
+    const actionRows = await pool.query<{ status: string; data: Record<string, unknown> }>(
+      `SELECT status, data FROM lms_pm_school_visit_actions WHERE id = $1`,
+      [actionId]
+    );
+    const actionRow = actionRows.rows[0];
+    expect(actionRow?.status).toBe("completed");
+
+    const students = actionRow?.data?.students as Array<Record<string, unknown>>;
+    expect(Array.isArray(students)).toBe(true);
+    expect(students.length).toBeGreaterThanOrEqual(2);
+    for (const student of students) {
+      expect(typeof student.id).toBe("number");
+      expect(typeof student.name).toBe("string");
+      expect(student.grade).toBe(11);
+      const questions = student.questions as Record<string, Record<string, unknown>>;
+      for (const key of INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys) {
+        expect(questions[key]?.answer).toBe(true);
+      }
+    }
+    expect(studentIds.length).toBe(2);
   });
 
   test("visit-completion-requires-school-staff-interaction", async ({ pmPage }) => {

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -1370,8 +1370,9 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     await expect(pmPage.getByTestId("multi-select-student-panel")).toBeVisible();
 
     const checkboxes = pmPage.locator('[data-testid^="student-checkbox-"]');
-    await expect(checkboxes.nth(0)).toBeVisible({ timeout: 10_000 });
-    await expect(checkboxes.nth(1)).toBeVisible({ timeout: 10_000 });
+    await checkboxes.first().waitFor({ state: "visible", timeout: 10_000 });
+    const checkboxCount = await checkboxes.count();
+    expect(checkboxCount).toBeGreaterThanOrEqual(2);
     await checkboxes.nth(0).check();
     await checkboxes.nth(1).check();
     await pmPage.getByTestId("add-selected-students").click();

--- a/src/components/visits/IndividualStudentDiscussionForm.test.tsx
+++ b/src/components/visits/IndividualStudentDiscussionForm.test.tsx
@@ -71,15 +71,23 @@ async function selectGrade(user: ReturnType<typeof userEvent.setup>, grade: stri
   await user.selectOptions(screen.getByTestId("student-grade-filter"), grade);
 }
 
-/** Focus the search input to open the dropdown listbox */
-async function openStudentSearch(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByTestId("add-student-select"));
+async function openMultiSelect(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("multi-select-student-trigger"));
+  await waitFor(() => {
+    expect(screen.getByTestId("multi-select-student-panel")).toBeInTheDocument();
+  });
 }
 
-/** Select a student by clicking their option in the searchable dropdown */
-async function selectStudentOption(user: ReturnType<typeof userEvent.setup>, studentId: number) {
-  const option = screen.getByTestId(`student-option-${studentId}`);
-  await user.click(option);
+async function checkStudent(user: ReturnType<typeof userEvent.setup>, studentId: number) {
+  await user.click(screen.getByTestId(`student-checkbox-${studentId}`));
+}
+
+async function clickAddSelected(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("add-selected-students"));
+}
+
+async function checkAllStudents(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("select-all-students"));
 }
 
 describe("IndividualStudentDiscussionForm", () => {
@@ -105,7 +113,7 @@ describe("IndividualStudentDiscussionForm", () => {
       render(<Harness />);
 
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(screen.queryByTestId("add-student-select")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("multi-select-student-trigger")).not.toBeInTheDocument();
     });
 
     it("fetches students with correct school_code and grade params when grade selected", async () => {
@@ -171,152 +179,321 @@ describe("IndividualStudentDiscussionForm", () => {
       });
     });
 
-    it("renders searchable student input after successful fetch", async () => {
+    it("renders multi-select student dropdown after successful fetch", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
 
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      // Focus to open dropdown
-      await openStudentSearch(user);
+      await user.click(screen.getByTestId("multi-select-student-trigger"));
 
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).getByText("Alice Student")).toBeInTheDocument();
-      expect(within(listbox).getByText("Bob Learner")).toBeInTheDocument();
-      expect(within(listbox).getByText("Carol Pupil")).toBeInTheDocument();
+      const panel = screen.getByTestId("multi-select-student-panel");
+      expect(within(panel).getByTestId("select-all-students")).toBeInTheDocument();
+      expect(within(panel).getByTestId("multi-select-student-search")).toBeInTheDocument();
+      expect(within(panel).getByTestId("student-checkbox-1")).toBeInTheDocument();
+      expect(within(panel).getByTestId("student-checkbox-2")).toBeInTheDocument();
+      expect(within(panel).getByTestId("student-checkbox-3")).toBeInTheDocument();
+      expect(within(panel).getByTestId("add-selected-students")).toHaveTextContent(
+        "Add Selected (0)"
+      );
     });
   });
 
-  describe("searchable dropdown", () => {
-    it("filters students by name as user types", async () => {
+  describe("multi-select dropdown", () => {
+    it("toggles an individual student checkbox", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await user.type(screen.getByTestId("add-student-select"), "alice");
+      await openMultiSelect(user);
+      const checkbox = screen.getByTestId("student-checkbox-1");
 
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).getByText("Alice Student")).toBeInTheDocument();
-      expect(within(listbox).queryByText("Bob Learner")).not.toBeInTheDocument();
-      expect(within(listbox).queryByText("Carol Pupil")).not.toBeInTheDocument();
+      await user.click(checkbox);
+      expect(checkbox).toBeChecked();
+      expect(screen.getByTestId("add-selected-students")).toHaveTextContent("Add Selected (1)");
+
+      await user.click(checkbox);
+      expect(checkbox).not.toBeChecked();
+      expect(screen.getByTestId("add-selected-students")).toBeDisabled();
     });
 
-    it("filters students by student_id", async () => {
+    it("supports checking multiple student rows before adding", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await user.type(screen.getByTestId("add-student-select"), "STU002");
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await checkStudent(user, 2);
 
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).queryByText("Alice Student")).not.toBeInTheDocument();
-      expect(within(listbox).getByText("Bob Learner")).toBeInTheDocument();
+      expect(screen.getByTestId("student-checkbox-1")).toBeChecked();
+      expect(screen.getByTestId("student-checkbox-2")).toBeChecked();
+      expect(screen.getByTestId("add-selected-students")).toHaveTextContent("Add Selected (2)");
     });
 
-    it("shows 'No matches' when filter returns empty", async () => {
+    it("select all checks all visible students when some are unchecked", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await user.type(screen.getByTestId("add-student-select"), "zzzzz");
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await checkAllStudents(user);
 
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).getByText("No matches")).toBeInTheDocument();
+      expect(screen.getByTestId("student-checkbox-1")).toBeChecked();
+      expect(screen.getByTestId("student-checkbox-2")).toBeChecked();
+      expect(screen.getByTestId("student-checkbox-3")).toBeChecked();
+      expect(screen.getByTestId("select-all-students")).toHaveTextContent("Deselect All");
     });
 
-    it("supports multi-token fuzzy matching", async () => {
+    it("select all unchecks visible students when all visible are checked", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      // "bob learn" should match "Bob Learner"
-      await user.type(screen.getByTestId("add-student-select"), "bob learn");
+      await openMultiSelect(user);
+      await checkAllStudents(user);
+      await checkAllStudents(user);
 
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).getByText("Bob Learner")).toBeInTheDocument();
-      expect(within(listbox).queryByText("Alice Student")).not.toBeInTheDocument();
+      expect(screen.getByTestId("student-checkbox-1")).not.toBeChecked();
+      expect(screen.getByTestId("student-checkbox-2")).not.toBeChecked();
+      expect(screen.getByTestId("student-checkbox-3")).not.toBeChecked();
+      expect(screen.getByTestId("add-selected-students")).toBeDisabled();
     });
 
-    it("selects student via keyboard (arrow down + enter)", async () => {
+    it("select all is disabled when the search has no matches", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      const input = screen.getByTestId("add-student-select");
-      await user.click(input);
-      await user.keyboard("{ArrowDown}{Enter}");
+      await openMultiSelect(user);
+      await user.type(screen.getByTestId("multi-select-student-search"), "zzzzz");
 
+      expect(screen.getByText("No matches")).toBeInTheDocument();
+      expect(screen.getByTestId("select-all-students")).toBeDisabled();
+      expect(screen.getByTestId("add-selected-students")).toBeDisabled();
+    });
+
+    it("select all only affects visible students", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      await user.type(screen.getByTestId("multi-select-student-search"), "alice");
+      await checkStudent(user, 1);
+      await user.clear(screen.getByTestId("multi-select-student-search"));
+      await user.type(screen.getByTestId("multi-select-student-search"), "bob");
+      await checkAllStudents(user);
+      expect(screen.getByTestId("student-checkbox-2")).toBeChecked();
+
+      await user.clear(screen.getByTestId("multi-select-student-search"));
+      expect(screen.getByTestId("student-checkbox-1")).toBeChecked();
+      expect(screen.getByTestId("student-checkbox-2")).toBeChecked();
+      expect(screen.getByTestId("student-checkbox-3")).not.toBeChecked();
+    });
+
+    it("filters students by name and student_id", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      const search = screen.getByTestId("multi-select-student-search");
+
+      await user.type(search, "alice");
+      expect(screen.getByText("Alice Student")).toBeInTheDocument();
+      expect(screen.queryByText("Bob Learner")).not.toBeInTheDocument();
+
+      await user.clear(search);
+      await user.type(search, "STU002");
+      expect(screen.queryByText("Alice Student")).not.toBeInTheDocument();
+      expect(screen.getByText("Bob Learner")).toBeInTheDocument();
+
+      await user.clear(search);
+      await user.type(search, "bob learn");
+      expect(screen.getByText("Bob Learner")).toBeInTheDocument();
+      expect(screen.queryByText("Carol Pupil")).not.toBeInTheDocument();
+    });
+
+    it("keeps checked state across search queries and adds all checked students", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      const search = screen.getByTestId("multi-select-student-search");
+      await user.type(search, "alice");
+      await checkStudent(user, 1);
+      await user.clear(search);
+      await user.type(search, "bob");
+      await checkStudent(user, 2);
+      await clickAddSelected(user);
+
+      expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
+      expect(screen.getByTestId("student-section-2")).toBeInTheDocument();
+      expect(screen.queryByTestId("multi-select-student-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("multi-select-student-trigger")).toHaveFocus();
+    });
+
+    it("closes on Escape, clears checked state and query, and returns focus", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await user.type(screen.getByTestId("multi-select-student-search"), "alice");
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByTestId("multi-select-student-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("multi-select-student-trigger")).toHaveFocus();
+
+      await openMultiSelect(user);
+      expect(screen.getByTestId("multi-select-student-search")).toHaveValue("");
+      expect(screen.getByTestId("student-checkbox-1")).not.toBeChecked();
+    });
+
+    it("outside click closes the dropdown but preserves checked state", async () => {
+      const user = userEvent.setup();
+      render(
+        <div>
+          <button type="button">Outside</button>
+          <Harness />
+        </div>
+      );
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await user.click(screen.getByRole("button", { name: "Outside" }));
+
+      expect(screen.queryByTestId("multi-select-student-panel")).not.toBeInTheDocument();
+
+      await openMultiSelect(user);
+      expect(screen.getByTestId("student-checkbox-1")).toBeChecked();
+    });
+
+    it("grade change clears pending checked state through remount", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+
+      await selectGrade(user, "12");
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/pm/students?school_code=12345&grade=12"
+        );
+      });
+      await openMultiSelect(user);
+      expect(screen.getByTestId("student-checkbox-1")).not.toBeChecked();
+    });
+
+    it("Enter in search adds checked students and is a no-op with no checked students", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      const search = screen.getByTestId("multi-select-student-search");
+      await user.click(search);
+      await user.keyboard("{Enter}");
+      expect(screen.queryByTestId("student-section-1")).not.toBeInTheDocument();
+      expect(screen.getByTestId("multi-select-student-panel")).toBeInTheDocument();
+
+      await checkStudent(user, 1);
+      await user.click(search);
+      await user.keyboard("{Enter}");
       expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
     });
 
-    it("closes dropdown on Escape", async () => {
+    it("updates aria-expanded as the dropdown opens and closes", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await openStudentSearch(user);
-      expect(screen.getByTestId("student-search-listbox")).toBeInTheDocument();
+      const trigger = screen.getByTestId("multi-select-student-trigger");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      await openMultiSelect(user);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
 
       await user.keyboard("{Escape}");
-      expect(screen.queryByTestId("student-search-listbox")).not.toBeInTheDocument();
-    });
-
-    it("clears input after selecting a student", async () => {
-      const user = userEvent.setup();
-      render(<Harness />);
-
-      await selectGrade(user, "11");
-      await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
-      });
-
-      await user.type(screen.getByTestId("add-student-select"), "alice");
-      await user.click(screen.getByTestId("student-option-1"));
-
-      expect(screen.getByTestId("add-student-select")).toHaveValue("");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
     });
   });
 
   describe("add student + sections", () => {
-    it("selecting student from dropdown creates new expanded section", async () => {
+    it("adding one checked student creates a new expanded section", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await openStudentSearch(user);
-      await selectStudentOption(user, 1);
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await clickAddSelected(user);
 
       expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
       // Section should be expanded — question radios visible
@@ -324,27 +501,159 @@ describe("IndividualStudentDiscussionForm", () => {
       expect(screen.getByTestId(`student-1-${firstKey}-yes`)).toBeInTheDocument();
     });
 
-    it("added student is removed from the dropdown", async () => {
+    it("batch-added students render as collapsed sections", async () => {
       const user = userEvent.setup();
       render(<Harness />);
 
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
-      await openStudentSearch(user);
-      await selectStudentOption(user, 1);
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await checkStudent(user, 2);
+      await checkStudent(user, 3);
+      await clickAddSelected(user);
 
-      // Type a space to re-open the dropdown and show all remaining
-      const input = screen.getByTestId("add-student-select");
-      await user.click(input);
       await waitFor(() => {
-        expect(screen.getByTestId("student-search-listbox")).toBeInTheDocument();
+        expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
+        expect(screen.getByTestId("student-section-2")).toBeInTheDocument();
+        expect(screen.getByTestId("student-section-3")).toBeInTheDocument();
       });
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).queryByText("Alice Student")).not.toBeInTheDocument();
-      expect(within(listbox).getByText("Bob Learner")).toBeInTheDocument();
+      const firstKey = INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys[0];
+      expect(screen.queryByTestId(`student-1-${firstKey}-yes`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`student-2-${firstKey}-yes`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`student-3-${firstKey}-yes`)).not.toBeInTheDocument();
+    });
+
+    it("batch add leaves existing expanded sections open", async () => {
+      const user = userEvent.setup();
+      render(<Harness initialData={{ students: [buildStudentEntry(99, "Existing Student")] }} />);
+
+      await user.click(screen.getByTestId("student-header-99"));
+      const firstKey = INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys[0];
+      expect(screen.getByTestId(`student-99-${firstKey}-yes`)).toBeInTheDocument();
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await checkStudent(user, 2);
+      await clickAddSelected(user);
+
+      expect(screen.getByTestId(`student-99-${firstKey}-yes`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`student-1-${firstKey}-yes`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`student-2-${firstKey}-yes`)).not.toBeInTheDocument();
+    });
+
+    it("added students are removed from the dropdown", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await clickAddSelected(user);
+
+      await openMultiSelect(user);
+      const panel = screen.getByTestId("multi-select-student-panel");
+      expect(within(panel).queryByText("Alice Student")).not.toBeInTheDocument();
+      expect(within(panel).getByText("Bob Learner")).toBeInTheDocument();
+    });
+
+    it("resets search, checked state, and focus after adding selected students", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      await user.type(screen.getByTestId("multi-select-student-search"), "alice");
+      await checkStudent(user, 1);
+      await clickAddSelected(user);
+
+      expect(screen.queryByTestId("multi-select-student-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("multi-select-student-trigger")).toHaveFocus();
+
+      await openMultiSelect(user);
+      expect(screen.getByTestId("multi-select-student-search")).toHaveValue("");
+      expect(screen.getByTestId("student-checkbox-2")).not.toBeChecked();
+      expect(screen.getByTestId("add-selected-students")).toHaveTextContent("Add Selected (0)");
+    });
+
+    it("filters duplicate IDs when adding selected students", async () => {
+      const user = userEvent.setup();
+      render(<Harness initialData={{ students: [buildStudentEntry(1, "Alice Student")] }} />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+
+      await openMultiSelect(user);
+      expect(screen.queryByTestId("student-checkbox-1")).not.toBeInTheDocument();
+      await checkStudent(user, 2);
+      await clickAddSelected(user);
+
+      expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
+      expect(screen.getByTestId("student-section-2")).toBeInTheDocument();
+      expect(screen.queryAllByTestId("student-section-1")).toHaveLength(1);
+    });
+
+    it("does not render the dropdown when the selected grade returns no students", async () => {
+      mockFetchStudents([]);
+      const user = userEvent.setup();
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId("multi-select-student-trigger")).not.toBeInTheDocument();
+    });
+
+    it("can add students from multiple grades to the same action", async () => {
+      const user = userEvent.setup();
+      const grade11 = [{ id: 1, full_name: "Alice Student", student_id: "STU001", grade: 11 }];
+      const grade12 = [{ id: 4, full_name: "Dev Student", student_id: "STU004", grade: 12 }];
+      mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: grade11 }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: grade12 }) });
+      vi.stubGlobal("fetch", mockFetch);
+      render(<Harness />);
+
+      await selectGrade(user, "11");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+      await openMultiSelect(user);
+      await checkStudent(user, 1);
+      await clickAddSelected(user);
+
+      await selectGrade(user, "12");
+      await waitFor(() => {
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
+      });
+      await openMultiSelect(user);
+      await checkStudent(user, 4);
+      await clickAddSelected(user);
+
+      expect(screen.getByTestId("student-section-1")).toBeInTheDocument();
+      expect(screen.getByTestId("student-grade-badge-1")).toHaveTextContent("Grade 11");
+      expect(screen.getByTestId("student-section-4")).toBeInTheDocument();
+      expect(screen.getByTestId("student-grade-badge-4")).toHaveTextContent("Grade 12");
     });
 
     it("section header shows name, grade badge, and question progress", async () => {
@@ -481,13 +790,13 @@ describe("IndividualStudentDiscussionForm", () => {
       // Select grade to trigger fetch and show search input
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
       // Open dropdown — Alice should NOT be listed (she's recorded)
-      await openStudentSearch(user);
-      const listbox = screen.getByTestId("student-search-listbox");
-      expect(within(listbox).queryByText("Alice Student")).not.toBeInTheDocument();
+      await openMultiSelect(user);
+      const panel = screen.getByTestId("multi-select-student-panel");
+      expect(within(panel).queryByText("Alice Student")).not.toBeInTheDocument();
 
       // Close dropdown, remove Alice
       await user.keyboard("{Escape}");
@@ -495,9 +804,9 @@ describe("IndividualStudentDiscussionForm", () => {
       await user.click(screen.getByTestId("remove-student-1"));
 
       // Re-open dropdown — Alice should be back
-      await openStudentSearch(user);
-      const listboxAfter = screen.getByTestId("student-search-listbox");
-      expect(within(listboxAfter).getByText("Alice Student")).toBeInTheDocument();
+      await openMultiSelect(user);
+      const panelAfter = screen.getByTestId("multi-select-student-panel");
+      expect(within(panelAfter).getByText("Alice Student")).toBeInTheDocument();
     });
   });
 
@@ -537,7 +846,7 @@ describe("IndividualStudentDiscussionForm", () => {
       );
 
       expect(screen.queryByTestId("student-grade-filter")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("add-student-select")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("multi-select-student-trigger")).not.toBeInTheDocument();
       expect(screen.queryByTestId("remove-student-1")).not.toBeInTheDocument();
     });
 
@@ -614,7 +923,7 @@ describe("IndividualStudentDiscussionForm", () => {
       // Select grade to trigger fetch
       await selectGrade(user, "11");
       await waitFor(() => {
-        expect(screen.getByTestId("add-student-select")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-select-student-trigger")).toBeInTheDocument();
       });
 
       // Section shows with name from data

--- a/src/components/visits/IndividualStudentDiscussionForm.tsx
+++ b/src/components/visits/IndividualStudentDiscussionForm.tsx
@@ -154,7 +154,7 @@ function MultiSelectStudentSearch({ students, onAddStudents }: MultiSelectStuden
       <button
         ref={triggerRef}
         type="button"
-        onClick={() => setIsOpen(true)}
+        onClick={() => setIsOpen((prev) => !prev)}
         className="min-h-[44px] w-56 rounded-lg border-2 border-border px-3 py-2.5 text-left text-sm text-text-primary transition-colors hover:bg-bg-card-alt focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
         data-testid="multi-select-student-trigger"
         aria-expanded={isOpen}
@@ -168,7 +168,7 @@ function MultiSelectStudentSearch({ students, onAddStudents }: MultiSelectStuden
           role="group"
           aria-label="Student selection"
           data-testid="multi-select-student-panel"
-          className="absolute z-20 mt-1 w-80 border-2 border-border bg-bg-card shadow-md"
+          className="absolute z-20 mt-1 w-full sm:w-80 max-w-[calc(100vw-1rem)] border-2 border-border bg-bg-card shadow-md"
           onKeyDown={(e) => {
             if (e.key === "Escape") {
               e.preventDefault();
@@ -193,6 +193,7 @@ function MultiSelectStudentSearch({ students, onAddStudents }: MultiSelectStuden
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleSearchKeyDown}
               placeholder="Search students..."
+              autoComplete="off"
               className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none"
               data-testid="multi-select-student-search"
             />
@@ -310,16 +311,13 @@ export default function IndividualStudentDiscussionForm({
     (students: Student[]) => {
       if (students.length === 0) return;
 
-      const currentIds = new Set(getStudentEntriesFromData(data).map((student) => student.id));
-      const studentsToAdd = students.filter((student) => !currentIds.has(Number(student.id)));
-      if (studentsToAdd.length === 0) return;
-
       const grade = selectedGradeRef.current;
+      let committed: IndividualStudentEntry[] = [];
 
       setData((current) => {
         const entries = getStudentEntriesFromData(current);
         const existingIds = new Set(entries.map((student) => student.id));
-        const newEntries: IndividualStudentEntry[] = studentsToAdd
+        committed = students
           .filter((student) => !existingIds.has(Number(student.id)))
           .map((student) => ({
             id: Number(student.id),
@@ -327,15 +325,15 @@ export default function IndividualStudentDiscussionForm({
             grade: grade ?? 11,
             questions: {},
           }));
-        if (newEntries.length === 0) return current;
-        return { ...current, students: [...entries, ...newEntries] };
+        if (committed.length === 0) return current;
+        return { ...current, students: [...entries, ...committed] };
       });
 
-      if (studentsToAdd.length === 1) {
-        setExpandedIds((prev) => new Set(prev).add(Number(studentsToAdd[0].id)));
+      if (committed.length === 1) {
+        setExpandedIds((prev) => new Set(prev).add(committed[0].id));
       }
     },
-    [data, setData]
+    [setData]
   );
 
   const handleRemoveStudent = useCallback(

--- a/src/components/visits/IndividualStudentDiscussionForm.tsx
+++ b/src/components/visits/IndividualStudentDiscussionForm.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
 import { fuzzyMatch } from "@/lib/fuzzy-match";
 import {
@@ -10,7 +19,7 @@ import {
 } from "@/lib/individual-student-discussion";
 import { getStudentDisplayName, type Student } from "@/lib/student-utils";
 import { isPlainObject } from "@/lib/visit-form-utils";
-import { FormSection, RadioPair, RemarkField, Select, StickyProgressBar } from "@/components/ui";
+import { FormSection, RadioPair, Select, StickyProgressBar } from "@/components/ui";
 
 interface IndividualStudentDiscussionFormProps {
   data: Record<string, unknown>;
@@ -40,19 +49,21 @@ function getQuestionProgress(entry: IndividualStudentEntry): string {
   return `${answered}/${total}`;
 }
 
-/* -- Searchable student combobox ----------------------------------------- */
+/* -- Multi-select student dropdown --------------------------------------- */
 
-interface SearchableStudentSelectProps {
+interface MultiSelectStudentSearchProps {
   students: Student[];
-  onSelect: (id: number) => void;
+  onAddStudents: (students: Student[]) => void;
 }
 
-function SearchableStudentSelect({ students, onSelect }: SearchableStudentSelectProps) {
+function MultiSelectStudentSearch({ students, onAddStudents }: MultiSelectStudentSearchProps) {
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [checkedIds, setCheckedIds] = useState<Set<number>>(() => new Set());
   const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const panelId = useId();
 
   const filtered = useMemo(() => {
     if (query.trim() === "") return students;
@@ -63,7 +74,20 @@ function SearchableStudentSelect({ students, onSelect }: SearchableStudentSelect
     );
   }, [students, query]);
 
-  // Close on outside click
+  const selectedStudents = useMemo(
+    () => students.filter((s) => checkedIds.has(Number(s.id))),
+    [students, checkedIds]
+  );
+
+  const allVisibleSelected =
+    filtered.length > 0 && filtered.every((student) => checkedIds.has(Number(student.id)));
+
+  useEffect(() => {
+    if (isOpen) {
+      searchRef.current?.focus();
+    }
+  }, [isOpen]);
+
   useEffect(() => {
     function handleMouseDown(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -74,110 +98,142 @@ function SearchableStudentSelect({ students, onSelect }: SearchableStudentSelect
     return () => document.removeEventListener("mousedown", handleMouseDown);
   }, []);
 
-  // Scroll highlighted item into view
-  useEffect(() => {
-    if (highlightIndex >= 0 && listRef.current) {
-      const items = listRef.current.children;
-      if (items[highlightIndex]) {
-        (items[highlightIndex] as HTMLElement).scrollIntoView?.({ block: "nearest" });
-      }
-    }
-  }, [highlightIndex]);
-
-  function selectStudent(id: number) {
-    onSelect(id);
-    setQuery("");
-    setIsOpen(false);
-    setHighlightIndex(-1);
+  function focusTrigger() {
+    triggerRef.current?.focus();
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (!isOpen) {
-      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        setIsOpen(true);
-        setHighlightIndex(0);
-        e.preventDefault();
+  function resetAndClose() {
+    setCheckedIds(new Set());
+    setQuery("");
+    setIsOpen(false);
+    focusTrigger();
+  }
+
+  function handleAddSelected() {
+    if (checkedIds.size === 0) return;
+    onAddStudents(selectedStudents);
+    resetAndClose();
+  }
+
+  function toggleStudent(studentId: number) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(studentId)) next.delete(studentId);
+      else next.add(studentId);
+      return next;
+    });
+  }
+
+  function toggleVisibleStudents() {
+    if (filtered.length === 0) return;
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        for (const student of filtered) next.delete(Number(student.id));
+      } else {
+        for (const student of filtered) next.add(Number(student.id));
       }
+      return next;
+    });
+  }
+
+  function handleSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddSelected();
       return;
     }
-
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        setHighlightIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : prev));
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        setHighlightIndex((prev) => (prev > 0 ? prev - 1 : prev));
-        break;
-      case "Enter":
-        e.preventDefault();
-        if (highlightIndex >= 0 && highlightIndex < filtered.length) {
-          selectStudent(Number(filtered[highlightIndex].id));
-        }
-        break;
-      case "Escape":
-        setIsOpen(false);
-        setHighlightIndex(-1);
-        break;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      resetAndClose();
     }
   }
 
   return (
     <div ref={containerRef} className="relative" data-testid="student-search-container">
-      <input
-        type="text"
-        value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setIsOpen(true);
-          setHighlightIndex(-1);
-        }}
-        onFocus={() => setIsOpen(true)}
+      <button
+        ref={triggerRef}
+        type="button"
         onClick={() => setIsOpen(true)}
-        onKeyDown={handleKeyDown}
-        placeholder="Search students..."
-        className="border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none w-56"
-        data-testid="add-student-select"
-        role="combobox"
+        className="min-h-[44px] w-56 rounded-lg border-2 border-border px-3 py-2.5 text-left text-sm text-text-primary transition-colors hover:bg-bg-card-alt focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+        data-testid="multi-select-student-trigger"
         aria-expanded={isOpen}
-        aria-autocomplete="list"
-        aria-controls="student-search-listbox"
-        autoComplete="off"
-      />
+        aria-controls={panelId}
+      >
+        Add students
+      </button>
       {isOpen && (
-        <ul
-          ref={listRef}
-          id="student-search-listbox"
-          role="listbox"
-          data-testid="student-search-listbox"
-          className="absolute z-20 mt-1 max-h-48 w-full overflow-auto border-2 border-border bg-bg-card shadow-md"
+        <div
+          id={panelId}
+          role="group"
+          aria-label="Student selection"
+          data-testid="multi-select-student-panel"
+          className="absolute z-20 mt-1 w-80 border-2 border-border bg-bg-card shadow-md"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              resetAndClose();
+            }
+          }}
         >
-          {filtered.length === 0 ? (
-            <li className="px-3 py-2 text-sm text-text-muted" role="option" aria-selected={false}>
-              No matches
-            </li>
-          ) : (
-            filtered.map((s, idx) => (
-              <li
-                key={s.id}
-                role="option"
-                aria-selected={highlightIndex === idx}
-                data-testid={`student-option-${s.id}`}
-                className={`cursor-pointer px-3 py-2 text-sm ${
-                  highlightIndex === idx ? "bg-accent/10 text-accent" : "text-text-primary hover:bg-bg-card-alt"
-                }`}
-                onMouseEnter={() => setHighlightIndex(idx)}
-                onMouseDown={(e) => {
-                  e.preventDefault(); // prevent input blur before click registers
-                  selectStudent(Number(s.id));
-                }}
-              >
-                {getStudentDisplayName(s)}
-              </li>
-            ))
-          )}
-        </ul>
+          <div className="space-y-2 border-b border-border p-3">
+            <button
+              type="button"
+              onClick={toggleVisibleStudents}
+              disabled={filtered.length === 0}
+              className="text-sm font-semibold text-accent disabled:cursor-not-allowed disabled:text-text-muted"
+              data-testid="select-all-students"
+            >
+              {allVisibleSelected ? "Deselect All" : "Select All"}
+            </button>
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              placeholder="Search students..."
+              className="w-full border-2 border-border px-3 py-2 text-sm focus:border-accent focus:outline-none"
+              data-testid="multi-select-student-search"
+            />
+          </div>
+          <fieldset className="max-h-60 overflow-y-auto p-2">
+            <legend className="sr-only">Students</legend>
+            {filtered.length === 0 ? (
+              <p className="px-2 py-3 text-sm text-text-muted">No matches</p>
+            ) : (
+              filtered.map((student) => {
+                const studentId = Number(student.id);
+                return (
+                  <label
+                    key={student.id}
+                    className="flex cursor-pointer items-center gap-2 px-2 py-2 text-sm text-text-primary hover:bg-bg-card-alt"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checkedIds.has(studentId)}
+                      onChange={() => toggleStudent(studentId)}
+                      data-testid={`student-checkbox-${studentId}`}
+                      className="h-4 w-4"
+                    />
+                    <span>{getStudentDisplayName(student)}</span>
+                  </label>
+                );
+              })
+            )}
+          </fieldset>
+          <div className="sticky bottom-0 border-t border-border bg-bg-card p-3">
+            <button
+              type="button"
+              onClick={handleAddSelected}
+              disabled={selectedStudents.length === 0}
+              className="w-full rounded-lg bg-accent px-3 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-border disabled:text-text-muted"
+              data-testid="add-selected-students"
+            >
+              Add Selected ({selectedStudents.length})
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -238,9 +294,6 @@ export default function IndividualStudentDiscussionForm({
     [availableStudents, recordedStudentIds]
   );
 
-  const availableStudentsRef = useRef(availableStudents);
-  availableStudentsRef.current = availableStudents;
-
   const selectedGradeRef = useRef(selectedGrade);
   selectedGradeRef.current = selectedGrade;
 
@@ -253,27 +306,36 @@ export default function IndividualStudentDiscussionForm({
     });
   }, []);
 
-  const handleAddStudent = useCallback(
-    (studentId: number) => {
-      const student = availableStudentsRef.current.find((s) => Number(s.id) === studentId);
-      if (!student) return;
-      const name = getStudentDisplayName(student);
+  const handleAddStudents = useCallback(
+    (students: Student[]) => {
+      if (students.length === 0) return;
+
+      const currentIds = new Set(getStudentEntriesFromData(data).map((student) => student.id));
+      const studentsToAdd = students.filter((student) => !currentIds.has(Number(student.id)));
+      if (studentsToAdd.length === 0) return;
+
       const grade = selectedGradeRef.current;
 
       setData((current) => {
         const entries = getStudentEntriesFromData(current);
-        const newEntry: IndividualStudentEntry = {
-          id: Number(student.id),
-          name,
-          grade: grade ?? 11,
-          questions: {},
-        };
-        return { ...current, students: [...entries, newEntry] };
+        const existingIds = new Set(entries.map((student) => student.id));
+        const newEntries: IndividualStudentEntry[] = studentsToAdd
+          .filter((student) => !existingIds.has(Number(student.id)))
+          .map((student) => ({
+            id: Number(student.id),
+            name: getStudentDisplayName(student),
+            grade: grade ?? 11,
+            questions: {},
+          }));
+        if (newEntries.length === 0) return current;
+        return { ...current, students: [...entries, ...newEntries] };
       });
 
-      setExpandedIds((prev) => new Set(prev).add(Number(student.id)));
+      if (studentsToAdd.length === 1) {
+        setExpandedIds((prev) => new Set(prev).add(Number(studentsToAdd[0].id)));
+      }
     },
-    [setData]
+    [data, setData]
   );
 
   const handleRemoveStudent = useCallback(
@@ -335,7 +397,7 @@ export default function IndividualStudentDiscussionForm({
 
   return (
     <div className="space-y-4" data-testid="action-renderer-individual_student_discussion">
-      {/* Grade filter + Student select */}
+      {/* Grade filter + student picker */}
       {!disabled && (
         <FormSection spacing="" className="flex flex-wrap items-end gap-3">
           <div>
@@ -362,9 +424,10 @@ export default function IndividualStudentDiscussionForm({
           </div>
 
           {selectedGrade !== null && !studentsLoading && !studentsError && remainingStudents.length > 0 && (
-            <SearchableStudentSelect
+            <MultiSelectStudentSearch
+              key={selectedGrade}
               students={remainingStudents}
-              onSelect={handleAddStudent}
+              onAddStudents={handleAddStudents}
             />
           )}
         </FormSection>


### PR DESCRIPTION
## Summary

Replaces the single-select searchable combobox for student names in the Individual Student Discussion form with a multi-select checkbox dropdown that supports batch-add. PMs can now tick multiple students, use "Select All" for whole-class selection, and add them all at once — eliminating the tedious one-at-a-time workflow for 100-200 students per grade.

**Key changes:**
- **New `MultiSelectStudentSearch` component** — checkbox dropdown with search, "Select All" toggle, and "Add Selected (N)" button. Proper ARIA model (disclosure widget with native checkboxes, not combobox roles).
- **Batch-add semantics** — single `setData` call for atomicity, duplicate guard, single-add auto-expands accordion while batch (2+) stays collapsed.
- **State lifecycle** — checked state persists across search queries and outside-click close; clears on "Add Selected", Escape, or grade change (component remounts via `key={selectedGrade}`).
- **Old `SearchableStudentSelect` deleted** — no legacy code remains.
- **Frontend-only** — no backend, validation, or API changes needed; payload structure unchanged.

**Files changed:**
- `src/components/visits/IndividualStudentDiscussionForm.tsx` — replaced component + rewritten handler
- `src/components/visits/IndividualStudentDiscussionForm.test.tsx` — 42 unit tests (full rewrite for new DOM)
- `e2e/tests/visits.spec.ts` — rewritten helper + new batch-add E2E test
- `CLAUDE.md` — updated Individual Student Interaction section
- `docs/ai/student-interaction/2026-03-18-student-interaction-implementation-plan.md` — marked superseded

## Linked Issues

- Closes #40
- Parent: #34

## Final Review

**Outcome: Pass with minor action items**

- All 42 unit tests pass. Full suite: 1797/1800 (3 pre-existing failures in unrelated `dashboard/page.test.tsx`).
- Lint passes (pre-existing baseline only, no new errors).
- All acceptance criteria verified (see `final-review.md` in workspace).
- E2E not run locally (requires test DB) — helper and new batch-add test reviewed via code inspection.
- Minor: coverage summary JSONs not re-committed (CI will show stale numbers until refreshed).

## Human QA Checklist

- [ ] Select grade 11, open multi-select dropdown, check 2-3 students, click "Add Selected" — all appear as accordion sections
- [ ] Single student add auto-expands accordion; batch add (2+) keeps all collapsed
- [ ] Search by name within dropdown, check students across multiple searches, "Add Selected" adds all
- [ ] "Select All" checks all visible students; "Deselect All" unchecks them; hidden checked students from other queries unaffected
- [ ] Click outside dropdown — closes but reopens with checked state preserved
- [ ] Press Escape — closes and clears all checked state
- [ ] Switch grade — dropdown resets (checked state, search query cleared)
- [ ] Add students from grade 11, switch to grade 12, add more — both grades coexist in the form
- [ ] Remove an individual student — they reappear in the dropdown
- [ ] Answer questions for added students, auto-save triggers correctly
- [ ] "Add Selected" button disabled when nothing is checked
- [ ] Dropdown hidden when all students already added or grade has no students
- [ ] Read-only mode (completed action) — no dropdown shown, existing data displays correctly
- [ ] Run `npm run test:e2e` with local test DB — all visit tests pass including new batch-add scenario
