### PR TITLE
feat: add school visit summary admin dashboard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,16 @@ _Avoid_: Group (overloaded — `group` is a DB table and `group_student_discussi
 Setting `deleted_at` timestamp instead of removing the row. Used for actions and (issue #35) visits.
 _Avoid_: Archive, deactivate
 
+### Staff
+
+**Staff**:
+AF employees assigned to a school — teachers, program managers, and others. Sourced from the external Centres API, not from the LMS database.
+_Avoid_: Teachers & Staff, AF Team (tab label is "Staff")
+
+**Centres API**:
+External service (`centres.avantifellows.org`) that provides staff assignments per school. Queried by `school.name`. Returns staff grouped by program (CoE / Nodal) and role (teachers / program_managers / others).
+_Avoid_: Budget API (legacy name from when it lived under `budget.avantifellows.org`)
+
 ### Roles & Access
 
 **PM (Program Manager)**:
@@ -69,6 +79,7 @@ _Avoid_: Access tier, role level
 ## Relationships
 
 - A **School** has many **Students** (via `group` → `group_user`)
+- A **School** has many **Staff** (via **Centres API**, keyed by `school.name`)
 - A **School** has many **Batches**
 - A **PM** creates **Visits** to a **School**
 - A **Visit** has many **Actions** (each with an **Action Type**)

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -147,6 +147,25 @@ const adminPermission = {
   program_ids: [1, 2, 64],
 };
 
+const programAdminSession = {
+  user: { email: "program-admin@avantifellows.org" },
+};
+
+const programAdminPermission = {
+  email: "program-admin@avantifellows.org",
+  level: 2,
+  role: "program_admin",
+  school_codes: null,
+  regions: ["West"],
+  program_ids: [1, 2],
+};
+
+const nvsOnlyProgramAdminPermission = {
+  ...programAdminPermission,
+  email: "nvs-only@avantifellows.org",
+  program_ids: [64],
+};
+
 const pmPermission = {
   email: "pm@avantifellows.org",
   level: 3,
@@ -360,7 +379,7 @@ describe("DashboardPage (server component)", () => {
     mockGetUserPermission.mockResolvedValue(singleSchoolPermission);
     mockGetProgramContextSync.mockReturnValue(defaultProgramContext);
     mockGetFeatureAccess.mockReturnValue({ canView: false, canEdit: false });
-    mockGetAccessibleSchoolCodes.mockResolvedValue(["SC001"]);
+    mockGetAccessibleSchoolCodes.mockResolvedValue(["SC001", "SC002"]);
     mockQuery
       .mockResolvedValueOnce([]) // schools
       .mockResolvedValueOnce([{ total: "0" }]); // count
@@ -445,14 +464,64 @@ describe("DashboardPage (server component)", () => {
 
   // --- PM nav links ---
 
-  it("shows Visits nav for PM users", async () => {
+  it("shows Visit Summary nav for admin users with visit access", async () => {
+    setupAdmin([], 0);
+
+    const jsx = await DashboardPage({ searchParams: defaultSearchParams });
+    render(jsx);
+
+    const summaryLink = screen.getByRole("link", { name: "Visit Summary" });
+    expect(summaryLink).toHaveAttribute("href", "/school-visit-summary");
+    expect(screen.queryByRole("link", { name: "Visits" })).not.toBeInTheDocument();
+  });
+
+  it("shows Visit Summary nav for program_admin users with visit access", async () => {
+    mockGetServerSession.mockResolvedValue(programAdminSession);
+    mockGetUserPermission.mockResolvedValue(programAdminPermission);
+    mockGetProgramContextSync.mockReturnValue(defaultProgramContext);
+    mockGetFeatureAccess.mockReturnValue({ canView: true, canEdit: false });
+    mockGetAccessibleSchoolCodes.mockResolvedValue(["SC001", "SC002"]);
+    mockQuery.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: "0" }]).mockResolvedValueOnce([]);
+
+    const jsx = await DashboardPage({ searchParams: defaultSearchParams });
+    render(jsx);
+
+    const summaryLink = screen.getByRole("link", { name: "Visit Summary" });
+    expect(summaryLink).toHaveAttribute("href", "/school-visit-summary");
+    expect(screen.queryByRole("link", { name: "Visits" })).not.toBeInTheDocument();
+  });
+
+  it("does not show Visit Summary nav for NVS-only program_admin users", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "nvs-only@avantifellows.org" },
+    });
+    mockGetUserPermission.mockResolvedValue(nvsOnlyProgramAdminPermission);
+    mockGetProgramContextSync.mockReturnValue({
+      hasAccess: true,
+      programIds: [64],
+      isNVSOnly: true,
+      hasCoEOrNodal: false,
+    });
+    mockGetFeatureAccess.mockReturnValue({ canView: false, canEdit: false });
+    mockGetAccessibleSchoolCodes.mockResolvedValue(["SC001", "SC002"]);
+    mockQuery.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: "0" }]);
+
+    const jsx = await DashboardPage({ searchParams: defaultSearchParams });
+    render(jsx);
+
+    expect(screen.queryByRole("link", { name: "Visit Summary" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Visits" })).not.toBeInTheDocument();
+  });
+
+  it("keeps Schools in the PM nav and removes the Visits link", async () => {
     setupPM([], 0);
 
     const jsx = await DashboardPage({ searchParams: defaultSearchParams });
     render(jsx);
 
-    const visitsLink = screen.getByText("Visits");
-    expect(visitsLink.closest("a")).toHaveAttribute("href", "/visits");
+    expect(screen.getByRole("link", { name: "Schools" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.queryByRole("link", { name: "Visits" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Visit Summary" })).not.toBeInTheDocument();
   });
 
   it("does not show Visits nav for non-PM users", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -235,6 +235,9 @@ export default async function DashboardPage({ searchParams }: PageProps) {
   }
 
   const hasPMAccess = getFeatureAccess(permission, "pm_dashboard").canView;
+  const canViewVisitSummary =
+    (permission.role === "admin" || permission.role === "program_admin") &&
+    getFeatureAccess(permission, "visits").canView;
 
   const schoolCodes = await getAccessibleSchoolCodes(session.user.email, permission);
 
@@ -282,7 +285,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
                       : `${totalCount} school(s)`}
               </p>
             </div>
-            {hasPMAccess && (
+            {(hasPMAccess || canViewVisitSummary) && (
               <nav className="flex gap-3 sm:gap-4">
                 <Link
                   href="/dashboard"
@@ -290,12 +293,14 @@ export default async function DashboardPage({ searchParams }: PageProps) {
                 >
                   Schools
                 </Link>
-                <Link
-                  href="/visits"
-                  className="text-sm font-medium text-text-muted uppercase tracking-wide hover:text-text-primary pb-1"
-                >
-                  Visits
-                </Link>
+                {canViewVisitSummary && (
+                  <Link
+                    href="/school-visit-summary"
+                    className="text-sm font-medium text-text-muted uppercase tracking-wide hover:text-text-primary pb-1"
+                  >
+                    Visit Summary
+                  </Link>
+                )}
               </nav>
             )}
           </div>

--- a/src/app/school-visit-summary/[id]/page.test.tsx
+++ b/src/app/school-visit-summary/[id]/page.test.tsx
@@ -1,0 +1,359 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetServerSession,
+  mockGetUserPermission,
+  mockGetFeatureAccess,
+  mockQuery,
+  mockRedirect,
+  mockNotFound,
+} = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockGetFeatureAccess: vi.fn(),
+  mockQuery: vi.fn(),
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+  mockNotFound: vi.fn(() => {
+    throw new Error("NOT_FOUND");
+  }),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+  notFound: mockNotFound,
+}));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mockGetUserPermission,
+  getFeatureAccess: mockGetFeatureAccess,
+}));
+vi.mock("@/lib/db", () => ({ query: mockQuery }));
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a href={href} className={className} {...props}>{children}</a>,
+}));
+vi.mock("@/components/visits/GpsMapLink", () => ({
+  __esModule: true,
+  default: ({ lat, lng }: { lat: number | string | null; lng: number | string | null }) => (
+    lat !== null && lng !== null ? <a href={`https://maps.google.com/?q=${lat},${lng}`}>GPS</a> : null
+  ),
+}));
+
+import SchoolVisitSummaryDetailPage from "./page";
+
+const adminSession = { user: { email: "admin@avantifellows.org" } };
+const adminPermission = {
+  email: "admin@avantifellows.org",
+  level: 3,
+  role: "admin",
+  read_only: false,
+  program_ids: [1],
+};
+const programAdminPermission = {
+  email: "program-admin@avantifellows.org",
+  level: 2,
+  role: "program_admin",
+  read_only: true,
+  regions: ["AHMEDABAD"],
+  program_ids: [1],
+};
+const pmPermission = {
+  email: "pm@avantifellows.org",
+  level: 3,
+  role: "program_manager",
+  read_only: false,
+  program_ids: [1],
+};
+const teacherPermission = {
+  email: "teacher@avantifellows.org",
+  level: 1,
+  role: "teacher",
+  read_only: false,
+  school_codes: ["SC001"],
+  program_ids: [1],
+};
+
+const visit = {
+  id: 101,
+  school_code: "SC001",
+  school_name: "Test School",
+  pm_email: "pm@avantifellows.org",
+  pm_name: "Program Manager",
+  visit_date: "2026-02-10",
+  status: "completed",
+  inserted_at: "2026-02-10T04:00:00Z",
+  updated_at: "2026-02-10T06:30:00Z",
+  completed_at: "2026-02-10T06:30:00Z",
+  start_lat: 12.9716,
+  start_lng: 77.5946,
+  start_accuracy: 8,
+  end_lat: 12.972,
+  end_lng: 77.595,
+  end_accuracy: 9,
+};
+
+const actions = [
+  {
+    id: 201,
+    visit_id: 101,
+    action_type: "classroom_observation",
+    status: "completed",
+    data: {
+      params: { teacher_on_time: { score: 1, remarks: "Started on time" } },
+      observer_summary_strengths: "Students were engaged",
+    },
+    started_at: "2026-02-10T04:20:00Z",
+    ended_at: "2026-02-10T04:50:00Z",
+    inserted_at: "2026-02-10T04:15:00Z",
+    updated_at: "2026-02-10T04:50:00Z",
+  },
+  {
+    id: 202,
+    visit_id: 101,
+    action_type: "af_team_interaction",
+    status: "completed",
+    data: {
+      teachers: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+      questions: {
+        op_class_duration: { answer: true, remark: "Classes are on schedule" },
+        op_centre_resources: { answer: false },
+      },
+    },
+    started_at: "2026-02-10T05:00:00Z",
+    ended_at: "2026-02-10T05:10:00Z",
+    inserted_at: "2026-02-10T04:55:00Z",
+    updated_at: "2026-02-10T05:10:00Z",
+  },
+  {
+    id: 203,
+    visit_id: 101,
+    action_type: "individual_af_teacher_interaction",
+    status: "completed",
+    data: {
+      teachers: [
+        {
+          id: 1,
+          name: "Alice",
+          attendance: "present",
+          questions: {
+            oh_class_duration: { answer: true, remark: "Full class duration" },
+            st_grade11_syllabus: { answer: false },
+          },
+        },
+        { id: 2, name: "Bob", attendance: "on_leave", questions: {} },
+        { id: 3, name: "Carol", attendance: "absent", questions: {} },
+      ],
+    },
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:11:00Z",
+    updated_at: "2026-02-10T05:12:00Z",
+  },
+  {
+    id: 204,
+    visit_id: 101,
+    action_type: "principal_interaction",
+    status: "completed",
+    data: {
+      questions: {
+        oh_program_feedback: { answer: true, remark: "Principal asked for monthly updates" },
+      },
+    },
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:13:00Z",
+    updated_at: "2026-02-10T05:14:00Z",
+  },
+  {
+    id: 205,
+    visit_id: 101,
+    action_type: "group_student_discussion",
+    status: "completed",
+    data: {
+      grade: 12,
+      questions: { gc_interacted: { answer: true, remark: "Students shared concerns" } },
+    },
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:15:00Z",
+    updated_at: "2026-02-10T05:16:00Z",
+  },
+  {
+    id: 206,
+    visit_id: 101,
+    action_type: "individual_student_discussion",
+    status: "completed",
+    data: {
+      entries: [
+        {
+          id: "entry-1",
+          grade: 11,
+          students: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+          questions: {
+            oh_teaching_concern: { answer: true, remark: "Students want slower pacing" },
+            oh_additional_support: { answer: false },
+          },
+        },
+        {
+          id: "entry-2",
+          grade: 12,
+          students: [{ id: 3, name: "Carol" }],
+          questions: {},
+        },
+      ],
+    },
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:17:00Z",
+    updated_at: "2026-02-10T05:18:00Z",
+  },
+  {
+    id: 207,
+    visit_id: 101,
+    action_type: "school_staff_interaction",
+    status: "completed",
+    data: {
+      questions: { gc_staff_concern: { answer: true, remark: "Staff requested lab support" } },
+    },
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:19:00Z",
+    updated_at: "2026-02-10T05:20:00Z",
+  },
+  {
+    id: 208,
+    visit_id: 101,
+    action_type: "future_action",
+    status: "pending",
+    data: {},
+    started_at: null,
+    ended_at: null,
+    inserted_at: "2026-02-10T05:21:00Z",
+    updated_at: "2026-02-10T05:22:00Z",
+  },
+];
+
+function setupAuth(permission = adminPermission, session = adminSession) {
+  mockGetServerSession.mockResolvedValue(session);
+  mockGetUserPermission.mockResolvedValue(permission);
+  mockGetFeatureAccess.mockReturnValue({ access: "edit", canView: true, canEdit: true });
+}
+
+function pageProps(id = "101") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("SchoolVisitSummaryDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it("redirects roles that cannot use the admin summary", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    await expect(SchoolVisitSummaryDetailPage(pageProps())).rejects.toThrow("REDIRECT:/");
+
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ user: {}, isPasscodeUser: true, schoolCode: "70705" });
+    await expect(SchoolVisitSummaryDetailPage(pageProps())).rejects.toThrow("REDIRECT:/school/70705");
+
+    vi.clearAllMocks();
+    setupAuth(pmPermission, { user: { email: "pm@avantifellows.org" } });
+    await expect(SchoolVisitSummaryDetailPage(pageProps())).rejects.toThrow("REDIRECT:/visits");
+
+    vi.clearAllMocks();
+    setupAuth(teacherPermission, { user: { email: "teacher@avantifellows.org" } });
+    await expect(SchoolVisitSummaryDetailPage(pageProps())).rejects.toThrow("REDIRECT:/dashboard");
+  });
+
+  it("returns not found for out-of-scope or soft-deleted visits and uses scoped detail SQL", async () => {
+    setupAuth(programAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
+    mockQuery.mockResolvedValueOnce([]);
+
+    await expect(SchoolVisitSummaryDetailPage(pageProps("999"))).rejects.toThrow("NOT_FOUND");
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("LEFT JOIN school s ON s.code = v.school_code");
+    expect(sql).toContain("v.id = $1");
+    expect(sql).toContain("v.deleted_at IS NULL");
+    expect(sql).toContain("COALESCE(s.region, '') = ANY($2)");
+    expect(params).toEqual(["999", ["AHMEDABAD"]]);
+  });
+
+  it("renders metadata, GPS, grouped action stats, remarks, and read-only links", async () => {
+    setupAuth();
+    mockQuery
+      .mockResolvedValueOnce([visit])
+      .mockResolvedValueOnce(actions);
+
+    const jsx = await SchoolVisitSummaryDetailPage(pageProps());
+    render(jsx);
+
+    expect(screen.getByRole("link", { name: /Back to Visit Summary/i })).toHaveAttribute("href", "/school-visit-summary");
+    expect(screen.getByRole("heading", { name: "Test School (SC001)" })).toBeInTheDocument();
+    expect(screen.getByText("Program Manager")).toBeInTheDocument();
+    expect(screen.getByText("pm@avantifellows.org")).toBeInTheDocument();
+    expect(screen.getByText("10 Feb 2026")).toBeInTheDocument();
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
+    expect(screen.getByText("2h 30m")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "GPS" })).toHaveLength(2);
+
+    expect(screen.getByRole("heading", { name: "Classroom Observation" })).toBeInTheDocument();
+    expect(screen.getByText("Score 1/45")).toBeInTheDocument();
+    expect(screen.getByText("Remarks 1")).toBeInTheDocument();
+    expect(screen.getByText("Answered 2/9")).toBeInTheDocument();
+    expect(screen.getByText("Teachers 2")).toBeInTheDocument();
+    expect(screen.getByText("Teachers 3 (1 present, 1 on leave, 1 absent)")).toBeInTheDocument();
+    expect(screen.getByText("Avg answered 2/13")).toBeInTheDocument();
+    expect(screen.getByText("Answered 1/7")).toBeInTheDocument();
+    expect(screen.getByText("Grade 12")).toBeInTheDocument();
+    expect(screen.getByText("Answered 1/4")).toBeInTheDocument();
+    expect(screen.getByText("Entries 2")).toBeInTheDocument();
+    expect(screen.getByText("Students 3")).toBeInTheDocument();
+    expect(screen.getByText("Avg answered 1/2")).toBeInTheDocument();
+    expect(screen.getByText("Answered 1/2")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Other" })).toBeInTheDocument();
+
+    const detailLinks = screen.getAllByRole("link", { name: "View full detail" });
+    const detailHrefs = detailLinks.map((link) => link.getAttribute("href"));
+    expect(detailLinks).toHaveLength(8);
+    expect(detailHrefs).toContain("/visits/101/actions/201?from=summary");
+    expect(detailHrefs).toContain("/visits/101/actions/208?from=summary");
+
+    const remarks = screen.getByRole("region", { name: "Remarks" });
+    expect(within(remarks).getByText("Started on time")).toBeInTheDocument();
+    expect(within(remarks).getByText("Students were engaged")).toBeInTheDocument();
+    expect(within(remarks).getByText("Classes are on schedule")).toBeInTheDocument();
+    expect(within(remarks).getByText("Principal asked for monthly updates")).toBeInTheDocument();
+    expect(within(remarks).getByText("Students want slower pacing")).toBeInTheDocument();
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start")).not.toBeInTheDocument();
+    expect(screen.queryByText("End")).not.toBeInTheDocument();
+  });
+
+  it("renders a graceful empty remarks state", async () => {
+    setupAuth();
+    mockQuery
+      .mockResolvedValueOnce([visit])
+      .mockResolvedValueOnce([{ ...actions[7], data: {} }]);
+
+    const jsx = await SchoolVisitSummaryDetailPage(pageProps());
+    render(jsx);
+
+    expect(screen.getByText("No remarks")).toBeInTheDocument();
+  });
+});

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -163,11 +163,13 @@ function statsChips(actionType: string, stats: unknown): string[] {
   }
   if (actionType === "individual_student_discussion") {
     const avgAnswered = formatNumber(stats.avgAnswered);
-    return [
-      `Entries ${stats.entryCount}`,
-      `Students ${stats.studentCount}`,
-      `Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`,
-    ];
+    const chips: string[] = [];
+    if (stats.entryCount !== null) {
+      chips.push(`Entries ${stats.entryCount}`);
+    }
+    chips.push(`Students ${stats.studentCount}`);
+    chips.push(`Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`);
+    return chips;
   }
   if (actionType === "school_staff_interaction") {
     return [`Answered ${stats.answeredCount}/${stats.totalQuestions}`];
@@ -227,7 +229,7 @@ async function getVisitSummaryDetail(id: string, actorEmail: string, permission:
   }
 
   const visits = await query<VisitSummaryDetail>(
-    `SELECT v.*, s.name AS school_name, s.code AS school_code, up.full_name AS pm_name
+    `SELECT v.*, s.name AS school_name, up.full_name AS pm_name
      FROM lms_pm_school_visits v
      LEFT JOIN school s ON s.code = v.school_code
      LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
@@ -421,6 +423,10 @@ export default async function SchoolVisitSummaryDetailPage({ params }: PageProps
       redirect("/visits");
     }
     redirect("/dashboard");
+  }
+
+  if (!/^\d+$/.test(id)) {
+    notFound();
   }
 
   const { visit, actions } = await getVisitSummaryDetail(id, session.user.email, permission);

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -90,11 +90,15 @@ function formatTimestamp(value: string | null): string {
 function formatDuration(startValue: string, endValue: string | null, now = new Date()): string {
   const start = new Date(startValue).getTime();
   const end = endValue ? new Date(endValue).getTime() : now.getTime();
-  const minutes = Math.max(0, Math.floor((end - start) / 60000));
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
+  const totalMinutes = Math.max(0, Math.floor((end - start) / 60000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
 
-  return `${hours}h ${remainingMinutes}m`;
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+  return `${hours}h ${minutes}m`;
 }
 
 function formatStatus(status: string): string {

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -1,0 +1,481 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { notFound, redirect } from "next/navigation";
+
+import GpsMapLink from "@/components/visits/GpsMapLink";
+import { Card } from "@/components/ui";
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import {
+  ACTION_TYPE_VALUES,
+  ACTION_TYPES,
+  isActionType,
+  statusBadgeClass,
+  type ActionType,
+} from "@/lib/visit-actions";
+import {
+  dispatchComputeInlineStats,
+  dispatchExtractRemarks,
+  type RemarkEntry,
+} from "@/lib/visit-summary";
+import {
+  buildVisitScopePredicate,
+  buildVisitsActor,
+  isScopedVisitsRole,
+} from "@/lib/visits-policy";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+interface VisitSummaryDetail {
+  id: number;
+  school_code: string;
+  school_name: string | null;
+  pm_email: string;
+  pm_name: string | null;
+  visit_date: string;
+  status: string;
+  inserted_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  start_lat: number | string | null;
+  start_lng: number | string | null;
+  start_accuracy: number | string | null;
+  end_lat: number | string | null;
+  end_lng: number | string | null;
+  end_accuracy: number | string | null;
+}
+
+interface VisitActionDetail {
+  id: number;
+  visit_id: number;
+  action_type: string;
+  status: string;
+  data: unknown;
+  started_at: string | null;
+  ended_at: string | null;
+  inserted_at: string;
+  updated_at: string;
+}
+
+type InlineStats = Record<string, unknown>;
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "Asia/Kolkata",
+  });
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+
+  return new Date(value).toLocaleString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Kolkata",
+  });
+}
+
+function formatDuration(startValue: string, endValue: string | null, now = new Date()): string {
+  const start = new Date(startValue).getTime();
+  const end = endValue ? new Date(endValue).getTime() : now.getTime();
+  const minutes = Math.max(0, Math.floor((end - start) / 60000));
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function formatStatus(status: string): string {
+  if (status === "completed") {
+    return "Completed";
+  }
+  if (status === "in_progress") {
+    return "In Progress";
+  }
+  if (status === "pending") {
+    return "Pending";
+  }
+  return status;
+}
+
+function formatSchool(visit: VisitSummaryDetail): string {
+  return visit.school_name ? `${visit.school_name} (${visit.school_code})` : visit.school_code;
+}
+
+function formatPm(visit: VisitSummaryDetail): string {
+  return visit.pm_name || visit.pm_email;
+}
+
+function isStats(value: unknown): value is InlineStats {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function formatNumber(value: unknown): string | null {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Number.isInteger(value) ? String(value) : String(Math.round(value * 10) / 10)
+    : null;
+}
+
+function statsChips(actionType: string, stats: unknown): string[] {
+  if (!isStats(stats)) {
+    return [];
+  }
+
+  if (actionType === "classroom_observation") {
+    return [
+      `Score ${stats.totalScore}/${stats.maxScore}`,
+      `Remarks ${stats.remarkCount}`,
+    ];
+  }
+  if (actionType === "af_team_interaction") {
+    return [
+      `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
+      `Teachers ${stats.teacherCount}`,
+    ];
+  }
+  if (actionType === "individual_af_teacher_interaction") {
+    const avgAnswered = formatNumber(stats.avgAnswered);
+    return [
+      `Teachers ${stats.teacherCount} (${stats.presentCount} present, ${stats.onLeaveCount} on leave, ${stats.absentCount} absent)`,
+      `Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`,
+    ];
+  }
+  if (actionType === "principal_interaction") {
+    return [`Answered ${stats.answeredCount}/${stats.totalQuestions}`];
+  }
+  if (actionType === "group_student_discussion") {
+    return [
+      stats.grade === null || stats.grade === undefined ? "Grade -" : `Grade ${stats.grade}`,
+      `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
+    ];
+  }
+  if (actionType === "individual_student_discussion") {
+    const avgAnswered = formatNumber(stats.avgAnswered);
+    return [
+      `Entries ${stats.entryCount}`,
+      `Students ${stats.studentCount}`,
+      `Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`,
+    ];
+  }
+  if (actionType === "school_staff_interaction") {
+    return [`Answered ${stats.answeredCount}/${stats.totalQuestions}`];
+  }
+  return [];
+}
+
+function actionTypeLabel(actionType: string): string {
+  return isActionType(actionType) ? ACTION_TYPES[actionType] : "Other";
+}
+
+function groupActions(actions: VisitActionDetail[]): Array<{
+  key: ActionType | "other";
+  label: string;
+  actions: VisitActionDetail[];
+}> {
+  const knownGroups = ACTION_TYPE_VALUES.map((actionType) => ({
+    key: actionType,
+    label: ACTION_TYPES[actionType],
+    actions: actions.filter((action) => action.action_type === actionType),
+  })).filter((group) => group.actions.length > 0);
+
+  const otherActions = actions.filter((action) => !isActionType(action.action_type));
+  if (otherActions.length === 0) {
+    return knownGroups;
+  }
+
+  return [
+    ...knownGroups,
+    { key: "other" as const, label: "Other", actions: otherActions },
+  ];
+}
+
+function collectRemarks(actions: VisitActionDetail[]): Array<RemarkEntry & {
+  actionId: number;
+  actionLabel: string;
+}> {
+  return actions.flatMap((action) =>
+    dispatchExtractRemarks(action.action_type, action.data).map((remark) => ({
+      ...remark,
+      actionId: action.id,
+      actionLabel: actionTypeLabel(action.action_type),
+    }))
+  );
+}
+
+async function getVisitSummaryDetail(id: string, actorEmail: string, permission: NonNullable<Awaited<ReturnType<typeof getUserPermission>>>) {
+  const actor = buildVisitsActor(actorEmail, permission);
+  const scope = buildVisitScopePredicate(actor, {
+    startIndex: 2,
+    schoolCodeColumn: "v.school_code",
+    schoolRegionColumn: "s.region",
+  });
+  const predicates = ["v.id = $1", "v.deleted_at IS NULL"];
+  if (scope.clause) {
+    predicates.push(scope.clause);
+  }
+
+  const visits = await query<VisitSummaryDetail>(
+    `SELECT v.*, s.name AS school_name, s.code AS school_code, up.full_name AS pm_name
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
+     WHERE ${predicates.join(" AND ")}`,
+    [id, ...scope.params]
+  );
+
+  if (visits.length === 0) {
+    return { visit: null, actions: [] };
+  }
+
+  const actions = await query<VisitActionDetail>(
+    `SELECT id, visit_id, action_type, status, data, started_at, ended_at, inserted_at, updated_at
+     FROM lms_pm_school_visit_actions
+     WHERE visit_id = $1 AND deleted_at IS NULL
+     ORDER BY action_type, inserted_at`,
+    [id]
+  );
+
+  return { visit: visits[0], actions };
+}
+
+function MetadataGrid({ visit }: { visit: VisitSummaryDetail }) {
+  const items = [
+    ["School", formatSchool(visit)],
+    ["PM", formatPm(visit)],
+    ["Visit Date", formatDate(visit.visit_date)],
+    ["Started", formatTimestamp(visit.inserted_at)],
+    ["Completed", formatTimestamp(visit.completed_at)],
+    ["Updated", formatTimestamp(visit.updated_at)],
+    ["Duration", formatDuration(visit.inserted_at, visit.completed_at)],
+  ];
+
+  return (
+    <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {items.map(([label, value]) => (
+        <div key={label} className="border border-border bg-bg-card-alt px-3 py-2">
+          <dt className="text-xs font-bold uppercase tracking-wide text-text-muted">{label}</dt>
+          <dd className="mt-1 text-sm font-medium text-text-primary">{value}</dd>
+          {label === "PM" && visit.pm_name && (
+            <dd className="mt-1 font-mono text-xs text-text-muted">{visit.pm_email}</dd>
+          )}
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function GpsSection({ visit }: { visit: VisitSummaryDetail }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <Card elevation="sm" className="p-4">
+        <div className="text-xs font-bold uppercase tracking-wide text-text-muted">Start GPS</div>
+        <div className="mt-2">
+          <GpsMapLink lat={visit.start_lat} lng={visit.start_lng} accuracy={visit.start_accuracy} />
+        </div>
+      </Card>
+      <Card elevation="sm" className="p-4">
+        <div className="text-xs font-bold uppercase tracking-wide text-text-muted">End GPS</div>
+        <div className="mt-2">
+          <GpsMapLink lat={visit.end_lat} lng={visit.end_lng} accuracy={visit.end_accuracy} />
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function ActionRow({ action }: { action: VisitActionDetail }) {
+  const chips = statsChips(action.action_type, dispatchComputeInlineStats(action.action_type, action.data));
+
+  return (
+    <div className="border-t border-border/60 px-4 py-4 first:border-t-0">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`inline-flex ${statusBadgeClass(action.status)}`}>
+              {formatStatus(action.status)}
+            </span>
+            <span className="font-mono text-xs text-text-muted">Action #{action.id}</span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-text-muted">
+            <span>Started: {formatTimestamp(action.started_at)}</span>
+            <span>Ended: {formatTimestamp(action.ended_at)}</span>
+            <span>Created: {formatTimestamp(action.inserted_at)}</span>
+            <span>Updated: {formatTimestamp(action.updated_at)}</span>
+          </div>
+          {chips.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {chips.map((chip) => (
+                <span key={chip} className="border border-border bg-bg-card-alt px-2 py-1 font-mono text-xs text-text-secondary">
+                  {chip}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <Link
+          href={`/visits/${action.visit_id}/actions/${action.id}?from=summary`}
+          className="shrink-0 text-sm font-bold uppercase text-accent hover:text-accent-hover"
+        >
+          View full detail
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ActionsSection({ actions }: { actions: VisitActionDetail[] }) {
+  const groups = groupActions(actions);
+
+  if (groups.length === 0) {
+    return (
+      <Card elevation="sm" className="p-6 text-center text-sm text-text-muted">
+        No actions recorded for this visit.
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map((group) => (
+        <Card key={group.key} elevation="sm" className="overflow-hidden">
+          <div className="border-b border-border bg-bg-card-alt px-4 py-3">
+            <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+              {group.label}
+            </h2>
+          </div>
+          {group.actions.map((action) => (
+            <ActionRow key={action.id} action={action} />
+          ))}
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function RemarksSection({ remarks }: { remarks: ReturnType<typeof collectRemarks> }) {
+  return (
+    <Card elevation="sm" className="p-4" role="region" aria-label="Remarks">
+      <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">Remarks</h2>
+      {remarks.length === 0 ? (
+        <p className="mt-3 text-sm text-text-muted">No remarks</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {remarks.map((remark, index) => (
+            <div key={`${remark.actionId}-${index}`} className="border-l-4 border-border-accent pl-3">
+              <div className="text-xs font-bold uppercase tracking-wide text-text-muted">
+                {remark.actionLabel} #{remark.actionId}
+              </div>
+              <div className="mt-1 text-sm font-medium text-text-primary">{remark.label}</div>
+              <p className="mt-1 text-sm text-text-secondary">{remark.text}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default async function SchoolVisitSummaryDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/");
+  }
+
+  if (session.isPasscodeUser) {
+    if (session.schoolCode) {
+      redirect(`/school/${session.schoolCode}`);
+    }
+    redirect("/dashboard");
+  }
+
+  if (!session.user?.email) {
+    redirect("/");
+  }
+
+  const permission = await getUserPermission(session.user.email);
+  if (!permission) {
+    redirect("/dashboard");
+  }
+
+  if (!getFeatureAccess(permission, "visits").canView) {
+    redirect("/dashboard");
+  }
+
+  const actor = buildVisitsActor(session.user.email, permission);
+  if (!isScopedVisitsRole(actor)) {
+    if (actor.role === "program_manager") {
+      redirect("/visits");
+    }
+    redirect("/dashboard");
+  }
+
+  const { visit, actions } = await getVisitSummaryDetail(id, session.user.email, permission);
+  if (!visit) {
+    notFound();
+  }
+
+  const remarks = collectRemarks(actions);
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <div className="sticky top-0 z-10 border-b border-border bg-bg-card/95 px-4 py-3 shadow-sm backdrop-blur sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <Link href="/school-visit-summary" className="text-sm font-bold uppercase text-accent hover:text-accent-hover">
+            &larr; Back to Visit Summary
+          </Link>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+        <Card elevation="sm" className="p-4 sm:p-6">
+          <div className="flex flex-col gap-3 border-b-4 border-border-accent pb-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
+                {formatSchool(visit)}
+              </h1>
+              <p className="mt-1 text-sm text-text-secondary">
+                Visit summary detail
+              </p>
+            </div>
+            <span className={`inline-flex shrink-0 ${statusBadgeClass(visit.status)}`}>
+              {formatStatus(visit.status)}
+            </span>
+          </div>
+          <div className="mt-4">
+            <MetadataGrid visit={visit} />
+          </div>
+        </Card>
+
+        <GpsSection visit={visit} />
+
+        <section aria-labelledby="actions-heading">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 id="actions-heading" className="text-base font-bold uppercase tracking-wide text-text-primary">
+              Actions
+            </h2>
+            <span className="font-mono text-sm text-text-muted">
+              {actions.length} total
+            </span>
+          </div>
+          <ActionsSection actions={actions} />
+        </section>
+
+        <RemarksSection remarks={remarks} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -575,8 +575,10 @@ describe("SchoolVisitSummaryPage", () => {
       expect(screen.getByText("Avg Completion")).toBeInTheDocument();
       expect(screen.getByText("43%")).toBeInTheDocument();
       expect(screen.getByText("4 total, 1 completed")).toBeInTheDocument();
-      expect(screen.getByText("14%")).toBeInTheDocument();
-      expect(screen.getByText("1/7 complete, 2/7 in-progress, 4/7 not started")).toBeInTheDocument();
+      expect(screen.getAllByText("14%").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Classroom Observation: completed").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("AF Team Interaction: pending").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Principal Interaction: in progress").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("1/7 complete").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByRole("link", { name: "View visit" })[0]).toHaveAttribute(
         "href",

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -98,7 +98,13 @@ const teacherPermission = {
   program_ids: [1],
 };
 
-const summaryVisit = {
+const summaryVisit: {
+  id: number; school_code: string; school_name: string; pm_email: string;
+  pm_name: string | null; visit_date: string; status: string;
+  inserted_at: string; completed_at: string | null;
+  start_lat: number; start_lng: number; start_accuracy: number;
+  end_lat: null; end_lng: null; end_accuracy: null;
+} = {
   id: 101,
   school_code: "SC001",
   school_name: "Test School",

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -1,0 +1,353 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetServerSession,
+  mockGetUserPermission,
+  mockGetFeatureAccess,
+  mockQuery,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockGetUserPermission: vi.fn(),
+  mockGetFeatureAccess: vi.fn(),
+  mockQuery: vi.fn(),
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("@/lib/permissions", () => ({
+  getUserPermission: mockGetUserPermission,
+  getFeatureAccess: mockGetFeatureAccess,
+}));
+vi.mock("@/lib/db", () => ({ query: mockQuery }));
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a href={href} className={className} {...props}>{children}</a>,
+}));
+vi.mock("@/components/visits/GpsMapLink", () => ({
+  __esModule: true,
+  default: ({ lat, lng }: { lat: number | string | null; lng: number | string | null }) => (
+    lat !== null && lng !== null ? <a href={`https://maps.google.com/?q=${lat},${lng}`}>GPS</a> : null
+  ),
+}));
+
+import SchoolVisitSummaryPage from "./page";
+
+const adminSession = {
+  user: { email: "admin@avantifellows.org" },
+};
+
+const adminPermission = {
+  email: "admin@avantifellows.org",
+  level: 3,
+  role: "admin",
+  read_only: false,
+  program_ids: [1],
+};
+
+const programAdminPermission = {
+  email: "program-admin@avantifellows.org",
+  level: 2,
+  role: "program_admin",
+  read_only: true,
+  regions: ["AHMEDABAD"],
+  program_ids: [1],
+};
+
+const schoolScopedProgramAdminPermission = {
+  email: "program-admin@avantifellows.org",
+  level: 1,
+  role: "program_admin",
+  read_only: true,
+  school_codes: ["SC001"],
+  program_ids: [1],
+};
+
+const programManagerPermission = {
+  email: "pm@avantifellows.org",
+  level: 3,
+  role: "program_manager",
+  read_only: false,
+  program_ids: [1],
+};
+
+const teacherPermission = {
+  email: "teacher@avantifellows.org",
+  level: 1,
+  role: "teacher",
+  school_codes: ["SC001"],
+  read_only: false,
+  program_ids: [1],
+};
+
+const summaryVisit = {
+  id: 101,
+  school_code: "SC001",
+  school_name: "Test School",
+  pm_email: "pm@avantifellows.org",
+  pm_name: "Program Manager",
+  visit_date: "2026-02-10",
+  status: "completed",
+  inserted_at: "2026-02-10T04:00:00Z",
+  completed_at: "2026-02-10T06:30:00Z",
+  start_lat: 12.9716,
+  start_lng: 77.5946,
+  start_accuracy: 8,
+  end_lat: null,
+  end_lng: null,
+  end_accuracy: null,
+};
+
+const inProgressVisit = {
+  ...summaryVisit,
+  id: 102,
+  school_code: "SC002",
+  school_name: "Fallback School",
+  pm_email: "fallback@avantifellows.org",
+  pm_name: null,
+  status: "in_progress",
+  inserted_at: "2026-02-10T04:00:00Z",
+  completed_at: null,
+};
+
+function setupAuth(permission = adminPermission, session = adminSession) {
+  mockGetServerSession.mockResolvedValue(session);
+  mockGetUserPermission.mockResolvedValue(permission);
+  mockGetFeatureAccess.mockReturnValue({ access: "edit", canView: true, canEdit: true });
+}
+
+describe("SchoolVisitSummaryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("auth/access", () => {
+    it("redirects unauthenticated users to /", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/");
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("redirects passcode users to their school page or dashboard", async () => {
+      mockGetServerSession.mockResolvedValue({ user: {}, isPasscodeUser: true, schoolCode: "70705" });
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/school/70705");
+      expect(mockRedirect).toHaveBeenCalledWith("/school/70705");
+
+      vi.clearAllMocks();
+      mockGetServerSession.mockResolvedValue({ user: {}, isPasscodeUser: true });
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/dashboard");
+      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("redirects PM users to /visits and teachers to /dashboard", async () => {
+      setupAuth(programManagerPermission, { user: { email: "pm@avantifellows.org" } });
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/visits");
+      expect(mockRedirect).toHaveBeenCalledWith("/visits");
+
+      vi.clearAllMocks();
+      setupAuth(teacherPermission, { user: { email: "teacher@avantifellows.org" } });
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/dashboard");
+      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("redirects NVS-only program_admin users when visits feature access is blocked", async () => {
+      setupAuth(programAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
+      mockGetFeatureAccess.mockReturnValue({ access: "none", canView: false, canEdit: false });
+
+      await expect(SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) })).rejects.toThrow("REDIRECT:/dashboard");
+      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scope", () => {
+    it("applies level 2 program_admin region scope with explicit visit columns", async () => {
+      setupAuth(programAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
+      mockQuery
+        .mockResolvedValueOnce([{ total: "0" }]);
+
+      await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain("LEFT JOIN school s ON s.code = v.school_code");
+      expect(sql).toContain("v.deleted_at IS NULL");
+      expect(sql).toContain("COALESCE(s.region, '') = ANY($1)");
+      expect(params).toEqual([["AHMEDABAD"]]);
+    });
+
+    it("applies level 1 program_admin school-code scope with explicit visit columns", async () => {
+      setupAuth(schoolScopedProgramAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
+      mockQuery.mockResolvedValueOnce([{ total: "0" }]);
+
+      await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain("v.school_code = ANY($1)");
+      expect(params).toEqual([["SC001"]]);
+    });
+  });
+
+  describe("sorting", () => {
+    it("uses the default visit date descending sort", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+
+      const [sql] = mockQuery.mock.calls[1];
+      expect(sql).toContain("ORDER BY v.visit_date DESC, v.id DESC");
+    });
+
+    it("sorts completed_at ascending with NULLS LAST", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ sort: "completed_at", dir: "asc" }),
+      });
+
+      const [sql] = mockQuery.mock.calls[1];
+      expect(sql).toContain("ORDER BY v.completed_at ASC NULLS LAST, v.id DESC");
+    });
+
+    it("renders active sort headers as direction toggles", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      const jsx = await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ sort: "school_name", dir: "asc" }),
+      });
+      render(jsx);
+
+      const schoolSortLink = screen
+        .getAllByRole("link", { name: /school/i })
+        .find((link) => link.getAttribute("href")?.includes("sort=school_name"));
+
+      expect(schoolSortLink).toHaveAttribute(
+        "href",
+        "/school-visit-summary?sort=school_name&dir=desc"
+      );
+    });
+
+    it("rejects SQL injection in sort params by falling back to the safe default", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ sort: "visit_date; DROP TABLE school", dir: "asc; DROP" }),
+      });
+
+      const [sql] = mockQuery.mock.calls[1];
+      expect(sql).toContain("ORDER BY v.visit_date DESC, v.id DESC");
+      expect(sql).not.toContain("DROP TABLE");
+    });
+  });
+
+  describe("pagination", () => {
+    it("uses 20 rows per page and clamps out-of-range pages", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "25" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({ page: "999" }) });
+      render(jsx);
+
+      expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
+      const [, params] = mockQuery.mock.calls[1];
+      expect(params).toEqual([20, 20]);
+    });
+  });
+
+  describe("rendering", () => {
+    it("renders a paginated visit summary table for admin users", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+      render(jsx);
+
+      expect(screen.getByRole("heading", { name: "School Visit Summary" })).toBeInTheDocument();
+      expect(screen.getAllByText("Test School (SC001)").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Program Manager").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Completed").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("2h 30m").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByRole("link", { name: "View visit" })[0]).toHaveAttribute(
+        "href",
+        "/school-visit-summary/101"
+      );
+    });
+
+    it("renders empty state when no visits match", async () => {
+      setupAuth();
+      mockQuery.mockResolvedValueOnce([{ total: "0" }]);
+
+      const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+      render(jsx);
+
+      expect(screen.getByText("No visits found")).toBeInTheDocument();
+      expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    });
+
+    it("falls back to PM email and computes in-progress duration from current time", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-02-10T07:45:00Z"));
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([inProgressVisit]);
+
+      const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+      render(jsx);
+
+      expect(screen.getAllByText("fallback@avantifellows.org").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("3h 45m").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders the read-only summary without edit/delete/start/end controls", async () => {
+      setupAuth();
+      mockQuery
+        .mockResolvedValueOnce([{ total: "1" }])
+        .mockResolvedValueOnce([summaryVisit]);
+
+      const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+      render(jsx);
+
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+      expect(screen.queryByText("Start")).not.toBeInTheDocument();
+      expect(screen.queryByText("End")).not.toBeInTheDocument();
+      expect(screen.queryByText("Continue")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -19,7 +19,11 @@ const {
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
-vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+  usePathname: () => "/school-visit-summary",
+  useRouter: () => ({ replace: vi.fn() }),
+}));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
   getFeatureAccess: mockGetFeatureAccess,
@@ -159,14 +163,20 @@ function setupSummaryQueries({
   stats = aggregateStats,
   visits = [summaryVisit],
   actions = summaryActionRows,
+  schoolOptions = [{ code: "SC001", name: "Test School" }],
+  pmOptions = [{ email: "pm@avantifellows.org", name: "Program Manager" }],
 }: {
   stats?: typeof aggregateStats | typeof emptyAggregateStats;
   visits?: Array<typeof summaryVisit>;
   actions?: Array<{ visit_id: number; action_type: string; status: string }>;
+  schoolOptions?: Array<{ code: string; name: string }>;
+  pmOptions?: Array<{ email: string; name: string | null }>;
 } = {}) {
   mockQuery
     .mockResolvedValueOnce([stats])
     .mockResolvedValueOnce(visits)
+    .mockResolvedValueOnce(schoolOptions)
+    .mockResolvedValueOnce(pmOptions)
     .mockResolvedValueOnce(actions);
 }
 
@@ -275,12 +285,15 @@ describe("SchoolVisitSummaryPage", () => {
         if (sql.includes("LIMIT")) {
           return visitsPromise;
         }
+        if (sql.includes("SELECT DISTINCT")) {
+          return Promise.resolve([]);
+        }
         return Promise.resolve(summaryActionRows);
       });
 
       const pagePromise = SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
 
-      await waitFor(() => expect(mockQuery).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockQuery).toHaveBeenCalledTimes(4));
       expect(mockQuery.mock.calls[0][0]).toContain("WITH action_completion");
       expect(mockQuery.mock.calls[1][0]).toContain("LIMIT");
 
@@ -288,8 +301,8 @@ describe("SchoolVisitSummaryPage", () => {
       resolveVisits([summaryVisit]);
       await pagePromise;
 
-      expect(mockQuery.mock.calls[2][0]).toContain("WHERE visit_id = ANY($1)");
-      expect(mockQuery.mock.calls[2][0]).toContain("deleted_at IS NULL");
+      expect(mockQuery.mock.calls[4][0]).toContain("WHERE visit_id = ANY($1)");
+      expect(mockQuery.mock.calls[4][0]).toContain("deleted_at IS NULL");
     });
 
     it("uses known action types and numeric division in the aggregate stats query", async () => {
@@ -309,6 +322,138 @@ describe("SchoolVisitSummaryPage", () => {
         "school_staff_interaction",
       ]));
       expect(params[1]).toBe(7);
+    });
+  });
+
+  describe("filters", () => {
+    it("applies the status filter to aggregate stats and paginated visits", async () => {
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ status: "completed" }),
+      });
+
+      const [statsSql, statsParams] = mockQuery.mock.calls[0];
+      const [visitsSql, visitsParams] = mockQuery.mock.calls[1];
+      expect(statsSql).toContain("v.status = $3");
+      expect(statsParams).toEqual([
+        expect.any(Array),
+        7,
+        "completed",
+      ]);
+      expect(visitsSql).toContain("v.status = $1");
+      expect(visitsParams).toEqual(["completed", 20, 0]);
+    });
+
+    it("parses multi-select schools and PMs plus inclusive manual date filters", async () => {
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({
+          schools: "SC001,,SC002",
+          pms: "PM@Example.org, other@example.org",
+          from: "2026-05-01",
+          to: "2026-05-31",
+        }),
+      });
+
+      const [visitsSql, visitsParams] = mockQuery.mock.calls[1];
+      expect(visitsSql).toContain("v.school_code = ANY($1)");
+      expect(visitsSql).toContain("LOWER(v.pm_email) = ANY($2)");
+      expect(visitsSql).toContain("v.visit_date >= $3");
+      expect(visitsSql).toContain("v.visit_date <= $4");
+      expect(visitsParams).toEqual([
+        ["SC001", "SC002"],
+        ["pm@example.org", "other@example.org"],
+        "2026-05-01",
+        "2026-05-31",
+        20,
+        0,
+      ]);
+    });
+
+    it("uses date presets instead of manual dates and re-anchors them to today in IST", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-05-21T20:00:00.000Z"));
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({
+          preset: "7d",
+          from: "2026-01-01",
+          to: "2026-01-31",
+        }),
+      });
+
+      const [visitsSql, visitsParams] = mockQuery.mock.calls[1];
+      expect(visitsSql).toContain("v.visit_date >= $1");
+      expect(visitsSql).toContain("v.visit_date <= $2");
+      expect(visitsParams).toEqual(["2026-05-16", "2026-05-22", 20, 0]);
+    });
+
+    it("handles from dates after to dates as an empty result predicate", async () => {
+      setupAuth();
+      setupSummaryQueries({ stats: emptyAggregateStats, visits: [], actions: [] });
+
+      const jsx = await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ from: "2026-06-01", to: "2026-05-01" }),
+      });
+      render(jsx);
+
+      const [visitsSql] = mockQuery.mock.calls[1];
+      expect(visitsSql).toContain("1 = 0");
+      expect(screen.getByText("No visits match your filters")).toBeInTheDocument();
+    });
+
+    it("queries cascading school and PM dropdown options excluding only their own filter", async () => {
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({
+          schools: "SC001",
+          pms: "pm@example.org",
+          status: "completed",
+        }),
+      });
+
+      const schoolOptionsCall = mockQuery.mock.calls.find(([sql]) => String(sql).includes("SELECT DISTINCT v.school_code"));
+      const pmOptionsCall = mockQuery.mock.calls.find(([sql]) => String(sql).includes("SELECT DISTINCT LOWER(v.pm_email)"));
+
+      expect(schoolOptionsCall).toBeDefined();
+      expect(schoolOptionsCall?.[0]).not.toContain("v.school_code = ANY");
+      expect(schoolOptionsCall?.[0]).toContain("LOWER(v.pm_email) = ANY");
+      expect(schoolOptionsCall?.[0]).toContain("v.status = $2");
+      expect(schoolOptionsCall?.[1]).toEqual([["pm@example.org"], "completed"]);
+
+      expect(pmOptionsCall).toBeDefined();
+      expect(pmOptionsCall?.[0]).toContain("v.school_code = ANY");
+      expect(pmOptionsCall?.[0]).not.toContain("LOWER(v.pm_email) = ANY");
+      expect(pmOptionsCall?.[0]).toContain("v.status = $2");
+      expect(pmOptionsCall?.[1]).toEqual([["SC001"], "completed"]);
+    });
+
+    it("filters action-completion buckets with known action types and includes zero-action visits for none", async () => {
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ bucket: "none" }),
+      });
+
+      const [visitsSql, visitsParams] = mockQuery.mock.calls[1];
+      expect(visitsSql).toContain("LEFT JOIN (");
+      expect(visitsSql).toContain("COUNT(DISTINCT action_type) FILTER (WHERE action_type = ANY($1::text[])) AS touched_types");
+      expect(visitsSql).toContain("COUNT(DISTINCT CASE WHEN status = 'completed' AND action_type = ANY($1::text[]) THEN action_type END) AS completed_types");
+      expect(visitsSql).toContain("COALESCE(action_agg.touched_types, 0) = 0");
+      expect(visitsParams).toEqual([
+        expect.arrayContaining(["classroom_observation", "school_staff_interaction"]),
+        20,
+        0,
+      ]);
     });
   });
 
@@ -354,6 +499,25 @@ describe("SchoolVisitSummaryPage", () => {
       );
     });
 
+    it("preserves active filters when building sort links", async () => {
+      setupAuth();
+      setupSummaryQueries({ stats: { ...aggregateStats, total_visits: "25" } });
+
+      const jsx = await SchoolVisitSummaryPage({
+        searchParams: Promise.resolve({ status: "completed", schools: "SC001", sort: "school_name", dir: "asc", page: "2" }),
+      });
+      render(jsx);
+
+      const schoolSortLink = screen
+        .getAllByRole("link", { name: /school/i })
+        .find((link) => link.getAttribute("href")?.includes("sort=school_name"));
+
+      expect(schoolSortLink).toHaveAttribute(
+        "href",
+        "/school-visit-summary?status=completed&schools=SC001&sort=school_name&dir=desc"
+      );
+    });
+
     it("rejects SQL injection in sort params by falling back to the safe default", async () => {
       setupAuth();
       setupSummaryQueries();
@@ -374,6 +538,8 @@ describe("SchoolVisitSummaryPage", () => {
       mockQuery
         .mockResolvedValueOnce([{ ...aggregateStats, total_visits: "25" }])
         .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([summaryVisit])
         .mockResolvedValueOnce(summaryActionRows);
 
@@ -382,7 +548,7 @@ describe("SchoolVisitSummaryPage", () => {
 
       expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
       expect(mockQuery.mock.calls[1][1]).toEqual([20, 19960]);
-      expect(mockQuery.mock.calls[2][1]).toEqual([20, 20]);
+      expect(mockQuery.mock.calls[4][1]).toEqual([20, 20]);
     });
   });
 
@@ -419,7 +585,7 @@ describe("SchoolVisitSummaryPage", () => {
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
       render(jsx);
 
-      expect(screen.getByText("No visits found")).toBeInTheDocument();
+      expect(screen.getByText("No visits match your filters")).toBeInTheDocument();
       expect(screen.getByText("Avg Completion")).toBeInTheDocument();
       expect(screen.getByText("—")).toBeInTheDocument();
       expect(screen.queryByRole("table")).not.toBeInTheDocument();

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -124,15 +124,56 @@ const inProgressVisit = {
   completed_at: null,
 };
 
+const aggregateStats = {
+  total_visits: "1",
+  in_progress_count: "0",
+  completed_count: "1",
+  unique_schools: "1",
+  unique_pms: "1",
+  avg_action_completion: "42.857142",
+};
+
+const emptyAggregateStats = {
+  total_visits: "0",
+  in_progress_count: "0",
+  completed_count: "0",
+  unique_schools: "0",
+  unique_pms: "0",
+  avg_action_completion: null,
+};
+
+const summaryActionRows = [
+  { visit_id: 101, action_type: "classroom_observation", status: "completed" },
+  { visit_id: 101, action_type: "classroom_observation", status: "pending" },
+  { visit_id: 101, action_type: "af_team_interaction", status: "pending" },
+  { visit_id: 101, action_type: "principal_interaction", status: "in_progress" },
+];
+
 function setupAuth(permission = adminPermission, session = adminSession) {
   mockGetServerSession.mockResolvedValue(session);
   mockGetUserPermission.mockResolvedValue(permission);
   mockGetFeatureAccess.mockReturnValue({ access: "edit", canView: true, canEdit: true });
 }
 
+function setupSummaryQueries({
+  stats = aggregateStats,
+  visits = [summaryVisit],
+  actions = summaryActionRows,
+}: {
+  stats?: typeof aggregateStats | typeof emptyAggregateStats;
+  visits?: Array<typeof summaryVisit>;
+  actions?: Array<{ visit_id: number; action_type: string; status: string }>;
+} = {}) {
+  mockQuery
+    .mockResolvedValueOnce([stats])
+    .mockResolvedValueOnce(visits)
+    .mockResolvedValueOnce(actions);
+}
+
 describe("SchoolVisitSummaryPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQuery.mockReset();
     vi.useRealTimers();
   });
 
@@ -184,36 +225,97 @@ describe("SchoolVisitSummaryPage", () => {
   describe("scope", () => {
     it("applies level 2 program_admin region scope with explicit visit columns", async () => {
       setupAuth(programAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
-      mockQuery
-        .mockResolvedValueOnce([{ total: "0" }]);
+      setupSummaryQueries({ stats: emptyAggregateStats, visits: [], actions: [] });
 
       await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
 
       const [sql, params] = mockQuery.mock.calls[0];
       expect(sql).toContain("LEFT JOIN school s ON s.code = v.school_code");
       expect(sql).toContain("v.deleted_at IS NULL");
-      expect(sql).toContain("COALESCE(s.region, '') = ANY($1)");
-      expect(params).toEqual([["AHMEDABAD"]]);
+      expect(sql).toContain("COALESCE(s.region, '') = ANY($3)");
+      expect(params).toEqual([
+        expect.any(Array),
+        7,
+        ["AHMEDABAD"],
+      ]);
     });
 
     it("applies level 1 program_admin school-code scope with explicit visit columns", async () => {
       setupAuth(schoolScopedProgramAdminPermission, { user: { email: "program-admin@avantifellows.org" } });
-      mockQuery.mockResolvedValueOnce([{ total: "0" }]);
+      setupSummaryQueries({ stats: emptyAggregateStats, visits: [], actions: [] });
 
       await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
 
       const [sql, params] = mockQuery.mock.calls[0];
-      expect(sql).toContain("v.school_code = ANY($1)");
-      expect(params).toEqual([["SC001"]]);
+      expect(sql).toContain("v.school_code = ANY($3)");
+      expect(params).toEqual([
+        expect.any(Array),
+        7,
+        ["SC001"],
+      ]);
+    });
+  });
+
+  describe("summary queries", () => {
+    it("dispatches aggregate and paginated queries before awaiting either result", async () => {
+      setupAuth();
+      let resolveStats: (value: unknown) => void = () => {};
+      let resolveVisits: (value: unknown) => void = () => {};
+      const statsPromise = new Promise((resolve) => {
+        resolveStats = resolve;
+      });
+      const visitsPromise = new Promise((resolve) => {
+        resolveVisits = resolve;
+      });
+
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes("WITH action_completion") || sql.includes("COUNT(*) AS total")) {
+          return statsPromise;
+        }
+        if (sql.includes("LIMIT")) {
+          return visitsPromise;
+        }
+        return Promise.resolve(summaryActionRows);
+      });
+
+      const pagePromise = SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+
+      await waitFor(() => expect(mockQuery).toHaveBeenCalledTimes(2));
+      expect(mockQuery.mock.calls[0][0]).toContain("WITH action_completion");
+      expect(mockQuery.mock.calls[1][0]).toContain("LIMIT");
+
+      resolveStats([aggregateStats]);
+      resolveVisits([summaryVisit]);
+      await pagePromise;
+
+      expect(mockQuery.mock.calls[2][0]).toContain("WHERE visit_id = ANY($1)");
+      expect(mockQuery.mock.calls[2][0]).toContain("deleted_at IS NULL");
+    });
+
+    it("uses known action types and numeric division in the aggregate stats query", async () => {
+      setupAuth();
+      setupSummaryQueries();
+
+      await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
+
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain("COUNT(DISTINCT LOWER(v.pm_email))");
+      expect(sql).toContain("::numeric");
+      expect(sql).toContain("a.action_type = ANY($1");
+      expect(sql).toContain("COUNT(*) * $2");
+      expect(params[0]).toEqual(expect.arrayContaining([
+        "classroom_observation",
+        "af_team_interaction",
+        "school_staff_interaction",
+      ]));
+      expect(params[1]).toBe(7);
     });
   });
 
   describe("sorting", () => {
     it("uses the default visit date descending sort", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
 
@@ -223,9 +325,7 @@ describe("SchoolVisitSummaryPage", () => {
 
     it("sorts completed_at ascending with NULLS LAST", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       await SchoolVisitSummaryPage({
         searchParams: Promise.resolve({ sort: "completed_at", dir: "asc" }),
@@ -237,9 +337,7 @@ describe("SchoolVisitSummaryPage", () => {
 
     it("renders active sort headers as direction toggles", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       const jsx = await SchoolVisitSummaryPage({
         searchParams: Promise.resolve({ sort: "school_name", dir: "asc" }),
@@ -258,9 +356,7 @@ describe("SchoolVisitSummaryPage", () => {
 
     it("rejects SQL injection in sort params by falling back to the safe default", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       await SchoolVisitSummaryPage({
         searchParams: Promise.resolve({ sort: "visit_date; DROP TABLE school", dir: "asc; DROP" }),
@@ -276,24 +372,24 @@ describe("SchoolVisitSummaryPage", () => {
     it("uses 20 rows per page and clamps out-of-range pages", async () => {
       setupAuth();
       mockQuery
-        .mockResolvedValueOnce([{ total: "25" }])
-        .mockResolvedValueOnce([summaryVisit]);
+        .mockResolvedValueOnce([{ ...aggregateStats, total_visits: "25" }])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([summaryVisit])
+        .mockResolvedValueOnce(summaryActionRows);
 
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({ page: "999" }) });
       render(jsx);
 
       expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
-      const [, params] = mockQuery.mock.calls[1];
-      expect(params).toEqual([20, 20]);
+      expect(mockQuery.mock.calls[1][1]).toEqual([20, 19960]);
+      expect(mockQuery.mock.calls[2][1]).toEqual([20, 20]);
     });
   });
 
   describe("rendering", () => {
     it("renders a paginated visit summary table for admin users", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
       render(jsx);
@@ -303,6 +399,13 @@ describe("SchoolVisitSummaryPage", () => {
       expect(screen.getAllByText("Program Manager").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Completed").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("2h 30m").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Total Visits")).toBeInTheDocument();
+      expect(screen.getByText("Avg Completion")).toBeInTheDocument();
+      expect(screen.getByText("43%")).toBeInTheDocument();
+      expect(screen.getByText("4 total, 1 completed")).toBeInTheDocument();
+      expect(screen.getByText("14%")).toBeInTheDocument();
+      expect(screen.getByText("1/7 complete, 2/7 in-progress, 4/7 not started")).toBeInTheDocument();
+      expect(screen.getAllByText("1/7 complete").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByRole("link", { name: "View visit" })[0]).toHaveAttribute(
         "href",
         "/school-visit-summary/101"
@@ -311,12 +414,14 @@ describe("SchoolVisitSummaryPage", () => {
 
     it("renders empty state when no visits match", async () => {
       setupAuth();
-      mockQuery.mockResolvedValueOnce([{ total: "0" }]);
+      setupSummaryQueries({ stats: emptyAggregateStats, visits: [], actions: [] });
 
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
       render(jsx);
 
       expect(screen.getByText("No visits found")).toBeInTheDocument();
+      expect(screen.getByText("Avg Completion")).toBeInTheDocument();
+      expect(screen.getByText("—")).toBeInTheDocument();
       expect(screen.queryByRole("table")).not.toBeInTheDocument();
     });
 
@@ -324,9 +429,7 @@ describe("SchoolVisitSummaryPage", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-02-10T07:45:00Z"));
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([inProgressVisit]);
+      setupSummaryQueries({ visits: [inProgressVisit], actions: [] });
 
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
       render(jsx);
@@ -337,9 +440,7 @@ describe("SchoolVisitSummaryPage", () => {
 
     it("renders the read-only summary without edit/delete/start/end controls", async () => {
       setupAuth();
-      mockQuery
-        .mockResolvedValueOnce([{ total: "1" }])
-        .mockResolvedValueOnce([summaryVisit]);
+      setupSummaryQueries();
 
       const jsx = await SchoolVisitSummaryPage({ searchParams: Promise.resolve({}) });
       render(jsx);

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
 import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
-import { ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
+import { ACTION_TYPES, ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
 import {
   resolvePresetDateRange,
   rollupActionTypes,
@@ -72,6 +72,7 @@ interface VisitActionSummary {
   inProgressTypes: number;
   notStartedTypes: number;
   completionPercent: number | null;
+  rollup: Record<ActionType, ActionTypeRollupStatus>;
 }
 
 interface SchoolFilterOption {
@@ -254,11 +255,15 @@ function formatPm(visit: SummaryVisit): string {
 function formatDuration(visit: SummaryVisit, now = new Date()): string {
   const start = new Date(visit.inserted_at).getTime();
   const end = visit.completed_at ? new Date(visit.completed_at).getTime() : now.getTime();
-  const minutes = Math.max(0, Math.floor((end - start) / 60000));
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
+  const totalMinutes = Math.max(0, Math.floor((end - start) / 60000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
 
-  return `${hours}h ${remainingMinutes}m`;
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+  return `${hours}h ${minutes}m`;
 }
 
 function buildWhereClause(
@@ -513,6 +518,7 @@ function summarizeActions(actions: VisitActionRow[]): VisitActionSummary {
     completionPercent: totalActions === 0
       ? null
       : (completedTypes / ACTION_TYPE_VALUES.length) * 100,
+    rollup,
   };
 }
 
@@ -685,8 +691,38 @@ function formatActionCounts(summary: VisitActionSummary): string {
   return `${summary.totalActions} total, ${summary.completedActions} completed`;
 }
 
-function formatActionTypeBreakdown(summary: VisitActionSummary): string {
-  return `${summary.completedTypes}/${ACTION_TYPE_VALUES.length} complete, ${summary.inProgressTypes}/${ACTION_TYPE_VALUES.length} in-progress, ${summary.notStartedTypes}/${ACTION_TYPE_VALUES.length} not started`;
+function ActionTypeBar({ summary }: { summary: VisitActionSummary }) {
+  const pct = summary.completionPercent !== null ? Math.round(summary.completionPercent) : 0;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex h-5 w-28 rounded-sm border border-border/60">
+        {ACTION_TYPE_VALUES.map((actionType) => {
+          const status = summary.rollup[actionType];
+          const label = ACTION_TYPES[actionType];
+          const statusLabel = status.replace("_", " ");
+          const colorClass =
+            status === "completed"
+              ? "bg-success"
+              : status === "in_progress" || status === "pending"
+                ? "bg-brand-amber"
+                : "bg-gray-200";
+
+          return (
+            <span
+              key={actionType}
+              className={`group/seg relative flex-1 border-r border-border/30 last:border-r-0 ${colorClass} cursor-default hover:opacity-80`}
+            >
+              <span className="pointer-events-none invisible absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 shadow-lg transition-all group-hover/seg:visible group-hover/seg:opacity-100">
+                {label}: {statusLabel}
+              </span>
+            </span>
+          );
+        })}
+      </div>
+      <span className="text-xs font-mono text-text-muted whitespace-nowrap">{pct}%</span>
+    </div>
+  );
 }
 
 function formatMobileActionSummary(summary: VisitActionSummary): string {
@@ -836,8 +872,8 @@ function VisitDesktopTable({
                 <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
                   {formatPercent(actionSummary.completionPercent)}
                 </td>
-                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
-                  {formatActionTypeBreakdown(actionSummary)}
+                <td className="whitespace-nowrap px-4 py-4">
+                  <ActionTypeBar summary={actionSummary} />
                 </td>
                 <td className="whitespace-nowrap px-4 py-4 text-right text-sm">
                   <Link
@@ -913,7 +949,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
   return (
     <div className="min-h-screen bg-bg">
       <header className="border-b border-border bg-bg-card shadow-sm">
-        <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-y-2 px-4 py-3 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 px-4 py-3 sm:px-6 lg:px-8">
           <div className="flex min-w-0 items-center gap-3 sm:gap-6">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -950,7 +986,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <main className="px-4 py-6 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-col gap-2 border-b-4 border-border-accent pb-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -4,12 +4,14 @@ import { redirect } from "next/navigation";
 
 import StatCard from "@/components/StatCard";
 import GpsMapLink from "@/components/visits/GpsMapLink";
+import VisitSummaryFilterBar from "@/components/visits/VisitSummaryFilterBar";
 import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
 import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
 import { ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
 import {
+  resolvePresetDateRange,
   rollupActionTypes,
   type ActionTypeRollupStatus,
 } from "@/lib/visit-summary";
@@ -72,10 +74,22 @@ interface VisitActionSummary {
   completionPercent: number | null;
 }
 
+interface SchoolFilterOption {
+  code: string;
+  name: string;
+}
+
+interface PmFilterOption {
+  email: string;
+  name: string | null;
+}
+
 interface SummaryResult {
   visits: SummaryVisit[];
   stats: SummaryStats;
   actionSummaries: Map<number, VisitActionSummary>;
+  schoolOptions: SchoolFilterOption[];
+  pmOptions: PmFilterOption[];
   totalCount: number;
   currentPage: number;
   totalPages: number;
@@ -88,11 +102,33 @@ interface PageProps {
     sort?: string;
     dir?: string;
     page?: string;
+    schools?: string;
+    pms?: string;
+    status?: string;
+    from?: string;
+    to?: string;
+    preset?: string;
+    bucket?: string;
   }>;
 }
 
 type SortKey = "visit_date" | "school_name" | "pm_email" | "status" | "inserted_at" | "completed_at";
 type SortDirection = "asc" | "desc";
+type VisitSummaryStatusFilter = "in_progress" | "completed";
+type FilterExclusion = "schools" | "pms";
+type ActionCompletionBucketFilter = "none" | "partial" | "all_present" | "all_complete";
+type SummarySearchParams = Record<string, string | undefined>;
+
+interface VisitSummaryFilters {
+  schools: string[];
+  pms: string[];
+  status?: VisitSummaryStatusFilter;
+  from?: string;
+  to?: string;
+  preset?: string;
+  bucket?: ActionCompletionBucketFilter;
+  forceEmpty: boolean;
+}
 
 const SORT_COLUMNS: Record<SortKey, { sql: string; defaultDir: SortDirection }> = {
   visit_date: { sql: "v.visit_date", defaultDir: "desc" },
@@ -119,6 +155,50 @@ function normalizeSort(sortParam?: string, dirParam?: string): { sort: SortKey; 
 function normalizePage(pageParam?: string): number {
   const parsed = Number.parseInt(pageParam || "1", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function parseListFilter(value: string | undefined, transform: (item: string) => string = (item) => item): string[] {
+  return (value || "")
+    .split(",")
+    .map((item) => transform(item.trim()))
+    .filter(Boolean);
+}
+
+function isDateString(value: string | undefined): value is string {
+  return Boolean(value && /^\d{4}-\d{2}-\d{2}$/.test(value));
+}
+
+function normalizeFilters(searchParams: {
+  schools?: string;
+  pms?: string;
+  status?: string;
+  from?: string;
+  to?: string;
+  preset?: string;
+  bucket?: string;
+}): VisitSummaryFilters {
+  const presetRange = resolvePresetDateRange(searchParams.preset, new Date());
+  const manualFrom = isDateString(searchParams.from) ? searchParams.from : undefined;
+  const manualTo = isDateString(searchParams.to) ? searchParams.to : undefined;
+  const from = presetRange?.from ?? manualFrom;
+  const to = presetRange?.to ?? manualTo;
+
+  return {
+    schools: parseListFilter(searchParams.schools),
+    pms: parseListFilter(searchParams.pms, (item) => item.toLowerCase()),
+    status: searchParams.status === "in_progress" || searchParams.status === "completed"
+      ? searchParams.status
+      : undefined,
+    from,
+    to,
+    preset: presetRange || searchParams.preset === "all" ? searchParams.preset : undefined,
+    bucket: isActionCompletionBucket(searchParams.bucket) ? searchParams.bucket : undefined,
+    forceEmpty: Boolean(from && to && from > to),
+  };
+}
+
+function isActionCompletionBucket(value: string | undefined): value is ActionCompletionBucketFilter {
+  return value === "none" || value === "partial" || value === "all_present" || value === "all_complete";
 }
 
 function formatDate(value: string): string {
@@ -184,14 +264,78 @@ function formatDuration(visit: SummaryVisit, now = new Date()): string {
 function buildWhereClause(
   permission: UserPermission,
   actorEmail: string,
-  startIndex = 1
-): { whereSql: string; params: unknown[] } {
+  filters: VisitSummaryFilters = {},
+  startIndex = 1,
+  exclude?: FilterExclusion
+): { whereSql: string; joinSql: string; params: unknown[] } {
   const actor = buildVisitsActor(actorEmail, permission);
   const predicates = ["v.deleted_at IS NULL"];
+  const joins: string[] = [];
   const params: unknown[] = [];
+  let nextIndex = startIndex;
+
+  if (filters.forceEmpty) {
+    predicates.push("1 = 0");
+  }
+
+  if (exclude !== "schools" && filters.schools.length > 0) {
+    predicates.push(`v.school_code = ANY($${nextIndex})`);
+    params.push(filters.schools);
+    nextIndex += 1;
+  }
+
+  if (exclude !== "pms" && filters.pms.length > 0) {
+    predicates.push(`LOWER(v.pm_email) = ANY($${nextIndex})`);
+    params.push(filters.pms);
+    nextIndex += 1;
+  }
+
+  if (filters.status) {
+    predicates.push(`v.status = $${nextIndex}`);
+    params.push(filters.status);
+    nextIndex += 1;
+  }
+
+  if (filters.from) {
+    predicates.push(`v.visit_date >= $${nextIndex}`);
+    params.push(filters.from);
+    nextIndex += 1;
+  }
+
+  if (filters.to) {
+    predicates.push(`v.visit_date <= $${nextIndex}`);
+    params.push(filters.to);
+    nextIndex += 1;
+  }
+
+  if (filters.bucket) {
+    const knownTypesIndex = nextIndex;
+    joins.push(
+      `LEFT JOIN (
+        SELECT visit_id,
+               COUNT(DISTINCT action_type) FILTER (WHERE action_type = ANY($${knownTypesIndex}::text[])) AS touched_types,
+               COUNT(DISTINCT CASE WHEN status = 'completed' AND action_type = ANY($${knownTypesIndex}::text[]) THEN action_type END) AS completed_types
+        FROM lms_pm_school_visit_actions
+        WHERE deleted_at IS NULL
+        GROUP BY visit_id
+      ) AS action_agg ON action_agg.visit_id = v.id`
+    );
+    params.push(ACTION_TYPE_VALUES);
+    nextIndex += 1;
+
+    if (filters.bucket === "none") {
+      predicates.push("COALESCE(action_agg.touched_types, 0) = 0");
+    } else if (filters.bucket === "partial") {
+      predicates.push(`COALESCE(action_agg.touched_types, 0) > 0 AND COALESCE(action_agg.touched_types, 0) < ${ACTION_TYPE_VALUES.length}`);
+    } else if (filters.bucket === "all_present") {
+      predicates.push(`COALESCE(action_agg.touched_types, 0) = ${ACTION_TYPE_VALUES.length} AND COALESCE(action_agg.completed_types, 0) < ${ACTION_TYPE_VALUES.length}`);
+    } else {
+      predicates.push(`COALESCE(action_agg.completed_types, 0) = ${ACTION_TYPE_VALUES.length}`);
+    }
+  }
 
   const scope = buildVisitScopePredicate(actor, {
-    startIndex,
+    startIndex: nextIndex,
     schoolCodeColumn: "v.school_code",
     schoolRegionColumn: "s.region",
   });
@@ -203,6 +347,7 @@ function buildWhereClause(
 
   return {
     whereSql: predicates.join(" AND "),
+    joinSql: joins.join("\n"),
     params,
   };
 }
@@ -231,9 +376,10 @@ function parseNullableNumber(value: string | number | null | undefined): number 
 
 async function getSummaryStats(
   actorEmail: string,
-  permission: UserPermission
+  permission: UserPermission,
+  filters: VisitSummaryFilters
 ): Promise<SummaryStats> {
-  const { whereSql, params } = buildWhereClause(permission, actorEmail, 3);
+  const { whereSql, joinSql, params } = buildWhereClause(permission, actorEmail, filters, 3);
   const rows = await query<SummaryStatsRow>(
     `WITH action_completion AS (
        SELECT a.visit_id,
@@ -255,6 +401,7 @@ async function getSummaryStats(
      FROM lms_pm_school_visits v
      LEFT JOIN school s ON s.code = v.school_code
      LEFT JOIN action_completion ac ON ac.visit_id = v.id
+     ${joinSql}
      WHERE ${whereSql}`,
     [ACTION_TYPE_VALUES, ACTION_TYPE_VALUES.length, ...params]
   );
@@ -273,11 +420,12 @@ async function getSummaryStats(
 async function getPaginatedVisits(
   actorEmail: string,
   permission: UserPermission,
+  filters: VisitSummaryFilters,
   sort: SortKey,
   dir: SortDirection,
   page: number
 ): Promise<SummaryVisit[]> {
-  const { whereSql, params } = buildWhereClause(permission, actorEmail);
+  const { whereSql, joinSql, params } = buildWhereClause(permission, actorEmail, filters);
   const offset = (page - 1) * VISITS_PER_PAGE;
   const limitIndex = params.length + 1;
   const offsetIndex = params.length + 2;
@@ -290,10 +438,48 @@ async function getPaginatedVisits(
      FROM lms_pm_school_visits v
      LEFT JOIN school s ON s.code = v.school_code
      LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
+     ${joinSql}
      WHERE ${whereSql}
      ORDER BY ${buildOrderClause(sort, dir)}
      LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
     [...params, VISITS_PER_PAGE, offset]
+  );
+}
+
+async function getSchoolFilterOptions(
+  actorEmail: string,
+  permission: UserPermission,
+  filters: VisitSummaryFilters
+): Promise<SchoolFilterOption[]> {
+  const { whereSql, joinSql, params } = buildWhereClause(permission, actorEmail, filters, 1, "schools");
+
+  return query<SchoolFilterOption>(
+    `SELECT DISTINCT v.school_code AS code, COALESCE(s.name, v.school_code) AS name
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     ${joinSql}
+     WHERE ${whereSql}
+     ORDER BY name ASC, code ASC`,
+    params
+  );
+}
+
+async function getPmFilterOptions(
+  actorEmail: string,
+  permission: UserPermission,
+  filters: VisitSummaryFilters
+): Promise<PmFilterOption[]> {
+  const { whereSql, joinSql, params } = buildWhereClause(permission, actorEmail, filters, 1, "pms");
+
+  return query<PmFilterOption>(
+    `SELECT DISTINCT LOWER(v.pm_email) AS email, up.full_name AS name
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
+     ${joinSql}
+     WHERE ${whereSql}
+     ORDER BY name ASC NULLS LAST, email ASC`,
+    params
   );
 }
 
@@ -347,31 +533,68 @@ function buildActionSummaryMap(visits: SummaryVisit[], actions: VisitActionRow[]
 async function getSummaryVisits(
   actorEmail: string,
   permission: UserPermission,
-  searchParams: { sort?: string; dir?: string; page?: string }
+  searchParams: {
+    sort?: string;
+    dir?: string;
+    page?: string;
+    schools?: string;
+    pms?: string;
+    status?: string;
+    from?: string;
+    to?: string;
+    preset?: string;
+    bucket?: string;
+  }
 ): Promise<SummaryResult> {
   const { sort, dir } = normalizeSort(searchParams.sort, searchParams.dir);
+  const filters = normalizeFilters(searchParams);
   const requestedPage = normalizePage(searchParams.page);
-  const [stats, initialVisits] = await Promise.all([
-    getSummaryStats(actorEmail, permission),
-    getPaginatedVisits(actorEmail, permission, sort, dir, requestedPage),
+  const [stats, initialVisits, schoolOptions, pmOptions] = await Promise.all([
+    getSummaryStats(actorEmail, permission, filters),
+    getPaginatedVisits(actorEmail, permission, filters, sort, dir, requestedPage),
+    getSchoolFilterOptions(actorEmail, permission, filters),
+    getPmFilterOptions(actorEmail, permission, filters),
   ]);
   const totalCount = stats.totalVisits;
   const totalPages = Math.max(1, Math.ceil(totalCount / VISITS_PER_PAGE));
   const currentPage = Math.min(requestedPage, totalPages);
   const visits = totalCount > 0 && currentPage !== requestedPage
-    ? await getPaginatedVisits(actorEmail, permission, sort, dir, currentPage)
+    ? await getPaginatedVisits(actorEmail, permission, filters, sort, dir, currentPage)
     : initialVisits;
   const actionRows = await getActionRowsForVisits(visits.map((visit) => visit.id));
   const actionSummaries = buildActionSummaryMap(visits, actionRows);
 
-  return { visits, stats, actionSummaries, totalCount, currentPage, totalPages, sort, dir };
+  return {
+    visits,
+    stats,
+    actionSummaries,
+    schoolOptions,
+    pmOptions,
+    totalCount,
+    currentPage,
+    totalPages,
+    sort,
+    dir,
+  };
 }
 
-function sortHref(column: SortKey, currentSort: SortKey, currentDir: SortDirection): string {
+function sortHref(
+  column: SortKey,
+  currentSort: SortKey,
+  currentDir: SortDirection,
+  currentParams: SummarySearchParams
+): string {
   const dir = column === currentSort
     ? currentDir === "asc" ? "desc" : "asc"
     : SORT_COLUMNS[column].defaultDir;
-  const params = new URLSearchParams({ sort: column, dir });
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(currentParams)) {
+    if (value && key !== "sort" && key !== "dir" && key !== "page") {
+      params.set(key, value);
+    }
+  }
+  params.set("sort", column);
+  params.set("dir", dir);
   return `/school-visit-summary?${params.toString()}`;
 }
 
@@ -379,18 +602,20 @@ function SortHeader({
   column,
   currentSort,
   currentDir,
+  currentParams,
   children,
 }: {
   column: SortKey;
   currentSort: SortKey;
   currentDir: SortDirection;
+  currentParams: SummarySearchParams;
   children: React.ReactNode;
 }) {
   const active = column === currentSort;
 
   return (
     <Link
-      href={sortHref(column, currentSort, currentDir)}
+      href={sortHref(column, currentSort, currentDir, currentParams)}
       className="inline-flex items-center gap-1 hover:text-text-primary"
     >
       {children}
@@ -404,18 +629,27 @@ function PaginationControls({
   totalPages,
   sort,
   dir,
+  currentParams,
 }: {
   currentPage: number;
   totalPages: number;
   sort: SortKey;
   dir: SortDirection;
+  currentParams: SummarySearchParams;
 }) {
   if (totalPages <= 1) {
     return null;
   }
 
   const hrefFor = (page: number) => {
-    const params = new URLSearchParams({ sort, dir });
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(currentParams)) {
+      if (value && key !== "page") {
+        params.set(key, value);
+      }
+    }
+    params.set("sort", sort);
+    params.set("dir", dir);
     if (page > 1) {
       params.set("page", String(page));
     }
@@ -506,11 +740,13 @@ function VisitDesktopTable({
   actionSummaries,
   sort,
   dir,
+  currentParams,
 }: {
   visits: SummaryVisit[];
   actionSummaries: Map<number, VisitActionSummary>;
   sort: SortKey;
   dir: SortDirection;
+  currentParams: SummarySearchParams;
 }) {
   return (
     <Card elevation="sm" className="hidden overflow-x-auto sm:block">
@@ -518,22 +754,22 @@ function VisitDesktopTable({
         <thead className="border-b-2 border-border-accent bg-bg-card-alt">
           <tr>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="school_name" currentSort={sort} currentDir={dir}>School</SortHeader>
+              <SortHeader column="school_name" currentSort={sort} currentDir={dir} currentParams={currentParams}>School</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="pm_email" currentSort={sort} currentDir={dir}>PM</SortHeader>
+              <SortHeader column="pm_email" currentSort={sort} currentDir={dir} currentParams={currentParams}>PM</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="visit_date" currentSort={sort} currentDir={dir}>Visit Date</SortHeader>
+              <SortHeader column="visit_date" currentSort={sort} currentDir={dir} currentParams={currentParams}>Visit Date</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="status" currentSort={sort} currentDir={dir}>Status</SortHeader>
+              <SortHeader column="status" currentSort={sort} currentDir={dir} currentParams={currentParams}>Status</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="inserted_at" currentSort={sort} currentDir={dir}>Started At</SortHeader>
+              <SortHeader column="inserted_at" currentSort={sort} currentDir={dir} currentParams={currentParams}>Started At</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
-              <SortHeader column="completed_at" currentSort={sort} currentDir={dir}>Completed At</SortHeader>
+              <SortHeader column="completed_at" currentSort={sort} currentDir={dir} currentParams={currentParams}>Completed At</SortHeader>
             </th>
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
               Duration
@@ -657,7 +893,18 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
     redirect("/dashboard");
   }
 
-  const { visits, stats, actionSummaries, totalCount, currentPage, totalPages, sort, dir } = await getSummaryVisits(
+  const {
+    visits,
+    stats,
+    actionSummaries,
+    schoolOptions,
+    pmOptions,
+    totalCount,
+    currentPage,
+    totalPages,
+    sort,
+    dir,
+  } = await getSummaryVisits(
     session.user.email,
     permission,
     rawSearchParams
@@ -717,9 +964,15 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
 
         <StatCards stats={stats} />
 
+        <VisitSummaryFilterBar
+          schoolOptions={schoolOptions}
+          pmOptions={pmOptions}
+          currentParams={rawSearchParams}
+        />
+
         {visits.length === 0 ? (
           <div className="py-12 text-center">
-            <div className="text-text-muted uppercase tracking-wide">No visits found</div>
+            <div className="text-text-muted uppercase tracking-wide">No visits match your filters</div>
           </div>
         ) : (
           <>
@@ -738,6 +991,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
               actionSummaries={actionSummaries}
               sort={sort}
               dir={dir}
+              currentParams={rawSearchParams}
             />
 
             <PaginationControls
@@ -745,6 +999,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
               totalPages={totalPages}
               sort={sort}
               dir={dir}
+              currentParams={rawSearchParams}
             />
           </>
         )}

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -264,7 +264,7 @@ function formatDuration(visit: SummaryVisit, now = new Date()): string {
 function buildWhereClause(
   permission: UserPermission,
   actorEmail: string,
-  filters: VisitSummaryFilters = {},
+  filters: VisitSummaryFilters = { schools: [], pms: [], forceEmpty: false },
   startIndex = 1,
   exclude?: FilterExclusion
 ): { whereSql: string; joinSql: string; params: unknown[] } {

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -2,12 +2,17 @@ import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
+import StatCard from "@/components/StatCard";
 import GpsMapLink from "@/components/visits/GpsMapLink";
 import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
 import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
-import { statusBadgeClass } from "@/lib/visit-actions";
+import { ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
+import {
+  rollupActionTypes,
+  type ActionTypeRollupStatus,
+} from "@/lib/visit-summary";
 import {
   buildVisitScopePredicate,
   buildVisitsActor,
@@ -34,8 +39,43 @@ interface SummaryVisit {
   end_accuracy: number | string | null;
 }
 
+interface SummaryStats {
+  totalVisits: number;
+  inProgressCount: number;
+  completedCount: number;
+  uniqueSchools: number;
+  uniquePms: number;
+  avgActionCompletion: number | null;
+}
+
+interface SummaryStatsRow {
+  total_visits: string | number | null;
+  in_progress_count: string | number | null;
+  completed_count: string | number | null;
+  unique_schools: string | number | null;
+  unique_pms: string | number | null;
+  avg_action_completion: string | number | null;
+}
+
+interface VisitActionRow {
+  visit_id: number | string;
+  action_type: string;
+  status: string;
+}
+
+interface VisitActionSummary {
+  totalActions: number;
+  completedActions: number;
+  completedTypes: number;
+  inProgressTypes: number;
+  notStartedTypes: number;
+  completionPercent: number | null;
+}
+
 interface SummaryResult {
   visits: SummaryVisit[];
+  stats: SummaryStats;
+  actionSummaries: Map<number, VisitActionSummary>;
   totalCount: number;
   currentPage: number;
   totalPages: number;
@@ -116,6 +156,13 @@ function formatStatus(status: string): string {
   return status;
 }
 
+function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "—";
+  }
+  return `${Math.round(value)}%`;
+}
+
 function formatSchool(visit: SummaryVisit): string {
   return visit.school_name ? `${visit.school_name} (${visit.school_code})` : visit.school_code;
 }
@@ -136,14 +183,15 @@ function formatDuration(visit: SummaryVisit, now = new Date()): string {
 
 function buildWhereClause(
   permission: UserPermission,
-  actorEmail: string
+  actorEmail: string,
+  startIndex = 1
 ): { whereSql: string; params: unknown[] } {
   const actor = buildVisitsActor(actorEmail, permission);
   const predicates = ["v.deleted_at IS NULL"];
   const params: unknown[] = [];
 
   const scope = buildVisitScopePredicate(actor, {
-    startIndex: params.length + 1,
+    startIndex,
     schoolCodeColumn: "v.school_code",
     schoolRegionColumn: "s.region",
   });
@@ -166,6 +214,136 @@ function buildOrderClause(sort: SortKey, dir: SortDirection): string {
   return `${sortColumn} ${dir.toUpperCase()}${nullsClause}, v.id DESC`;
 }
 
+function parseCount(value: string | number | null | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  return Number.parseInt(value || "0", 10);
+}
+
+function parseNullableNumber(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = typeof value === "number" ? value : Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function getSummaryStats(
+  actorEmail: string,
+  permission: UserPermission
+): Promise<SummaryStats> {
+  const { whereSql, params } = buildWhereClause(permission, actorEmail, 3);
+  const rows = await query<SummaryStatsRow>(
+    `WITH action_completion AS (
+       SELECT a.visit_id,
+              COUNT(DISTINCT CASE
+                WHEN a.status = 'completed' AND a.action_type = ANY($1::text[])
+                THEN a.action_type
+              END) AS completed_types
+       FROM lms_pm_school_visit_actions a
+       WHERE a.deleted_at IS NULL
+       GROUP BY a.visit_id
+     )
+     SELECT COUNT(*) AS total_visits,
+            COUNT(*) FILTER (WHERE v.status = 'in_progress') AS in_progress_count,
+            COUNT(*) FILTER (WHERE v.status = 'completed') AS completed_count,
+            COUNT(DISTINCT v.school_code) AS unique_schools,
+            COUNT(DISTINCT LOWER(v.pm_email)) AS unique_pms,
+            100.0 * SUM(COALESCE(ac.completed_types, 0))::numeric
+              / NULLIF(COUNT(*) * $2, 0) AS avg_action_completion
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     LEFT JOIN action_completion ac ON ac.visit_id = v.id
+     WHERE ${whereSql}`,
+    [ACTION_TYPE_VALUES, ACTION_TYPE_VALUES.length, ...params]
+  );
+
+  const row = rows[0];
+  return {
+    totalVisits: parseCount(row?.total_visits),
+    inProgressCount: parseCount(row?.in_progress_count),
+    completedCount: parseCount(row?.completed_count),
+    uniqueSchools: parseCount(row?.unique_schools),
+    uniquePms: parseCount(row?.unique_pms),
+    avgActionCompletion: parseNullableNumber(row?.avg_action_completion),
+  };
+}
+
+async function getPaginatedVisits(
+  actorEmail: string,
+  permission: UserPermission,
+  sort: SortKey,
+  dir: SortDirection,
+  page: number
+): Promise<SummaryVisit[]> {
+  const { whereSql, params } = buildWhereClause(permission, actorEmail);
+  const offset = (page - 1) * VISITS_PER_PAGE;
+  const limitIndex = params.length + 1;
+  const offsetIndex = params.length + 2;
+
+  return query<SummaryVisit>(
+    `SELECT v.id, v.school_code, s.name AS school_name, v.pm_email,
+            up.full_name AS pm_name, v.visit_date, v.status, v.inserted_at,
+            v.completed_at, v.start_lat, v.start_lng, v.start_accuracy,
+            v.end_lat, v.end_lng, v.end_accuracy
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
+     WHERE ${whereSql}
+     ORDER BY ${buildOrderClause(sort, dir)}
+     LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
+    [...params, VISITS_PER_PAGE, offset]
+  );
+}
+
+async function getActionRowsForVisits(visitIds: number[]): Promise<VisitActionRow[]> {
+  if (visitIds.length === 0) {
+    return [];
+  }
+
+  return query<VisitActionRow>(
+    `SELECT visit_id, action_type, status
+     FROM lms_pm_school_visit_actions
+     WHERE visit_id = ANY($1) AND deleted_at IS NULL`,
+    [visitIds]
+  );
+}
+
+function summarizeActions(actions: VisitActionRow[]): VisitActionSummary {
+  const rollup = rollupActionTypes(actions);
+  const countStatuses = (statuses: ActionTypeRollupStatus[]) => ACTION_TYPE_VALUES.filter(
+    (actionType: ActionType) => statuses.includes(rollup[actionType])
+  ).length;
+  const completedTypes = countStatuses(["completed"]);
+  const totalActions = actions.length;
+
+  return {
+    totalActions,
+    completedActions: actions.filter((action) => action.status === "completed").length,
+    completedTypes,
+    inProgressTypes: countStatuses(["pending", "in_progress"]),
+    notStartedTypes: countStatuses(["not_started"]),
+    completionPercent: totalActions === 0
+      ? null
+      : (completedTypes / ACTION_TYPE_VALUES.length) * 100,
+  };
+}
+
+function buildActionSummaryMap(visits: SummaryVisit[], actions: VisitActionRow[]): Map<number, VisitActionSummary> {
+  const actionsByVisit = new Map<number, VisitActionRow[]>();
+
+  for (const action of actions) {
+    const visitId = Number(action.visit_id);
+    actionsByVisit.set(visitId, [...(actionsByVisit.get(visitId) || []), action]);
+  }
+
+  return new Map(visits.map((visit) => [
+    visit.id,
+    summarizeActions(actionsByVisit.get(visit.id) || []),
+  ]));
+}
+
 async function getSummaryVisits(
   actorEmail: string,
   permission: UserPermission,
@@ -173,39 +351,20 @@ async function getSummaryVisits(
 ): Promise<SummaryResult> {
   const { sort, dir } = normalizeSort(searchParams.sort, searchParams.dir);
   const requestedPage = normalizePage(searchParams.page);
-  const { whereSql, params } = buildWhereClause(permission, actorEmail);
-
-  const countRows = await query<{ total: string }>(
-    `SELECT COUNT(*) AS total
-     FROM lms_pm_school_visits v
-     LEFT JOIN school s ON s.code = v.school_code
-     WHERE ${whereSql}`,
-    params
-  );
-  const totalCount = Number.parseInt(countRows[0]?.total || "0", 10);
+  const [stats, initialVisits] = await Promise.all([
+    getSummaryStats(actorEmail, permission),
+    getPaginatedVisits(actorEmail, permission, sort, dir, requestedPage),
+  ]);
+  const totalCount = stats.totalVisits;
   const totalPages = Math.max(1, Math.ceil(totalCount / VISITS_PER_PAGE));
   const currentPage = Math.min(requestedPage, totalPages);
-  const offset = (currentPage - 1) * VISITS_PER_PAGE;
-  const limitIndex = params.length + 1;
-  const offsetIndex = params.length + 2;
+  const visits = totalCount > 0 && currentPage !== requestedPage
+    ? await getPaginatedVisits(actorEmail, permission, sort, dir, currentPage)
+    : initialVisits;
+  const actionRows = await getActionRowsForVisits(visits.map((visit) => visit.id));
+  const actionSummaries = buildActionSummaryMap(visits, actionRows);
 
-  const visits = totalCount === 0
-    ? []
-    : await query<SummaryVisit>(
-      `SELECT v.id, v.school_code, s.name AS school_name, v.pm_email,
-              up.full_name AS pm_name, v.visit_date, v.status, v.inserted_at,
-              v.completed_at, v.start_lat, v.start_lng, v.start_accuracy,
-              v.end_lat, v.end_lng, v.end_accuracy
-       FROM lms_pm_school_visits v
-       LEFT JOIN school s ON s.code = v.school_code
-       LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
-       WHERE ${whereSql}
-       ORDER BY ${buildOrderClause(sort, dir)}
-       LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
-      [...params, VISITS_PER_PAGE, offset]
-    );
-
-  return { visits, totalCount, currentPage, totalPages, sort, dir };
+  return { visits, stats, actionSummaries, totalCount, currentPage, totalPages, sort, dir };
 }
 
 function sortHref(column: SortKey, currentSort: SortKey, currentDir: SortDirection): string {
@@ -288,7 +447,38 @@ function PaginationControls({
   );
 }
 
-function VisitMobileCard({ visit }: { visit: SummaryVisit }) {
+function formatActionCounts(summary: VisitActionSummary): string {
+  return `${summary.totalActions} total, ${summary.completedActions} completed`;
+}
+
+function formatActionTypeBreakdown(summary: VisitActionSummary): string {
+  return `${summary.completedTypes}/${ACTION_TYPE_VALUES.length} complete, ${summary.inProgressTypes}/${ACTION_TYPE_VALUES.length} in-progress, ${summary.notStartedTypes}/${ACTION_TYPE_VALUES.length} not started`;
+}
+
+function formatMobileActionSummary(summary: VisitActionSummary): string {
+  return `${summary.completedTypes}/${ACTION_TYPE_VALUES.length} complete`;
+}
+
+function StatCards({ stats }: { stats: SummaryStats }) {
+  return (
+    <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-6">
+      <StatCard label="Total Visits" value={stats.totalVisits} size="sm" />
+      <StatCard label="In Progress" value={stats.inProgressCount} size="sm" />
+      <StatCard label="Completed" value={stats.completedCount} size="sm" />
+      <StatCard label="Unique Schools" value={stats.uniqueSchools} size="sm" />
+      <StatCard label="Unique PMs" value={stats.uniquePms} size="sm" />
+      <StatCard label="Avg Completion" value={formatPercent(stats.avgActionCompletion)} size="sm" />
+    </div>
+  );
+}
+
+function VisitMobileCard({
+  visit,
+  actionSummary,
+}: {
+  visit: SummaryVisit;
+  actionSummary: VisitActionSummary;
+}) {
   return (
     <Link href={`/school-visit-summary/${visit.id}`} aria-label="View visit">
       <Card elevation="sm" className="p-4">
@@ -304,6 +494,7 @@ function VisitMobileCard({ visit }: { visit: SummaryVisit }) {
         <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono text-text-muted">
           <span>{formatDate(visit.visit_date)}</span>
           <span>{formatDuration(visit)}</span>
+          <span>{formatMobileActionSummary(actionSummary)}</span>
         </div>
       </Card>
     </Link>
@@ -312,10 +503,12 @@ function VisitMobileCard({ visit }: { visit: SummaryVisit }) {
 
 function VisitDesktopTable({
   visits,
+  actionSummaries,
   sort,
   dir,
 }: {
   visits: SummaryVisit[];
+  actionSummaries: Map<number, VisitActionSummary>;
   sort: SortKey;
   dir: SortDirection;
 }) {
@@ -351,55 +544,77 @@ function VisitDesktopTable({
             <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
               End GPS
             </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              Actions
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              Action %
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              Action Types
+            </th>
             <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-text-muted">
               Detail
             </th>
           </tr>
         </thead>
         <tbody className="bg-bg-card">
-          {visits.map((visit) => (
-            <tr key={visit.id} className="border-b border-border/40 hover:bg-hover-bg">
-              <td className="whitespace-nowrap px-4 py-4 text-sm font-medium text-text-primary">
-                {formatSchool(visit)}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-sm text-text-secondary">
-                <div>{formatPm(visit)}</div>
-                {visit.pm_name && <div className="text-xs text-text-muted">{visit.pm_email}</div>}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
-                {formatDate(visit.visit_date)}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4">
-                <span className={`inline-flex ${statusBadgeClass(visit.status)}`}>
-                  {formatStatus(visit.status)}
-                </span>
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
-                {formatTimestamp(visit.inserted_at)}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
-                {formatTimestamp(visit.completed_at)}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
-                {formatDuration(visit)}
-              </td>
-              <td className="whitespace-nowrap px-4 py-4">
-                <GpsMapLink lat={visit.start_lat} lng={visit.start_lng} accuracy={visit.start_accuracy} />
-              </td>
-              <td className="whitespace-nowrap px-4 py-4">
-                <GpsMapLink lat={visit.end_lat} lng={visit.end_lng} accuracy={visit.end_accuracy} />
-              </td>
-              <td className="whitespace-nowrap px-4 py-4 text-right text-sm">
-                <Link
-                  href={`/school-visit-summary/${visit.id}`}
-                  aria-label="View visit"
-                  className="font-bold uppercase text-accent hover:text-accent-hover"
-                >
-                  View
-                </Link>
-              </td>
-            </tr>
-          ))}
+          {visits.map((visit) => {
+            const actionSummary = actionSummaries.get(visit.id) || summarizeActions([]);
+
+            return (
+              <tr key={visit.id} className="border-b border-border/40 hover:bg-hover-bg">
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-medium text-text-primary">
+                  {formatSchool(visit)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm text-text-secondary">
+                  <div>{formatPm(visit)}</div>
+                  {visit.pm_name && <div className="text-xs text-text-muted">{visit.pm_email}</div>}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatDate(visit.visit_date)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4">
+                  <span className={`inline-flex ${statusBadgeClass(visit.status)}`}>
+                    {formatStatus(visit.status)}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatTimestamp(visit.inserted_at)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatTimestamp(visit.completed_at)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatDuration(visit)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4">
+                  <GpsMapLink lat={visit.start_lat} lng={visit.start_lng} accuracy={visit.start_accuracy} />
+                </td>
+                <td className="whitespace-nowrap px-4 py-4">
+                  <GpsMapLink lat={visit.end_lat} lng={visit.end_lng} accuracy={visit.end_accuracy} />
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatActionCounts(actionSummary)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatPercent(actionSummary.completionPercent)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                  {formatActionTypeBreakdown(actionSummary)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-4 text-right text-sm">
+                  <Link
+                    href={`/school-visit-summary/${visit.id}`}
+                    aria-label="View visit"
+                    className="font-bold uppercase text-accent hover:text-accent-hover"
+                  >
+                    View
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </Card>
@@ -442,7 +657,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
     redirect("/dashboard");
   }
 
-  const { visits, totalCount, currentPage, totalPages, sort, dir } = await getSummaryVisits(
+  const { visits, stats, actionSummaries, totalCount, currentPage, totalPages, sort, dir } = await getSummaryVisits(
     session.user.email,
     permission,
     rawSearchParams
@@ -500,6 +715,8 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
           </div>
         </div>
 
+        <StatCards stats={stats} />
+
         {visits.length === 0 ? (
           <div className="py-12 text-center">
             <div className="text-text-muted uppercase tracking-wide">No visits found</div>
@@ -508,11 +725,20 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
           <>
             <div className="space-y-3 sm:hidden">
               {visits.map((visit) => (
-                <VisitMobileCard key={visit.id} visit={visit} />
+                <VisitMobileCard
+                  key={visit.id}
+                  visit={visit}
+                  actionSummary={actionSummaries.get(visit.id) || summarizeActions([])}
+                />
               ))}
             </div>
 
-            <VisitDesktopTable visits={visits} sort={sort} dir={dir} />
+            <VisitDesktopTable
+              visits={visits}
+              actionSummaries={actionSummaries}
+              sort={sort}
+              dir={dir}
+            />
 
             <PaginationControls
               currentPage={currentPage}

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -1,0 +1,528 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import GpsMapLink from "@/components/visits/GpsMapLink";
+import { Card } from "@/components/ui";
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
+import { statusBadgeClass } from "@/lib/visit-actions";
+import {
+  buildVisitScopePredicate,
+  buildVisitsActor,
+  isScopedVisitsRole,
+} from "@/lib/visits-policy";
+
+const VISITS_PER_PAGE = 20;
+
+interface SummaryVisit {
+  id: number;
+  school_code: string;
+  school_name: string | null;
+  pm_email: string;
+  pm_name: string | null;
+  visit_date: string;
+  status: string;
+  inserted_at: string;
+  completed_at: string | null;
+  start_lat: number | string | null;
+  start_lng: number | string | null;
+  start_accuracy: number | string | null;
+  end_lat: number | string | null;
+  end_lng: number | string | null;
+  end_accuracy: number | string | null;
+}
+
+interface SummaryResult {
+  visits: SummaryVisit[];
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+  sort: SortKey;
+  dir: SortDirection;
+}
+
+interface PageProps {
+  searchParams: Promise<{
+    sort?: string;
+    dir?: string;
+    page?: string;
+  }>;
+}
+
+type SortKey = "visit_date" | "school_name" | "pm_email" | "status" | "inserted_at" | "completed_at";
+type SortDirection = "asc" | "desc";
+
+const SORT_COLUMNS: Record<SortKey, { sql: string; defaultDir: SortDirection }> = {
+  visit_date: { sql: "v.visit_date", defaultDir: "desc" },
+  school_name: { sql: "s.name", defaultDir: "asc" },
+  pm_email: { sql: "v.pm_email", defaultDir: "asc" },
+  status: { sql: "v.status", defaultDir: "asc" },
+  inserted_at: { sql: "v.inserted_at", defaultDir: "desc" },
+  completed_at: { sql: "v.completed_at", defaultDir: "desc" },
+};
+
+function isSortKey(value: string | undefined): value is SortKey {
+  return Boolean(value && value in SORT_COLUMNS);
+}
+
+function normalizeSort(sortParam?: string, dirParam?: string): { sort: SortKey; dir: SortDirection } {
+  const sort = isSortKey(sortParam) ? sortParam : "visit_date";
+  const dir = dirParam === "asc" || dirParam === "desc"
+    ? dirParam
+    : SORT_COLUMNS[sort].defaultDir;
+
+  return { sort, dir };
+}
+
+function normalizePage(pageParam?: string): number {
+  const parsed = Number.parseInt(pageParam || "1", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "Asia/Kolkata",
+  });
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+
+  return new Date(value).toLocaleString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Kolkata",
+  });
+}
+
+function formatStatus(status: string): string {
+  if (status === "completed") {
+    return "Completed";
+  }
+  if (status === "in_progress") {
+    return "In Progress";
+  }
+  return status;
+}
+
+function formatSchool(visit: SummaryVisit): string {
+  return visit.school_name ? `${visit.school_name} (${visit.school_code})` : visit.school_code;
+}
+
+function formatPm(visit: SummaryVisit): string {
+  return visit.pm_name || visit.pm_email;
+}
+
+function formatDuration(visit: SummaryVisit, now = new Date()): string {
+  const start = new Date(visit.inserted_at).getTime();
+  const end = visit.completed_at ? new Date(visit.completed_at).getTime() : now.getTime();
+  const minutes = Math.max(0, Math.floor((end - start) / 60000));
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function buildWhereClause(
+  permission: UserPermission,
+  actorEmail: string
+): { whereSql: string; params: unknown[] } {
+  const actor = buildVisitsActor(actorEmail, permission);
+  const predicates = ["v.deleted_at IS NULL"];
+  const params: unknown[] = [];
+
+  const scope = buildVisitScopePredicate(actor, {
+    startIndex: params.length + 1,
+    schoolCodeColumn: "v.school_code",
+    schoolRegionColumn: "s.region",
+  });
+
+  if (scope.clause) {
+    predicates.push(scope.clause);
+    params.push(...scope.params);
+  }
+
+  return {
+    whereSql: predicates.join(" AND "),
+    params,
+  };
+}
+
+function buildOrderClause(sort: SortKey, dir: SortDirection): string {
+  const sortColumn = SORT_COLUMNS[sort].sql;
+  const nullsClause = sort === "completed_at" && dir === "asc" ? " NULLS LAST" : "";
+
+  return `${sortColumn} ${dir.toUpperCase()}${nullsClause}, v.id DESC`;
+}
+
+async function getSummaryVisits(
+  actorEmail: string,
+  permission: UserPermission,
+  searchParams: { sort?: string; dir?: string; page?: string }
+): Promise<SummaryResult> {
+  const { sort, dir } = normalizeSort(searchParams.sort, searchParams.dir);
+  const requestedPage = normalizePage(searchParams.page);
+  const { whereSql, params } = buildWhereClause(permission, actorEmail);
+
+  const countRows = await query<{ total: string }>(
+    `SELECT COUNT(*) AS total
+     FROM lms_pm_school_visits v
+     LEFT JOIN school s ON s.code = v.school_code
+     WHERE ${whereSql}`,
+    params
+  );
+  const totalCount = Number.parseInt(countRows[0]?.total || "0", 10);
+  const totalPages = Math.max(1, Math.ceil(totalCount / VISITS_PER_PAGE));
+  const currentPage = Math.min(requestedPage, totalPages);
+  const offset = (currentPage - 1) * VISITS_PER_PAGE;
+  const limitIndex = params.length + 1;
+  const offsetIndex = params.length + 2;
+
+  const visits = totalCount === 0
+    ? []
+    : await query<SummaryVisit>(
+      `SELECT v.id, v.school_code, s.name AS school_name, v.pm_email,
+              up.full_name AS pm_name, v.visit_date, v.status, v.inserted_at,
+              v.completed_at, v.start_lat, v.start_lng, v.start_accuracy,
+              v.end_lat, v.end_lng, v.end_accuracy
+       FROM lms_pm_school_visits v
+       LEFT JOIN school s ON s.code = v.school_code
+       LEFT JOIN user_permission up ON LOWER(up.email) = LOWER(v.pm_email)
+       WHERE ${whereSql}
+       ORDER BY ${buildOrderClause(sort, dir)}
+       LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
+      [...params, VISITS_PER_PAGE, offset]
+    );
+
+  return { visits, totalCount, currentPage, totalPages, sort, dir };
+}
+
+function sortHref(column: SortKey, currentSort: SortKey, currentDir: SortDirection): string {
+  const dir = column === currentSort
+    ? currentDir === "asc" ? "desc" : "asc"
+    : SORT_COLUMNS[column].defaultDir;
+  const params = new URLSearchParams({ sort: column, dir });
+  return `/school-visit-summary?${params.toString()}`;
+}
+
+function SortHeader({
+  column,
+  currentSort,
+  currentDir,
+  children,
+}: {
+  column: SortKey;
+  currentSort: SortKey;
+  currentDir: SortDirection;
+  children: React.ReactNode;
+}) {
+  const active = column === currentSort;
+
+  return (
+    <Link
+      href={sortHref(column, currentSort, currentDir)}
+      className="inline-flex items-center gap-1 hover:text-text-primary"
+    >
+      {children}
+      {active && <span aria-hidden="true">{currentDir === "asc" ? "↑" : "↓"}</span>}
+    </Link>
+  );
+}
+
+function PaginationControls({
+  currentPage,
+  totalPages,
+  sort,
+  dir,
+}: {
+  currentPage: number;
+  totalPages: number;
+  sort: SortKey;
+  dir: SortDirection;
+}) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const hrefFor = (page: number) => {
+    const params = new URLSearchParams({ sort, dir });
+    if (page > 1) {
+      params.set("page", String(page));
+    }
+    return `/school-visit-summary?${params.toString()}`;
+  };
+
+  return (
+    <nav className="mt-6 flex items-center justify-between border-t border-border bg-bg-card px-4 py-3 text-sm text-text-secondary">
+      <span className="font-mono">
+        Page {currentPage} of {totalPages}
+      </span>
+      <div className="flex gap-2">
+        {currentPage > 1 ? (
+          <Link href={hrefFor(currentPage - 1)} className="border border-border px-3 py-2 font-bold uppercase hover:bg-hover-bg">
+            Previous
+          </Link>
+        ) : (
+          <span className="border border-border px-3 py-2 text-text-muted">Previous</span>
+        )}
+        {currentPage < totalPages ? (
+          <Link href={hrefFor(currentPage + 1)} className="border border-border px-3 py-2 font-bold uppercase hover:bg-hover-bg">
+            Next
+          </Link>
+        ) : (
+          <span className="border border-border px-3 py-2 text-text-muted">Next</span>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+function VisitMobileCard({ visit }: { visit: SummaryVisit }) {
+  return (
+    <Link href={`/school-visit-summary/${visit.id}`} aria-label="View visit">
+      <Card elevation="sm" className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-sm font-bold text-text-primary">{formatSchool(visit)}</div>
+            <div className="mt-1 text-xs text-text-muted">{formatPm(visit)}</div>
+          </div>
+          <span className={`inline-flex shrink-0 ${statusBadgeClass(visit.status)}`}>
+            {formatStatus(visit.status)}
+          </span>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono text-text-muted">
+          <span>{formatDate(visit.visit_date)}</span>
+          <span>{formatDuration(visit)}</span>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+function VisitDesktopTable({
+  visits,
+  sort,
+  dir,
+}: {
+  visits: SummaryVisit[];
+  sort: SortKey;
+  dir: SortDirection;
+}) {
+  return (
+    <Card elevation="sm" className="hidden overflow-x-auto sm:block">
+      <table className="min-w-full">
+        <thead className="border-b-2 border-border-accent bg-bg-card-alt">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="school_name" currentSort={sort} currentDir={dir}>School</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="pm_email" currentSort={sort} currentDir={dir}>PM</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="visit_date" currentSort={sort} currentDir={dir}>Visit Date</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="status" currentSort={sort} currentDir={dir}>Status</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="inserted_at" currentSort={sort} currentDir={dir}>Started At</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              <SortHeader column="completed_at" currentSort={sort} currentDir={dir}>Completed At</SortHeader>
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              Duration
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              Start GPS
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-muted">
+              End GPS
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-text-muted">
+              Detail
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-bg-card">
+          {visits.map((visit) => (
+            <tr key={visit.id} className="border-b border-border/40 hover:bg-hover-bg">
+              <td className="whitespace-nowrap px-4 py-4 text-sm font-medium text-text-primary">
+                {formatSchool(visit)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-sm text-text-secondary">
+                <div>{formatPm(visit)}</div>
+                {visit.pm_name && <div className="text-xs text-text-muted">{visit.pm_email}</div>}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                {formatDate(visit.visit_date)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4">
+                <span className={`inline-flex ${statusBadgeClass(visit.status)}`}>
+                  {formatStatus(visit.status)}
+                </span>
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                {formatTimestamp(visit.inserted_at)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                {formatTimestamp(visit.completed_at)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-sm font-mono text-text-secondary">
+                {formatDuration(visit)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-4">
+                <GpsMapLink lat={visit.start_lat} lng={visit.start_lng} accuracy={visit.start_accuracy} />
+              </td>
+              <td className="whitespace-nowrap px-4 py-4">
+                <GpsMapLink lat={visit.end_lat} lng={visit.end_lng} accuracy={visit.end_accuracy} />
+              </td>
+              <td className="whitespace-nowrap px-4 py-4 text-right text-sm">
+                <Link
+                  href={`/school-visit-summary/${visit.id}`}
+                  aria-label="View visit"
+                  className="font-bold uppercase text-accent hover:text-accent-hover"
+                >
+                  View
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}
+
+export default async function SchoolVisitSummaryPage({ searchParams }: PageProps) {
+  const session = await getServerSession(authOptions);
+  const rawSearchParams = await searchParams;
+
+  if (!session) {
+    redirect("/");
+  }
+
+  if (session.isPasscodeUser) {
+    if (session.schoolCode) {
+      redirect(`/school/${session.schoolCode}`);
+    }
+    redirect("/dashboard");
+  }
+
+  if (!session.user?.email) {
+    redirect("/");
+  }
+
+  const permission = await getUserPermission(session.user.email);
+  if (!permission) {
+    redirect("/dashboard");
+  }
+
+  if (!getFeatureAccess(permission, "visits").canView) {
+    redirect("/dashboard");
+  }
+
+  const actor = buildVisitsActor(session.user.email, permission);
+  if (!isScopedVisitsRole(actor)) {
+    if (actor.role === "program_manager") {
+      redirect("/visits");
+    }
+    redirect("/dashboard");
+  }
+
+  const { visits, totalCount, currentPage, totalPages, sort, dir } = await getSummaryVisits(
+    session.user.email,
+    permission,
+    rawSearchParams
+  );
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <header className="border-b border-border bg-bg-card shadow-sm">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-y-2 px-4 py-3 sm:px-6 lg:px-8">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-6">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp"
+              alt="Avanti Fellows"
+              className="h-8 shrink-0 sm:h-10"
+            />
+            <nav className="flex gap-3 sm:gap-4">
+              <Link
+                href="/dashboard"
+                className="pb-1 text-sm font-medium uppercase tracking-wide text-text-muted hover:text-text-primary"
+              >
+                Schools
+              </Link>
+              <Link
+                href="/school-visit-summary"
+                className="border-b-2 border-accent pb-1 text-sm font-bold uppercase tracking-wide text-text-primary"
+              >
+                Visit Summary
+              </Link>
+            </nav>
+          </div>
+          <div className="flex items-center gap-3 sm:gap-4">
+            {permission.role === "admin" && (
+              <Link href="/admin" className="text-sm font-bold uppercase text-accent hover:text-accent-hover">
+                Admin
+              </Link>
+            )}
+            <span className="hidden font-mono text-sm text-text-muted sm:inline">{session.user.email}</span>
+            <Link href="/api/auth/signout" className="text-sm font-bold text-danger hover:text-danger/80">
+              Sign out
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-6 flex flex-col gap-2 border-b-4 border-border-accent pb-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
+              School Visit Summary
+            </h1>
+            <p className="mt-1 text-sm text-text-secondary">
+              {totalCount} visit{totalCount === 1 ? "" : "s"} found
+            </p>
+          </div>
+        </div>
+
+        {visits.length === 0 ? (
+          <div className="py-12 text-center">
+            <div className="text-text-muted uppercase tracking-wide">No visits found</div>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-3 sm:hidden">
+              {visits.map((visit) => (
+                <VisitMobileCard key={visit.id} visit={visit} />
+              ))}
+            </div>
+
+            <VisitDesktopTable visits={visits} sort={sort} dir={dir} />
+
+            <PaginationControls
+              currentPage={currentPage}
+              totalPages={totalPages}
+              sort={sort}
+              dir={dir}
+            />
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -517,16 +517,16 @@ function summarizeActions(actions: VisitActionRow[]): VisitActionSummary {
 }
 
 function buildActionSummaryMap(visits: SummaryVisit[], actions: VisitActionRow[]): Map<number, VisitActionSummary> {
-  const actionsByVisit = new Map<number, VisitActionRow[]>();
+  const actionsByVisit = new Map<string, VisitActionRow[]>();
 
   for (const action of actions) {
-    const visitId = Number(action.visit_id);
+    const visitId = String(action.visit_id);
     actionsByVisit.set(visitId, [...(actionsByVisit.get(visitId) || []), action]);
   }
 
   return new Map(visits.map((visit) => [
     visit.id,
-    summarizeActions(actionsByVisit.get(visit.id) || []),
+    summarizeActions(actionsByVisit.get(String(visit.id)) || []),
   ]));
 }
 

--- a/src/app/visits/[id]/actions/[actionId]/page.test.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.test.tsx
@@ -117,8 +117,11 @@ function makeAction(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function pageProps(id = "1", actionId = "101") {
-  return { params: Promise.resolve({ id, actionId }) };
+function pageProps(id = "1", actionId = "101", from?: string) {
+  return {
+    params: Promise.resolve({ id, actionId }),
+    searchParams: Promise.resolve(from ? { from } : {}),
+  };
 }
 
 function setupPmAuth() {
@@ -174,6 +177,77 @@ describe("VisitActionDetailPage", () => {
     expect(screen.getByText("Classroom Observation Details")).toBeInTheDocument();
     expect(screen.getByTestId("action-renderer-classroom_observation")).toBeInTheDocument();
     expect(screen.getByTestId("classroom-observation-form")).toBeInTheDocument();
+  });
+
+  it("links back to the summary detail page when opened from summary", async () => {
+    setupPmAuth();
+    mockQuery
+      .mockResolvedValueOnce([makeVisit()])
+      .mockResolvedValueOnce([makeAction()]);
+
+    const jsx = await VisitActionDetailPage(pageProps("1", "101", "summary"));
+    render(jsx);
+
+    const backLink = screen.getByRole("link", { name: /Back to Visit Summary/i });
+    expect(backLink).toHaveAttribute("href", "/school-visit-summary/1");
+  });
+
+  it("keeps the default visit breadcrumb when from is missing or invalid", async () => {
+    setupPmAuth();
+    mockQuery
+      .mockResolvedValueOnce([makeVisit()])
+      .mockResolvedValueOnce([makeAction()]);
+
+    const jsx = await VisitActionDetailPage(pageProps("1", "101", "dashboard"));
+    render(jsx);
+
+    const backLink = screen.getByRole("link", { name: /Back to Visit$/i });
+    expect(backLink).toHaveAttribute("href", "/visits/1");
+    expect(screen.queryByRole("link", { name: /Back to Visit Summary/i })).not.toBeInTheDocument();
+  });
+
+  it("links visit-not-found summary traffic back to the summary list", async () => {
+    setupPmAuth();
+    mockQuery.mockResolvedValueOnce([]);
+
+    const jsx = await VisitActionDetailPage(pageProps("404", "101", "summary"));
+    render(jsx);
+
+    expect(screen.getByText("Visit not found")).toBeInTheDocument();
+    const backLink = screen.getByRole("link", { name: /Back to Visit Summary/i });
+    expect(backLink).toHaveAttribute("href", "/school-visit-summary");
+  });
+
+  it("links forbidden summary traffic back to the summary list", async () => {
+    setupPmAuth();
+    mockQuery
+      .mockResolvedValueOnce([
+        makeVisit({
+          school_code: "SC999",
+          school_region: "South",
+          pm_email: "other-pm@avantifellows.org",
+        }),
+      ])
+      .mockResolvedValueOnce([makeAction()]);
+
+    const jsx = await VisitActionDetailPage(pageProps("1", "101", "summary"));
+    render(jsx);
+
+    expect(screen.getByText("You do not have access to this action.")).toBeInTheDocument();
+    const backLink = screen.getByRole("link", { name: /Back to Visit Summary/i });
+    expect(backLink).toHaveAttribute("href", "/school-visit-summary");
+  });
+
+  it("links action-not-found summary traffic back to the summary list", async () => {
+    setupPmAuth();
+    mockQuery.mockResolvedValueOnce([makeVisit()]).mockResolvedValueOnce([]);
+
+    const jsx = await VisitActionDetailPage(pageProps("1", "999", "summary"));
+    render(jsx);
+
+    expect(screen.getByText("Action not found")).toBeInTheDocument();
+    const backLink = screen.getByRole("link", { name: /Back to Visit Summary/i });
+    expect(backLink).toHaveAttribute("href", "/school-visit-summary");
   });
 
   it("shows unsupported classroom rubric warning and hides save/end actions", async () => {

--- a/src/app/visits/[id]/actions/[actionId]/page.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.tsx
@@ -162,11 +162,13 @@ export default async function VisitActionDetailPage({ params, searchParams }: Pa
     return notFoundState("Action not found", "This action may have been deleted.", fallbackBackHref);
   }
 
-  const canWrite = canEditVisit(actor, {
-    pmEmail: detail.visit.pm_email,
-    schoolCode: detail.visit.school_code,
-    schoolRegion: detail.visit.school_region,
-  });
+  const canWrite = backToSummary
+    ? false
+    : canEditVisit(actor, {
+        pmEmail: detail.visit.pm_email,
+        schoolCode: detail.visit.school_code,
+        schoolRegion: detail.visit.school_region,
+      });
 
   return (
     <main className="min-h-screen bg-bg">
@@ -179,6 +181,12 @@ export default async function VisitActionDetailPage({ params, searchParams }: Pa
             {backToSummary ? "← Back to Visit Summary" : "← Back to Visit"}
           </Link>
         </div>
+
+        {backToSummary && (
+          <div className="mb-4 border border-border bg-bg-card-alt px-4 py-3 text-sm text-text-muted">
+            View-only mode — editing is not available from the summary view.
+          </div>
+        )}
 
         <ActionDetailForm
           visitId={detail.visit.id}

--- a/src/app/visits/[id]/actions/[actionId]/page.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.tsx
@@ -38,6 +38,7 @@ interface ActionDetail {
 
 interface PageProps {
   params: Promise<{ id: string; actionId: string }>;
+  searchParams: Promise<{ from?: string }>;
 }
 
 async function getActionDetail(visitId: string, actionId: string): Promise<ActionDetail> {
@@ -71,13 +72,17 @@ async function getActionDetail(visitId: string, actionId: string): Promise<Actio
   };
 }
 
-function notFoundState(title: string, description: string) {
+function backLinkLabel(backHref: string) {
+  return backHref === "/school-visit-summary" ? "← Back to Visit Summary" : "← Back to Visits";
+}
+
+function notFoundState(title: string, description: string, backHref = "/visits") {
   return (
     <main className="min-h-screen bg-bg">
       <div className="px-4 sm:px-6 md:px-16 lg:px-32 xl:px-64 2xl:px-96 py-6 md:py-8">
         <div className="mb-4">
-          <Link href="/visits" className="text-sm text-accent hover:text-accent-hover font-semibold uppercase">
-            &larr; Back to Visits
+          <Link href={backHref} className="text-sm text-accent hover:text-accent-hover font-semibold uppercase">
+            {backLinkLabel(backHref)}
           </Link>
         </div>
         <div className="border border-danger/20 bg-danger-bg p-4" role="alert">
@@ -89,13 +94,13 @@ function notFoundState(title: string, description: string) {
   );
 }
 
-function forbiddenState() {
+function forbiddenState(backHref = "/visits") {
   return (
     <main className="min-h-screen bg-bg">
       <div className="px-4 sm:px-6 md:px-16 lg:px-32 xl:px-64 2xl:px-96 py-6 md:py-8">
         <div className="mb-4">
-          <Link href="/visits" className="text-sm text-accent hover:text-accent-hover font-semibold uppercase">
-            &larr; Back to Visits
+          <Link href={backHref} className="text-sm text-accent hover:text-accent-hover font-semibold uppercase">
+            {backLinkLabel(backHref)}
           </Link>
         </div>
         <div className="border border-warning-border bg-warning-bg p-4" role="alert">
@@ -106,8 +111,11 @@ function forbiddenState() {
   );
 }
 
-export default async function VisitActionDetailPage({ params }: PageProps) {
+export default async function VisitActionDetailPage({ params, searchParams }: PageProps) {
   const { id, actionId } = await params;
+  const { from } = await searchParams;
+  const backToSummary = from === "summary";
+  const fallbackBackHref = backToSummary ? "/school-visit-summary" : "/visits";
   const session = await getServerSession(authOptions);
 
   if (!session) {
@@ -136,7 +144,7 @@ export default async function VisitActionDetailPage({ params }: PageProps) {
 
   const detail = await getActionDetail(id, actionId);
   if (!detail.visit) {
-    return notFoundState("Visit not found", "The requested visit does not exist.");
+    return notFoundState("Visit not found", "The requested visit does not exist.", fallbackBackHref);
   }
 
   const actor = buildVisitsActor(session.user.email, permission);
@@ -147,11 +155,11 @@ export default async function VisitActionDetailPage({ params }: PageProps) {
   });
 
   if (!canView) {
-    return forbiddenState();
+    return forbiddenState(fallbackBackHref);
   }
 
   if (!detail.action) {
-    return notFoundState("Action not found", "This action may have been deleted.");
+    return notFoundState("Action not found", "This action may have been deleted.", fallbackBackHref);
   }
 
   const canWrite = canEditVisit(actor, {
@@ -164,8 +172,11 @@ export default async function VisitActionDetailPage({ params }: PageProps) {
     <main className="min-h-screen bg-bg">
       <div className="px-4 sm:px-6 md:px-16 lg:px-32 xl:px-64 2xl:px-96 py-6 md:py-8">
         <div className="sticky top-0 z-20 -mx-4 sm:-mx-6 md:-mx-16 lg:-mx-32 xl:-mx-64 2xl:-mx-96 px-4 sm:px-6 md:px-16 lg:px-32 xl:px-64 2xl:px-96 bg-bg py-3 mb-1">
-          <Link href={`/visits/${detail.visit.id}`} className="text-sm text-accent hover:text-accent-hover font-semibold uppercase">
-            &larr; Back to Visit
+          <Link
+            href={backToSummary ? `/school-visit-summary/${id}` : `/visits/${detail.visit.id}`}
+            className="text-sm text-accent hover:text-accent-hover font-semibold uppercase"
+          >
+            {backToSummary ? "← Back to Visit Summary" : "← Back to Visit"}
           </Link>
         </div>
 

--- a/src/app/visits/page.test.tsx
+++ b/src/app/visits/page.test.tsx
@@ -55,6 +55,13 @@ const passcodeSession = {
   isPasscodeUser: true,
   schoolCode: "70705",
 };
+const passcodeSessionWithoutSchool = {
+  user: {},
+  isPasscodeUser: true,
+};
+const teacherSession = {
+  user: { email: "teacher@avantifellows.org" },
+};
 
 const programManagerPermission = {
   email: "pm@avantifellows.org",
@@ -74,6 +81,13 @@ const programAdminPermission = {
   role: "program_admin",
   regions: ["AHMEDABAD"],
   read_only: true,
+};
+const teacherPermission = {
+  email: "teacher@avantifellows.org",
+  level: 1,
+  role: "teacher",
+  school_codes: ["SC001"],
+  read_only: false,
 };
 
 function setupAuth(permission = programManagerPermission) {
@@ -153,6 +167,15 @@ describe("VisitsListPage (server component)", () => {
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
+  it("redirects passcode users without a school code to the dashboard", async () => {
+    mockGetServerSession.mockResolvedValue(passcodeSessionWithoutSchool);
+
+    await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow("REDIRECT:/dashboard");
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    expect(mockGetUserPermission).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   it("redirects to /dashboard when permission is missing", async () => {
     mockGetServerSession.mockResolvedValue(pmSession);
     mockGetUserPermission.mockResolvedValue(null);
@@ -170,6 +193,61 @@ describe("VisitsListPage (server component)", () => {
     await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow("REDIRECT:/dashboard");
     expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
     expect(mockGetFeatureAccess).toHaveBeenCalledWith(programManagerPermission, "visits");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("redirects admin users with visit access to the school visit summary", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockGetUserPermission.mockResolvedValue(adminPermission);
+    mockGetFeatureAccess.mockReturnValue({ canView: true, canEdit: true });
+
+    await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow(
+      "REDIRECT:/school-visit-summary"
+    );
+    expect(mockRedirect).toHaveBeenCalledWith("/school-visit-summary");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("redirects program_admin users with visit access to the school visit summary", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "program-admin@avantifellows.org" },
+    });
+    mockGetUserPermission.mockResolvedValue(programAdminPermission);
+    mockGetFeatureAccess.mockReturnValue({ canView: true, canEdit: false });
+
+    await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow(
+      "REDIRECT:/school-visit-summary"
+    );
+    expect(mockRedirect).toHaveBeenCalledWith("/school-visit-summary");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("redirects NVS-only program_admin users to the dashboard before summary routing", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "nvs-only@avantifellows.org" },
+    });
+    mockGetUserPermission.mockResolvedValue({
+      ...programAdminPermission,
+      email: "nvs-only@avantifellows.org",
+      program_ids: [64],
+    });
+    mockGetFeatureAccess.mockReturnValue({ canView: false, canEdit: false });
+
+    await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow("REDIRECT:/dashboard");
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    expect(mockRedirect).not.toHaveBeenCalledWith("/school-visit-summary");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("redirects teachers to the dashboard", async () => {
+    mockGetServerSession.mockResolvedValue(teacherSession);
+    mockGetUserPermission.mockResolvedValue(teacherPermission);
+    mockGetFeatureAccess.mockReturnValue({ canView: false, canEdit: false });
+
+    await expect(VisitsListPage({ searchParams: defaultSearchParams })).rejects.toThrow("REDIRECT:/dashboard");
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
@@ -194,6 +272,17 @@ describe("VisitsListPage (server component)", () => {
     expect(deleteButtons).toHaveLength(2);
     expect(deleteButtons[0]).toHaveAttribute("data-visit-id", "1");
     expect(deleteButtons[0]).toHaveAttribute("data-mode", "list");
+  });
+
+  it("keeps Schools in the PM header and removes the Visits nav link", async () => {
+    setupAuth();
+    mockQuery.mockResolvedValue([inProgressVisit]);
+
+    const jsx = await VisitsListPage({ searchParams: defaultSearchParams });
+    render(jsx);
+
+    expect(screen.getByRole("link", { name: "Schools" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.queryByRole("link", { name: "Visits" })).not.toBeInTheDocument();
   });
 
   it("renders completed visits with View links and uses completed_at timestamp", async () => {
@@ -273,82 +362,4 @@ describe("VisitsListPage (server component)", () => {
     expect(params).toEqual(["pm@avantifellows.org"]);
   });
 
-  it("renders delete buttons for admin on in-progress visits", async () => {
-    setupAuth(adminPermission);
-    mockQuery.mockResolvedValue([inProgressVisit]);
-
-    const jsx = await VisitsListPage({ searchParams: defaultSearchParams });
-    render(jsx);
-
-    expect(screen.getAllByTestId("delete-visit-button")).toHaveLength(2);
-  });
-
-  it("does not render delete buttons for program_admin", async () => {
-    setupAuth(programAdminPermission);
-    mockQuery.mockResolvedValue([inProgressVisit]);
-
-    const jsx = await VisitsListPage({ searchParams: defaultSearchParams });
-    render(jsx);
-
-    expect(screen.queryByTestId("delete-visit-button")).not.toBeInTheDocument();
-  });
-
-  it("shows scoped-role filters and maps admin filter query params", async () => {
-    setupAuth({
-      email: "admin@avantifellows.org",
-      level: 3,
-      role: "admin",
-      read_only: false,
-    });
-    mockQuery.mockResolvedValue([completedVisit]);
-
-    const jsx = await VisitsListPage({
-      searchParams: Promise.resolve({
-        school_code: "70705",
-        status: "completed",
-        pm_email: "pm2@avantifellows.org",
-      }),
-    });
-    render(jsx);
-
-    expect(screen.getByLabelText("School Code")).toHaveValue("70705");
-    expect(screen.getByLabelText("Status")).toHaveValue("completed");
-    expect(screen.getByLabelText("PM Email")).toHaveValue("pm2@avantifellows.org");
-
-    const [sql, params] = mockQuery.mock.calls[0];
-    expect(sql).toContain("LOWER(v.pm_email) = LOWER($1)");
-    expect(sql).toContain("v.school_code = $2");
-    expect(sql).toContain("v.status = $3");
-    expect(params).toEqual(["pm2@avantifellows.org", "70705", "completed"]);
-  });
-
-  it("shows scoped filters for program_admin and applies mandatory filter params with scope", async () => {
-    setupAuth({
-      email: "program-admin@avantifellows.org",
-      level: 2,
-      role: "program_admin",
-      regions: ["AHMEDABAD"],
-      read_only: false,
-    });
-    mockQuery.mockResolvedValue([completedVisit]);
-
-    const jsx = await VisitsListPage({
-      searchParams: Promise.resolve({
-        school_code: "70705",
-        status: "completed",
-        pm_email: "pm2@avantifellows.org",
-      }),
-    });
-    render(jsx);
-
-    expect(screen.getByLabelText("School Code")).toHaveValue("70705");
-    expect(screen.getByLabelText("Status")).toHaveValue("completed");
-    expect(screen.getByLabelText("PM Email")).toHaveValue("pm2@avantifellows.org");
-
-    const [sql, params] = mockQuery.mock.calls[0];
-    expect(sql).toContain("v.school_code = $2");
-    expect(sql).toContain("v.status = $3");
-    expect(sql).toContain("COALESCE(s.region, '') = ANY($4)");
-    expect(params).toEqual(["pm2@avantifellows.org", "70705", "completed", ["AHMEDABAD"]]);
-  });
 });

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -138,6 +138,10 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
     redirect("/dashboard");
   }
 
+  if (permission.role === "admin" || permission.role === "program_admin") {
+    redirect("/school-visit-summary");
+  }
+
   const filters = normalizeVisitFilters(rawSearchParams);
   const isScopedRole = permission.role === "admin" || permission.role === "program_admin";
   const scopedFilters: VisitFilters = {
@@ -162,15 +166,9 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
             <nav className="flex gap-4">
               <Link
                 href="/dashboard"
-                className="text-sm font-medium text-text-muted uppercase tracking-wide hover:text-text-primary pb-1"
-              >
-                Schools
-              </Link>
-              <Link
-                href="/visits"
                 className="text-sm font-bold text-text-primary uppercase tracking-wide border-b-2 border-accent pb-1"
               >
-                Visits
+                Schools
               </Link>
             </nav>
           </div>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/visits-policy";
 import Link from "next/link";
 import DeleteVisitButton from "@/components/visits/DeleteVisitButton";
-import { Card, Input, Select, FormLabel, Button } from "@/components/ui";
+import { Card } from "@/components/ui";
 
 interface Visit {
   id: number;
@@ -143,18 +143,16 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
   }
 
   const filters = normalizeVisitFilters(rawSearchParams);
-  const isScopedRole = permission.role === "admin" || permission.role === "program_admin";
   const scopedFilters: VisitFilters = {
     schoolCode: filters.schoolCode,
     status: filters.status,
-    pmEmail: isScopedRole ? filters.pmEmail : undefined,
   };
 
   const visits = await getVisits(session.user.email, permission, scopedFilters);
 
   const inProgress = visits.filter((v) => v.status === "in_progress");
   const completed = visits.filter((v) => v.status === "completed");
-  const canDeleteVisits = permission.role === "program_manager" || permission.role === "admin";
+  const canDeleteVisits = permission.role === "program_manager";
 
   return (
     <div className="min-h-screen bg-bg">
@@ -173,14 +171,6 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
             </nav>
           </div>
           <div className="flex items-center gap-4">
-            {permission.role === "admin" && (
-              <Link
-                href="/admin"
-                className="text-sm font-bold text-accent hover:text-accent-hover uppercase"
-              >
-                Admin
-              </Link>
-            )}
             <span className="text-sm text-text-muted font-mono hidden sm:inline">{session.user.email}</span>
             <Link
               href="/api/auth/signout"
@@ -199,67 +189,6 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
             {visits.length} total ({inProgress.length} in progress)
           </div>
         </div>
-
-        {isScopedRole && (
-          <form method="get">
-          <Card elevation="sm" className="mb-6 p-4">
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <div>
-                <FormLabel htmlFor="school_code">
-                  School Code
-                </FormLabel>
-                <Input
-                  id="school_code"
-                  name="school_code"
-                  defaultValue={scopedFilters.schoolCode || ""}
-                  placeholder="e.g. 70705"
-                />
-              </div>
-              <div>
-                <FormLabel htmlFor="status">
-                  Status
-                </FormLabel>
-                <Select
-                  id="status"
-                  name="status"
-                  defaultValue={scopedFilters.status || ""}
-                >
-                  <option value="">All</option>
-                  <option value="in_progress">In Progress</option>
-                  <option value="completed">Completed</option>
-                </Select>
-              </div>
-              <div>
-                <FormLabel htmlFor="pm_email">
-                  PM Email
-                </FormLabel>
-                <Input
-                  id="pm_email"
-                  name="pm_email"
-                  type="email"
-                  defaultValue={scopedFilters.pmEmail || ""}
-                  placeholder="pm@avantifellows.org"
-                />
-              </div>
-              <div className="flex items-end gap-2 sm:col-span-1">
-                <Button
-                  type="submit"
-                  size="sm"
-                  className="flex-1 sm:flex-none uppercase tracking-wide"
-                >
-                  Apply
-                </Button>
-                <Link
-                  href="/visits"
-                  className="inline-flex items-center justify-center rounded-lg border border-border bg-bg-card px-4 text-sm font-bold uppercase tracking-wide text-text-secondary shadow-sm hover:bg-hover-bg active:bg-bg-card-alt min-h-[36px] py-1.5 flex-1 sm:flex-none"
-                >
-                  Reset
-                </Link>
-              </div>
-            </div>
-          </Card>
-          </form>
-        )}
 
         {/* In Progress Section */}
         {inProgress.length > 0 && (

--- a/src/components/visits/GpsMapLink.test.tsx
+++ b/src/components/visits/GpsMapLink.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import GpsMapLink from "./GpsMapLink";
+
+describe("GpsMapLink", () => {
+  it("renders a Google Maps link with accuracy when coordinates are present", () => {
+    render(<GpsMapLink lat={12.9716} lng={77.5946} accuracy={9.4} />);
+
+    const link = screen.getByRole("link", { name: /open gps location/i });
+    expect(link).toHaveAttribute("href", "https://maps.google.com/?q=12.9716,77.5946");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveTextContent("9 m");
+  });
+
+  it("renders nothing when either coordinate is absent", () => {
+    const { container, rerender } = render(<GpsMapLink lat={null} lng={77.5946} />);
+
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(<GpsMapLink lat={12.9716} lng={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/visits/GpsMapLink.tsx
+++ b/src/components/visits/GpsMapLink.tsx
@@ -1,0 +1,41 @@
+import { MapPin } from "lucide-react";
+
+interface GpsMapLinkProps {
+  lat: number | string | null;
+  lng: number | string | null;
+  accuracy?: number | string | null;
+}
+
+function isPresentCoordinate(value: number | string | null): value is number | string {
+  return value !== null && value !== "";
+}
+
+export default function GpsMapLink({ lat, lng, accuracy }: GpsMapLinkProps) {
+  if (!isPresentCoordinate(lat) || !isPresentCoordinate(lng)) {
+    return null;
+  }
+
+  const coordinate = `${lat},${lng}`;
+  const accuracyNumber = typeof accuracy === "number"
+    ? accuracy
+    : accuracy
+      ? Number(accuracy)
+      : null;
+
+  return (
+    <a
+      href={`https://maps.google.com/?q=${coordinate}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Open GPS location"
+      className="inline-flex items-center gap-1 text-accent hover:text-accent-hover"
+    >
+      <MapPin aria-hidden="true" className="h-4 w-4" />
+      {accuracyNumber !== null && Number.isFinite(accuracyNumber) && (
+        <span className="text-xs text-text-muted">
+          ({Math.round(accuracyNumber)} m)
+        </span>
+      )}
+    </a>
+  );
+}

--- a/src/components/visits/VisitSummaryFilterBar.test.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.test.tsx
@@ -56,7 +56,7 @@ describe("VisitSummaryFilterBar", () => {
       <VisitSummaryFilterBar
         schoolOptions={[]}
         pmOptions={[]}
-        currentParams={{ preset: "7d", sort: "visit_date", dir: "desc" }}
+        currentParams={{ sort: "visit_date", dir: "desc" }}
       />
     );
 
@@ -67,6 +67,19 @@ describe("VisitSummaryFilterBar", () => {
       "/school-visit-summary?sort=visit_date&dir=desc&page=1&from=2026-05-01",
       { scroll: false }
     );
+  });
+
+  it("hides manual date inputs when a preset is selected", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[]}
+        pmOptions={[]}
+        currentParams={{ preset: "7d" }}
+      />
+    );
+
+    expect(screen.queryByLabelText("From")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("To")).not.toBeInTheDocument();
   });
 
   it("updates PM, status, and action-completion bucket params", () => {
@@ -135,7 +148,7 @@ describe("VisitSummaryFilterBar", () => {
 
     const csvButton = screen.getByRole("button", { name: "Download CSV" });
     expect(csvButton).toBeDisabled();
-    expect(csvButton).toHaveAttribute("title", "Coming soon");
+    expect(screen.getByText("Coming soon")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
     expect(mockReplace).toHaveBeenCalledWith(

--- a/src/components/visits/VisitSummaryFilterBar.test.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/school-visit-summary",
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+import VisitSummaryFilterBar from "./VisitSummaryFilterBar";
+
+describe("VisitSummaryFilterBar", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    vi.useFakeTimers();
+  });
+
+  it("debounces school filter URL updates, resets page, and preserves sorting", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[{ code: "SC001", name: "Test School" }]}
+        pmOptions={[]}
+        currentParams={{ sort: "pm_email", dir: "asc", page: "3" }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Test School (SC001)" }));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(299);
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/school-visit-summary?sort=pm_email&dir=asc&page=1&schools=SC001",
+      { scroll: false }
+    );
+  });
+
+  it("shows selected school values missing from options with a not-in-results indicator", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[{ code: "SC001", name: "Test School" }]}
+        pmOptions={[]}
+        currentParams={{ schools: "SC999" }}
+      />
+    );
+
+    expect(screen.getByText("SC999 (not in results)")).toBeInTheDocument();
+  });
+
+  it("clears preset params when a manual date is edited", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[]}
+        pmOptions={[]}
+        currentParams={{ preset: "7d", sort: "visit_date", dir: "desc" }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("From"), { target: { value: "2026-05-01" } });
+    vi.advanceTimersByTime(300);
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/school-visit-summary?sort=visit_date&dir=desc&page=1&from=2026-05-01",
+      { scroll: false }
+    );
+  });
+
+  it("updates PM, status, and action-completion bucket params", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[]}
+        pmOptions={[{ email: "pm@example.org", name: "Program Manager" }]}
+        currentParams={{ page: "2" }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Program Manager (pm@example.org)" }));
+    vi.advanceTimersByTime(300);
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      "/school-visit-summary?page=1&pms=pm%40example.org",
+      { scroll: false }
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "completed" } });
+    vi.advanceTimersByTime(300);
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      "/school-visit-summary?page=1&status=completed",
+      { scroll: false }
+    );
+
+    fireEvent.change(screen.getByLabelText("Action Completion"), { target: { value: "partial" } });
+    vi.advanceTimersByTime(300);
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      "/school-visit-summary?page=1&bucket=partial",
+      { scroll: false }
+    );
+  });
+
+  it("coalesces rapid filter changes into a single debounced URL update", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[]}
+        pmOptions={[]}
+        currentParams={{}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "in_progress" } });
+    vi.advanceTimersByTime(100);
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "completed" } });
+    vi.advanceTimersByTime(299);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/school-visit-summary?page=1&status=completed",
+      { scroll: false }
+    );
+  });
+
+  it("renders the CSV placeholder and clears filter params while preserving sort", () => {
+    render(
+      <VisitSummaryFilterBar
+        schoolOptions={[]}
+        pmOptions={[]}
+        currentParams={{ schools: "SC001", status: "completed", page: "4", sort: "school_name", dir: "asc" }}
+      />
+    );
+
+    const csvButton = screen.getByRole("button", { name: "Download CSV" });
+    expect(csvButton).toBeDisabled();
+    expect(csvButton).toHaveAttribute("title", "Coming soon");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/school-visit-summary?sort=school_name&dir=asc",
+      { scroll: false }
+    );
+  });
+});

--- a/src/components/visits/VisitSummaryFilterBar.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+interface SchoolOption {
+  code: string;
+  name: string;
+}
+
+interface PmOption {
+  email: string;
+  name: string | null;
+}
+
+interface FilterBarProps {
+  schoolOptions: SchoolOption[];
+  pmOptions: PmOption[];
+  currentParams: Record<string, string | undefined>;
+}
+
+function parseListParam(value: string | undefined): string[] {
+  return (value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
+}
+
+function optionLabel(label: string, value: string): string {
+  return label === value ? value : `${label} (${value})`;
+}
+
+export default function VisitSummaryFilterBar({
+  schoolOptions,
+  pmOptions,
+  currentParams,
+}: FilterBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const debounceRef = useRef<number | null>(null);
+  const [selectedSchools, setSelectedSchools] = useState(() => parseListParam(currentParams.schools));
+  const [selectedPms, setSelectedPms] = useState(() => parseListParam(currentParams.pms));
+  const [status, setStatus] = useState(currentParams.status || "");
+  const [preset, setPreset] = useState(currentParams.preset || "");
+  const [from, setFrom] = useState(currentParams.from || "");
+  const [to, setTo] = useState(currentParams.to || "");
+  const [bucket, setBucket] = useState(currentParams.bucket || "");
+  const schoolOptionCodes = useMemo(
+    () => new Set(schoolOptions.map((school) => school.code)),
+    [schoolOptions]
+  );
+  const pmOptionEmails = useMemo(
+    () => new Set(pmOptions.map((pm) => pm.email)),
+    [pmOptions]
+  );
+  const missingSchools = selectedSchools.filter((code) => !schoolOptionCodes.has(code));
+  const missingPms = selectedPms.filter((email) => !pmOptionEmails.has(email));
+
+  function replaceWith(updates: Record<string, string | undefined>) {
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = window.setTimeout(() => {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(currentParams)) {
+        if (value && !(key in updates)) {
+          params.set(key, value);
+        }
+      }
+      params.set("page", "1");
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          params.set(key, value);
+        } else {
+          params.delete(key);
+        }
+      }
+
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    }, 300);
+  }
+
+  function clearFilters() {
+    const params = new URLSearchParams();
+    for (const key of ["sort", "dir"]) {
+      if (currentParams[key]) {
+        params.set(key, currentParams[key]);
+      }
+    }
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  return (
+    <section className="mb-6 border border-border bg-bg-card p-4 shadow-sm">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">Filters</h2>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled
+            title="Coming soon"
+            className="border border-border px-3 py-2 text-xs font-bold uppercase text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Download CSV
+          </button>
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="border border-border px-3 py-2 text-xs font-bold uppercase text-accent hover:bg-hover-bg"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-5">
+        <fieldset>
+          <legend className="text-xs font-bold uppercase tracking-wide text-text-muted">School</legend>
+          <div className="mt-2 space-y-2">
+            {missingSchools.map((code) => (
+              <button
+                key={code}
+                type="button"
+                onClick={() => {
+                  const next = selectedSchools.filter((schoolCode) => schoolCode !== code);
+                  setSelectedSchools(next);
+                  replaceWith({ schools: next.join(",") || undefined });
+                }}
+                className="block text-left text-sm text-text-muted"
+              >
+                {code} (not in results)
+              </button>
+            ))}
+            {schoolOptions.map((school) => (
+              <label key={school.code} className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={selectedSchools.includes(school.code)}
+                  onChange={() => {
+                    const next = toggleValue(selectedSchools, school.code);
+                    setSelectedSchools(next);
+                    replaceWith({ schools: next.join(",") || undefined });
+                  }}
+                />
+                <span>{school.name} ({school.code})</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend className="text-xs font-bold uppercase tracking-wide text-text-muted">PM</legend>
+          <div className="mt-2 space-y-2">
+            {missingPms.map((email) => (
+              <button
+                key={email}
+                type="button"
+                onClick={() => {
+                  const next = selectedPms.filter((pmEmail) => pmEmail !== email);
+                  setSelectedPms(next);
+                  replaceWith({ pms: next.join(",") || undefined });
+                }}
+                className="block text-left text-sm text-text-muted"
+              >
+                {email} (not in results)
+              </button>
+            ))}
+            {pmOptions.length === 0 && missingPms.length === 0 ? (
+              <div className="text-sm text-text-muted">All PMs</div>
+            ) : pmOptions.map((pm) => (
+              <label key={pm.email} className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={selectedPms.includes(pm.email)}
+                  onChange={() => {
+                    const next = toggleValue(selectedPms, pm.email);
+                    setSelectedPms(next);
+                    replaceWith({ pms: next.join(",") || undefined });
+                  }}
+                />
+                <span>{optionLabel(pm.name || pm.email, pm.email)}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <div>
+          <label htmlFor="visit-summary-status" className="text-xs font-bold uppercase tracking-wide text-text-muted">
+            Status
+          </label>
+          <select
+            id="visit-summary-status"
+            value={status}
+            onChange={(event) => {
+              setStatus(event.target.value);
+              replaceWith({ status: event.target.value || undefined });
+            }}
+            className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+          >
+            <option value="">Any status</option>
+            <option value="in_progress">In Progress</option>
+            <option value="completed">Completed</option>
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="visit-summary-bucket" className="text-xs font-bold uppercase tracking-wide text-text-muted">
+            Action Completion
+          </label>
+          <select
+            id="visit-summary-bucket"
+            value={bucket}
+            onChange={(event) => {
+              setBucket(event.target.value);
+              replaceWith({ bucket: event.target.value || undefined });
+            }}
+            className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+          >
+            <option value="">Any completion</option>
+            <option value="none">No actions</option>
+            <option value="partial">Partially started</option>
+            <option value="all_present">All types present but incomplete</option>
+            <option value="all_complete">All 7 complete</option>
+          </select>
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="visit-summary-preset" className="text-xs font-bold uppercase tracking-wide text-text-muted">
+              Date Preset
+            </label>
+            <select
+              id="visit-summary-preset"
+              value={preset}
+              onChange={(event) => {
+                setPreset(event.target.value);
+                setFrom("");
+                setTo("");
+                replaceWith({
+                  preset: event.target.value || undefined,
+                  from: undefined,
+                  to: undefined,
+                });
+              }}
+              className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+            >
+              <option value="">Manual range</option>
+              <option value="1d">Today</option>
+              <option value="7d">Last 7 days</option>
+              <option value="30d">Last 30 days</option>
+              <option value="90d">Last 90 days</option>
+              <option value="1y">Last year</option>
+              <option value="all">All dates</option>
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
+              From
+              <input
+                type="date"
+                value={from}
+                onChange={(event) => {
+                  setFrom(event.target.value);
+                  setPreset("");
+                  replaceWith({ from: event.target.value || undefined, preset: undefined });
+                }}
+                className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+              />
+            </label>
+            <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
+              To
+              <input
+                type="date"
+                value={to}
+                onChange={(event) => {
+                  setTo(event.target.value);
+                  setPreset("");
+                  replaceWith({ to: event.target.value || undefined, preset: undefined });
+                }}
+                className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+              />
+            </label>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/visits/VisitSummaryFilterBar.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.tsx
@@ -44,6 +44,7 @@ export default function VisitSummaryFilterBar({
   const router = useRouter();
   const pathname = usePathname();
   const debounceRef = useRef<number | null>(null);
+  const pendingUpdatesRef = useRef<Record<string, string | undefined>>({});
   const [selectedSchools, setSelectedSchools] = useState(() => parseListParam(currentParams.schools));
   const [selectedPms, setSelectedPms] = useState(() => parseListParam(currentParams.pms));
   const [status, setStatus] = useState(currentParams.status || "");
@@ -63,19 +64,24 @@ export default function VisitSummaryFilterBar({
   const missingPms = selectedPms.filter((email) => !pmOptionEmails.has(email));
 
   function replaceWith(updates: Record<string, string | undefined>) {
+    Object.assign(pendingUpdatesRef.current, updates);
+
     if (debounceRef.current !== null) {
       window.clearTimeout(debounceRef.current);
     }
 
     debounceRef.current = window.setTimeout(() => {
+      const merged = pendingUpdatesRef.current;
+      pendingUpdatesRef.current = {};
+
       const params = new URLSearchParams();
       for (const [key, value] of Object.entries(currentParams)) {
-        if (value && !(key in updates)) {
+        if (value && !(key in merged)) {
           params.set(key, value);
         }
       }
       params.set("page", "1");
-      for (const [key, value] of Object.entries(updates)) {
+      for (const [key, value] of Object.entries(merged)) {
         if (value) {
           params.set(key, value);
         } else {

--- a/src/components/visits/VisitSummaryFilterBar.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.tsx
@@ -110,14 +110,18 @@ export default function VisitSummaryFilterBar({
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">Filters</h2>
         <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            disabled
-            title="Coming soon"
-            className="border border-border px-3 py-2 text-xs font-bold uppercase text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Download CSV
-          </button>
+          <span className="group relative">
+            <button
+              type="button"
+              disabled
+              className="border border-border px-3 py-2 text-xs font-bold uppercase text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Download CSV
+            </button>
+            <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-text-primary px-2 py-1 text-xs text-bg opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+              Coming soon
+            </span>
+          </span>
           <button
             type="button"
             onClick={clearFilters}
@@ -268,34 +272,34 @@ export default function VisitSummaryFilterBar({
               <option value="all">All dates</option>
             </select>
           </div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
-              From
-              <input
-                type="date"
-                value={from}
-                onChange={(event) => {
-                  setFrom(event.target.value);
-                  setPreset("");
-                  replaceWith({ from: event.target.value || undefined, preset: undefined });
-                }}
-                className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
-              />
-            </label>
-            <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
-              To
-              <input
-                type="date"
-                value={to}
-                onChange={(event) => {
-                  setTo(event.target.value);
-                  setPreset("");
-                  replaceWith({ to: event.target.value || undefined, preset: undefined });
-                }}
-                className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
-              />
-            </label>
-          </div>
+          {!preset && (
+            <div className="grid grid-cols-2 gap-2">
+              <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
+                From
+                <input
+                  type="date"
+                  value={from}
+                  onChange={(event) => {
+                    setFrom(event.target.value);
+                    replaceWith({ from: event.target.value || undefined, preset: undefined });
+                  }}
+                  className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+                />
+              </label>
+              <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
+                To
+                <input
+                  type="date"
+                  value={to}
+                  onChange={(event) => {
+                    setTo(event.target.value);
+                    replaceWith({ to: event.target.value || undefined, preset: undefined });
+                  }}
+                  className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
+                />
+              </label>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/src/lib/af-team-interaction.test.ts
+++ b/src/lib/af-team-interaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   AF_TEAM_INTERACTION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   validateAFTeamInteractionSave,
   validateAFTeamInteractionComplete,
 } from "./af-team-interaction";
@@ -239,5 +241,45 @@ describe("validateAFTeamInteractionComplete (strict)", () => {
     (payload.questions as Record<string, { answer: boolean }>).some_future_key = { answer: true };
     const result = validateAFTeamInteractionComplete(payload);
     expect(result.valid).toBe(true);
+  });
+});
+
+describe("AF team interaction summary extractors", () => {
+  it("extracts non-empty question remarks and computes answered/teacher stats", () => {
+    expect(
+      extractRemarks({
+        teachers: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+        questions: {
+          op_class_duration: { answer: true, remark: "Classes are on schedule" },
+          op_centre_resources: { answer: false, remark: "   " },
+          sp_student_performance: { answer: null, remark: "Needs remedial plan" },
+        },
+      })
+    ).toEqual([
+      {
+        label: "Does the teacher get the required duration of classes?",
+        text: "Classes are on schedule",
+      },
+      {
+        label: "Are there concerns related to student performance?",
+        text: "Needs remedial plan",
+      },
+    ]);
+
+    expect(
+      computeInlineStats({
+        teachers: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+        questions: {
+          op_class_duration: { answer: true },
+          op_centre_resources: { answer: false },
+          sp_student_performance: { answer: null },
+        },
+      })
+    ).toEqual({ answeredCount: 2, totalQuestions: 9, teacherCount: 2 });
+  });
+
+  it("handles null data gracefully", () => {
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/af-team-interaction.ts
+++ b/src/lib/af-team-interaction.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -218,4 +220,58 @@ export function validateAFTeamInteractionComplete(data: unknown): ValidationResu
   errors.push(...validateQuestions(payload.questions, true));
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  for (const section of AF_TEAM_INTERACTION_CONFIG.sections) {
+    for (const question of section.questions) {
+      const answer = data.questions[question.key];
+      if (!isPlainObject(answer)) {
+        continue;
+      }
+      const text = nonEmptyString(answer.remark);
+      if (text) {
+        remarks.push({ label: question.label, text });
+      }
+    }
+  }
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  answeredCount: number;
+  totalQuestions: number;
+  teacherCount: number;
+} | null {
+  if (!isPlainObject(data)) {
+    return null;
+  }
+
+  const questions = isPlainObject(data.questions) ? data.questions : {};
+  let answeredCount = 0;
+  for (const key of AF_TEAM_INTERACTION_CONFIG.allQuestionKeys) {
+    const answer = questions[key];
+    if (isPlainObject(answer) && typeof answer.answer === "boolean") {
+      answeredCount += 1;
+    }
+  }
+
+  return {
+    answeredCount,
+    totalQuestions: AF_TEAM_INTERACTION_CONFIG.allQuestionKeys.length,
+    teacherCount: Array.isArray(data.teachers) ? data.teachers.length : 0,
+  };
 }

--- a/src/lib/classroom-observation-rubric.test.ts
+++ b/src/lib/classroom-observation-rubric.test.ts
@@ -4,7 +4,9 @@ import {
   CLASSROOM_OBSERVATION_RUBRIC,
   CURRENT_RUBRIC_VERSION,
   VALID_GRADES,
+  computeInlineStats,
   computeTotalScore,
+  extractRemarks,
   validateClassroomObservationComplete,
   validateClassroomObservationSave,
 } from "./classroom-observation-rubric";
@@ -35,6 +37,52 @@ describe("classroom-observation-rubric config", () => {
       const optionScores = parameter.options.map((option) => option.score);
       expect(optionScores).toContain(parameter.maxScore);
     }
+  });
+});
+
+describe("classroom observation summary extractors", () => {
+  it("extracts plural param remarks and observer summaries while computing score stats", () => {
+    const data = {
+      params: {
+        teacher_on_time: { score: 1, remarks: "Started exactly on time" },
+        recall_test: { score: 2, remark: "singular field ignored" },
+        gender_sensitivity: { score: 3, remarks: "   " },
+      },
+      observer_summary_strengths: "Strong student engagement",
+      observer_summary_improvements: "Needs tighter closure",
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      {
+        label: "Teacher started the class on time",
+        text: "Started exactly on time",
+      },
+      {
+        label: "Observer Summary (Strengths)",
+        text: "Strong student engagement",
+      },
+      {
+        label: "Observer Summary (Points of Improvement)",
+        text: "Needs tighter closure",
+      },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      totalScore: 6,
+      maxScore: 45,
+      remarkCount: 1,
+    });
+  });
+
+  it("handles missing params and null data gracefully", () => {
+    expect(extractRemarks({
+      observer_summary_strengths: "Legacy strength",
+      observer_summary_improvements: "",
+    })).toEqual([
+      { label: "Observer Summary (Strengths)", text: "Legacy strength" },
+    ]);
+    expect(computeInlineStats({ observer_summary_strengths: "Legacy strength" })).toBeNull();
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });
 

--- a/src/lib/classroom-observation-rubric.ts
+++ b/src/lib/classroom-observation-rubric.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface RubricOption {
   label: string;
   score: number;
@@ -560,4 +562,71 @@ export function validateClassroomObservationComplete(data: unknown): ValidationR
   errors.push(...validateParams(payload.params, rubric, true));
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  if (isPlainObject(data.params)) {
+    for (const parameter of CLASSROOM_OBSERVATION_RUBRIC.parameters) {
+      const param = data.params[parameter.key];
+      if (!isPlainObject(param)) {
+        continue;
+      }
+      const text = nonEmptyString(param.remarks);
+      if (text) {
+        remarks.push({ label: parameter.label, text });
+      }
+    }
+  }
+
+  const strengthText = nonEmptyString(data.observer_summary_strengths);
+  if (strengthText) {
+    remarks.push({ label: "Observer Summary (Strengths)", text: strengthText });
+  }
+
+  const improvementText = nonEmptyString(data.observer_summary_improvements);
+  if (improvementText) {
+    remarks.push({
+      label: "Observer Summary (Points of Improvement)",
+      text: improvementText,
+    });
+  }
+
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  totalScore: number;
+  maxScore: number;
+  remarkCount: number;
+} | null {
+  if (!isPlainObject(data) || !isPlainObject(data.params)) {
+    return null;
+  }
+
+  let remarkCount = 0;
+  for (const parameter of CLASSROOM_OBSERVATION_RUBRIC.parameters) {
+    const param = data.params[parameter.key];
+    if (isPlainObject(param) && nonEmptyString(param.remarks)) {
+      remarkCount += 1;
+    }
+  }
+
+  return {
+    totalScore: computeTotalScore(data.params as Record<string, ParamData | undefined>),
+    maxScore: CLASSROOM_OBSERVATION_RUBRIC.maxScore,
+    remarkCount,
+  };
 }

--- a/src/lib/group-student-discussion.test.ts
+++ b/src/lib/group-student-discussion.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   GROUP_STUDENT_DISCUSSION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   validateGroupStudentDiscussionSave,
   validateGroupStudentDiscussionComplete,
 } from "./group-student-discussion";
@@ -286,5 +288,32 @@ describe("validateGroupStudentDiscussionComplete (strict)", () => {
     const result = validateGroupStudentDiscussionComplete(payload);
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("grade is required and must be 11 or 12");
+  });
+});
+
+describe("group student discussion summary extractors", () => {
+  it("extracts question remarks and computes grade/answered stats", () => {
+    const data = {
+      grade: 12,
+      questions: {
+        gc_interacted: { answer: true, remark: "Students shared concerns" },
+        gc_program_updates: { answer: false },
+        gc_direction: { answer: null, remark: "" },
+      },
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      { label: "Have you interacted with the students?", text: "Students shared concerns" },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      grade: 12,
+      answeredCount: 2,
+      totalQuestions: 4,
+    });
+  });
+
+  it("handles null data gracefully", () => {
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/group-student-discussion.ts
+++ b/src/lib/group-student-discussion.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -183,4 +185,58 @@ export function validateGroupStudentDiscussionComplete(data: unknown): Validatio
   errors.push(...validateQuestions(payload.questions, true));
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  for (const section of GROUP_STUDENT_DISCUSSION_CONFIG.sections) {
+    for (const question of section.questions) {
+      const answer = data.questions[question.key];
+      if (!isPlainObject(answer)) {
+        continue;
+      }
+      const text = nonEmptyString(answer.remark);
+      if (text) {
+        remarks.push({ label: question.label, text });
+      }
+    }
+  }
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  grade: number | null;
+  answeredCount: number;
+  totalQuestions: number;
+} | null {
+  if (!isPlainObject(data)) {
+    return null;
+  }
+
+  const questions = isPlainObject(data.questions) ? data.questions : {};
+  let answeredCount = 0;
+  for (const key of GROUP_STUDENT_DISCUSSION_CONFIG.allQuestionKeys) {
+    const answer = questions[key];
+    if (isPlainObject(answer) && typeof answer.answer === "boolean") {
+      answeredCount += 1;
+    }
+  }
+
+  return {
+    grade: typeof data.grade === "number" ? data.grade : null,
+    answeredCount,
+    totalQuestions: GROUP_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.length,
+  };
 }

--- a/src/lib/individual-af-teacher-interaction.test.ts
+++ b/src/lib/individual-af-teacher-interaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   validateIndividualTeacherSave,
   validateIndividualTeacherComplete,
   type IndividualTeacherEntry,
@@ -333,5 +335,56 @@ describe("validateIndividualTeacherComplete (strict)", () => {
     expect(
       result.errors.every((e) => !e.includes("oh_class_duration"))
     ).toBe(true);
+  });
+});
+
+describe("individual AF teacher summary extractors", () => {
+  it("prefixes remark labels with teacher names and handles mixed attendance stats", () => {
+    const data = {
+      teachers: [
+        {
+          id: 1,
+          name: "Alice",
+          attendance: "present",
+          questions: {
+            oh_class_duration: { answer: true, remark: "Teacher has full duration" },
+            st_grade11_syllabus: { answer: false },
+          },
+        },
+        {
+          id: 2,
+          name: "Bob",
+          attendance: "on_leave",
+          questions: {
+            oh_class_duration: { answer: true, remark: "Leave remark should still show" },
+          },
+        },
+        { id: 3, name: "Carol", attendance: "absent", questions: {} },
+      ],
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      {
+        label: "Alice: Does the teacher get the required duration of classes?",
+        text: "Teacher has full duration",
+      },
+      {
+        label: "Bob: Does the teacher get the required duration of classes?",
+        text: "Leave remark should still show",
+      },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      teacherCount: 3,
+      presentCount: 1,
+      onLeaveCount: 1,
+      absentCount: 1,
+      avgAnswered: 2,
+      totalQuestions: 13,
+    });
+  });
+
+  it("handles null data gracefully", () => {
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/individual-af-teacher-interaction.ts
+++ b/src/lib/individual-af-teacher-interaction.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -261,4 +263,96 @@ export function validateIndividualTeacherComplete(data: unknown): ValidationResu
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function getTeacherName(entry: Record<string, unknown>, index: number): string {
+  return typeof entry.name === "string" && entry.name.trim() !== ""
+    ? entry.name.trim()
+    : `Teacher ${index + 1}`;
+}
+
+function answeredCountForQuestions(questions: unknown): number {
+  if (!isPlainObject(questions)) {
+    return 0;
+  }
+  return INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG.allQuestionKeys.filter((key) => {
+    const answer = questions[key];
+    return isPlainObject(answer) && typeof answer.answer === "boolean";
+  }).length;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data) || !Array.isArray(data.teachers)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  data.teachers.forEach((teacher, index) => {
+    if (!isPlainObject(teacher) || !isPlainObject(teacher.questions)) {
+      return;
+    }
+    const teacherName = getTeacherName(teacher, index);
+    for (const section of INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG.sections) {
+      for (const question of section.questions) {
+        const answer = teacher.questions[question.key];
+        if (!isPlainObject(answer)) {
+          continue;
+        }
+        const text = nonEmptyString(answer.remark);
+        if (text) {
+          remarks.push({ label: `${teacherName}: ${question.label}`, text });
+        }
+      }
+    }
+  });
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  teacherCount: number;
+  presentCount: number;
+  onLeaveCount: number;
+  absentCount: number;
+  avgAnswered: number | null;
+  totalQuestions: number;
+} | null {
+  if (!isPlainObject(data) || !Array.isArray(data.teachers)) {
+    return null;
+  }
+
+  let presentCount = 0;
+  let onLeaveCount = 0;
+  let absentCount = 0;
+  let presentAnsweredSum = 0;
+
+  for (const teacher of data.teachers) {
+    if (!isPlainObject(teacher)) {
+      continue;
+    }
+    if (teacher.attendance === "present") {
+      presentCount += 1;
+      presentAnsweredSum += answeredCountForQuestions(teacher.questions);
+    } else if (teacher.attendance === "on_leave") {
+      onLeaveCount += 1;
+    } else if (teacher.attendance === "absent") {
+      absentCount += 1;
+    }
+  }
+
+  return {
+    teacherCount: data.teachers.length,
+    presentCount,
+    onLeaveCount,
+    absentCount,
+    avgAnswered: presentCount > 0 ? presentAnsweredSum / presentCount : null,
+    totalQuestions: INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG.allQuestionKeys.length,
+  };
 }

--- a/src/lib/individual-student-discussion.test.ts
+++ b/src/lib/individual-student-discussion.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   ALLOWED_TOP_LEVEL_KEYS,
   INDIVIDUAL_STUDENT_DISCUSSION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   getEntriesFromData,
   validateIndividualStudentDiscussionComplete,
   validateIndividualStudentDiscussionSave,
@@ -298,5 +300,51 @@ describe("validateIndividualStudentDiscussionComplete (strict)", () => {
     });
 
     expect(result.errors).toContain("Entry 0: grade must be 11 or 12");
+  });
+});
+
+describe("individual student discussion summary extractors", () => {
+  it("labels remarks with student names and computes entry/student stats", () => {
+    const data = {
+      entries: [
+        {
+          id: "entry-1",
+          grade: 11,
+          students: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+          questions: {
+            oh_teaching_concern: { answer: true, remark: "Students want slower pacing" },
+            oh_additional_support: { answer: false },
+          },
+        },
+        {
+          id: "entry-2",
+          grade: 12,
+          students: [{ id: 3, name: "Carol" }],
+          questions: {
+            oh_teaching_concern: { answer: null, remark: "   " },
+          },
+        },
+      ],
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      {
+        label: "Alice, Bob: Did any student raise a concern on teaching quality and classroom environment?",
+        text: "Students want slower pacing",
+      },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      entryCount: 2,
+      studentCount: 3,
+      avgAnswered: 1,
+      totalQuestions: 2,
+    });
+  });
+
+  it("returns empty remarks and null stats for legacy students shape", () => {
+    expect(extractRemarks({ students: [{ id: 1, name: "Alice" }] })).toEqual([]);
+    expect(computeInlineStats({ students: [{ id: 1, name: "Alice" }] })).toBeNull();
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/individual-student-discussion.test.ts
+++ b/src/lib/individual-student-discussion.test.ts
@@ -341,9 +341,15 @@ describe("individual student discussion summary extractors", () => {
     });
   });
 
-  it("returns empty remarks and null stats for legacy students shape", () => {
+  it("returns student-only stats for legacy students shape and empty for null/undefined", () => {
     expect(extractRemarks({ students: [{ id: 1, name: "Alice" }] })).toEqual([]);
-    expect(computeInlineStats({ students: [{ id: 1, name: "Alice" }] })).toBeNull();
+    expect(computeInlineStats({ students: [{ id: 1, name: "Alice" }] })).toEqual({
+      entryCount: null,
+      studentCount: 1,
+      avgAnswered: null,
+      totalQuestions: 2,
+    });
+    expect(computeInlineStats({ students: [] })).toBeNull();
     expect(extractRemarks(null)).toEqual([]);
     expect(computeInlineStats(undefined)).toBeNull();
   });

--- a/src/lib/individual-student-discussion.ts
+++ b/src/lib/individual-student-discussion.ts
@@ -359,30 +359,43 @@ export function extractRemarks(data: unknown): RemarkEntry[] {
 }
 
 export function computeInlineStats(data: unknown): {
-  entryCount: number;
+  entryCount: number | null;
   studentCount: number;
   avgAnswered: number | null;
   totalQuestions: number;
 } | null {
-  if (!isPlainObject(data) || !Array.isArray(data.entries)) {
+  if (!isPlainObject(data)) {
     return null;
   }
 
-  const entries = getEntriesFromData(data);
-  if (entries.length === 0) {
-    return null;
+  if (Array.isArray(data.entries)) {
+    const entries = getEntriesFromData(data);
+    if (entries.length === 0) {
+      return null;
+    }
+
+    const answeredSum = entries.reduce(
+      (sum, entry) => sum + answeredCountForQuestions(entry.questions),
+      0
+    );
+    const studentCount = entries.reduce((sum, entry) => sum + entry.students.length, 0);
+
+    return {
+      entryCount: entries.length,
+      studentCount,
+      avgAnswered: answeredSum / entries.length,
+      totalQuestions: INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.length,
+    };
   }
 
-  const answeredSum = entries.reduce(
-    (sum, entry) => sum + answeredCountForQuestions(entry.questions),
-    0
-  );
-  const studentCount = entries.reduce((sum, entry) => sum + entry.students.length, 0);
+  if (Array.isArray(data.students) && data.students.length > 0) {
+    return {
+      entryCount: null,
+      studentCount: data.students.length,
+      avgAnswered: null,
+      totalQuestions: INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.length,
+    };
+  }
 
-  return {
-    entryCount: entries.length,
-    studentCount,
-    avgAnswered: answeredSum / entries.length,
-    totalQuestions: INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.length,
-  };
+  return null;
 }

--- a/src/lib/individual-student-discussion.ts
+++ b/src/lib/individual-student-discussion.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -301,4 +303,86 @@ export function validateIndividualStudentDiscussionComplete(data: unknown): Vali
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function answeredCountForQuestions(questions: unknown): number {
+  if (!isPlainObject(questions)) {
+    return 0;
+  }
+  return INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.filter((key) => {
+    const answer = questions[key];
+    return isPlainObject(answer) && typeof answer.answer === "boolean";
+  }).length;
+}
+
+function studentNames(students: unknown, fallback: string): string {
+  if (!Array.isArray(students)) {
+    return fallback;
+  }
+  const names = students
+    .map((student) => isPlainObject(student) ? nonEmptyString(student.name) : null)
+    .filter((name): name is string => Boolean(name));
+  return names.length > 0 ? names.join(", ") : fallback;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  const entries = getEntriesFromData(data);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  entries.forEach((entry, index) => {
+    const prefix = studentNames(entry.students, `Entry ${index + 1}`);
+    for (const section of INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.sections) {
+      for (const question of section.questions) {
+        const answer = entry.questions[question.key];
+        if (!isPlainObject(answer)) {
+          continue;
+        }
+        const text = nonEmptyString(answer.remark);
+        if (text) {
+          remarks.push({ label: `${prefix}: ${question.label}`, text });
+        }
+      }
+    }
+  });
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  entryCount: number;
+  studentCount: number;
+  avgAnswered: number | null;
+  totalQuestions: number;
+} | null {
+  if (!isPlainObject(data) || !Array.isArray(data.entries)) {
+    return null;
+  }
+
+  const entries = getEntriesFromData(data);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const answeredSum = entries.reduce(
+    (sum, entry) => sum + answeredCountForQuestions(entry.questions),
+    0
+  );
+  const studentCount = entries.reduce((sum, entry) => sum + entry.students.length, 0);
+
+  return {
+    entryCount: entries.length,
+    studentCount,
+    avgAnswered: answeredSum / entries.length,
+    totalQuestions: INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.length,
+  };
 }

--- a/src/lib/principal-interaction.test.ts
+++ b/src/lib/principal-interaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   PRINCIPAL_INTERACTION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   validatePrincipalInteractionSave,
   validatePrincipalInteractionComplete,
 } from "./principal-interaction";
@@ -222,5 +224,33 @@ describe("validatePrincipalInteractionComplete (strict)", () => {
     const result = validatePrincipalInteractionComplete(payload);
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Unknown field: extra");
+  });
+});
+
+describe("principal interaction summary extractors", () => {
+  it("extracts non-empty question remarks and computes answered stats", () => {
+    const data = {
+      questions: {
+        oh_program_feedback: { answer: true, remark: "Principal requested more updates" },
+        ip_curriculum_progress: { answer: false },
+        ip_key_events: { answer: null, remark: "   " },
+      },
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      {
+        label: "Does the Principal have any feedback or concerns on the program implementation?",
+        text: "Principal requested more updates",
+      },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      answeredCount: 2,
+      totalQuestions: 7,
+    });
+  });
+
+  it("handles null data gracefully", () => {
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/principal-interaction.ts
+++ b/src/lib/principal-interaction.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -200,4 +202,55 @@ export function validatePrincipalInteractionComplete(data: unknown): ValidationR
   errors.push(...validateQuestions(payload.questions, true));
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  for (const section of PRINCIPAL_INTERACTION_CONFIG.sections) {
+    for (const question of section.questions) {
+      const answer = data.questions[question.key];
+      if (!isPlainObject(answer)) {
+        continue;
+      }
+      const text = nonEmptyString(answer.remark);
+      if (text) {
+        remarks.push({ label: question.label, text });
+      }
+    }
+  }
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  answeredCount: number;
+  totalQuestions: number;
+} | null {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return null;
+  }
+
+  let answeredCount = 0;
+  for (const key of PRINCIPAL_INTERACTION_CONFIG.allQuestionKeys) {
+    const answer = data.questions[key];
+    if (isPlainObject(answer) && typeof answer.answer === "boolean") {
+      answeredCount += 1;
+    }
+  }
+
+  return {
+    answeredCount,
+    totalQuestions: PRINCIPAL_INTERACTION_CONFIG.allQuestionKeys.length,
+  };
 }

--- a/src/lib/school-staff-interaction.test.ts
+++ b/src/lib/school-staff-interaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   SCHOOL_STAFF_INTERACTION_CONFIG,
+  computeInlineStats,
+  extractRemarks,
   validateSchoolStaffInteractionSave,
   validateSchoolStaffInteractionComplete,
 } from "./school-staff-interaction";
@@ -208,5 +210,32 @@ describe("validateSchoolStaffInteractionComplete (strict)", () => {
     const result = validateSchoolStaffInteractionComplete(payload);
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Unknown field: extra");
+  });
+});
+
+describe("school staff interaction summary extractors", () => {
+  it("extracts question remarks and computes answered stats", () => {
+    const data = {
+      questions: {
+        gc_staff_concern: { answer: true, remark: "Staff requested lab support" },
+        gc_pertaining_issue: { answer: null, remark: "" },
+      },
+    };
+
+    expect(extractRemarks(data)).toEqual([
+      {
+        label: "Did any school staff raise any concern related to the program?",
+        text: "Staff requested lab support",
+      },
+    ]);
+    expect(computeInlineStats(data)).toEqual({
+      answeredCount: 1,
+      totalQuestions: 2,
+    });
+  });
+
+  it("handles null data gracefully", () => {
+    expect(extractRemarks(null)).toEqual([]);
+    expect(computeInlineStats(undefined)).toBeNull();
   });
 });

--- a/src/lib/school-staff-interaction.ts
+++ b/src/lib/school-staff-interaction.ts
@@ -1,3 +1,5 @@
+import type { RemarkEntry } from "./visit-summary";
+
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -156,4 +158,55 @@ export function validateSchoolStaffInteractionComplete(data: unknown): Validatio
   errors.push(...validateQuestions(payload.questions, true));
 
   return { valid: errors.length === 0, errors };
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractRemarks(data: unknown): RemarkEntry[] {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return [];
+  }
+
+  const remarks: RemarkEntry[] = [];
+  for (const section of SCHOOL_STAFF_INTERACTION_CONFIG.sections) {
+    for (const question of section.questions) {
+      const answer = data.questions[question.key];
+      if (!isPlainObject(answer)) {
+        continue;
+      }
+      const text = nonEmptyString(answer.remark);
+      if (text) {
+        remarks.push({ label: question.label, text });
+      }
+    }
+  }
+  return remarks;
+}
+
+export function computeInlineStats(data: unknown): {
+  answeredCount: number;
+  totalQuestions: number;
+} | null {
+  if (!isPlainObject(data) || !isPlainObject(data.questions)) {
+    return null;
+  }
+
+  let answeredCount = 0;
+  for (const key of SCHOOL_STAFF_INTERACTION_CONFIG.allQuestionKeys) {
+    const answer = data.questions[key];
+    if (isPlainObject(answer) && typeof answer.answer === "boolean") {
+      answeredCount += 1;
+    }
+  }
+
+  return {
+    answeredCount,
+    totalQuestions: SCHOOL_STAFF_INTERACTION_CONFIG.allQuestionKeys.length,
+  };
 }

--- a/src/lib/visit-summary.test.ts
+++ b/src/lib/visit-summary.test.ts
@@ -4,6 +4,8 @@ import { ACTION_TYPE_VALUES, type ActionType } from "./visit-actions";
 import {
   classifyActionCompletion,
   computeAverageCompletion,
+  dispatchComputeInlineStats,
+  dispatchExtractRemarks,
   resolvePresetDateRange,
   rollupActionTypes,
   type ActionTypeRollupStatus,
@@ -134,5 +136,79 @@ describe("RemarkEntry", () => {
     const remark: RemarkEntry = { label: "Question", text: "Follow up required" };
 
     expect(remark).toEqual({ label: "Question", text: "Follow up required" });
+  });
+});
+
+describe("summary action dispatch", () => {
+  it("delegates known action types and handles unknown types gracefully", () => {
+    expect(
+      dispatchExtractRemarks("principal_interaction", {
+        questions: {
+          oh_program_feedback: { answer: true, remark: "Principal wants monthly updates" },
+        },
+      })
+    ).toEqual([
+      {
+        label: "Does the Principal have any feedback or concerns on the program implementation?",
+        text: "Principal wants monthly updates",
+      },
+    ]);
+
+    expect(
+      dispatchComputeInlineStats("principal_interaction", {
+        questions: {
+          oh_program_feedback: { answer: true },
+          ip_curriculum_progress: { answer: null },
+        },
+      })
+    ).toEqual({ answeredCount: 1, totalQuestions: 7 });
+
+    expect(dispatchExtractRemarks("unknown_action", {})).toEqual([]);
+    expect(dispatchComputeInlineStats("unknown_action", {})).toBeNull();
+  });
+
+  it("dispatches all known action types to their summary extractors", () => {
+    expect(dispatchComputeInlineStats("classroom_observation", {
+      params: { teacher_on_time: { score: 1, remarks: "On time" } },
+    })).toMatchObject({ totalScore: 1, maxScore: 45, remarkCount: 1 });
+
+    expect(dispatchComputeInlineStats("af_team_interaction", {
+      teachers: [{ id: 1, name: "Alice" }],
+      questions: { op_class_duration: { answer: true } },
+    })).toEqual({ answeredCount: 1, totalQuestions: 9, teacherCount: 1 });
+
+    expect(dispatchComputeInlineStats("individual_af_teacher_interaction", {
+      teachers: [{
+        id: 1,
+        name: "Alice",
+        attendance: "present",
+        questions: { oh_class_duration: { answer: true } },
+      }],
+    })).toEqual({
+      teacherCount: 1,
+      presentCount: 1,
+      onLeaveCount: 0,
+      absentCount: 0,
+      avgAnswered: 1,
+      totalQuestions: 13,
+    });
+
+    expect(dispatchComputeInlineStats("group_student_discussion", {
+      grade: 11,
+      questions: { gc_interacted: { answer: true } },
+    })).toEqual({ grade: 11, answeredCount: 1, totalQuestions: 4 });
+
+    expect(dispatchComputeInlineStats("individual_student_discussion", {
+      entries: [{
+        id: "entry-1",
+        grade: 11,
+        students: [{ id: 1, name: "Alice" }],
+        questions: { oh_teaching_concern: { answer: true } },
+      }],
+    })).toEqual({ entryCount: 1, studentCount: 1, avgAnswered: 1, totalQuestions: 2 });
+
+    expect(dispatchComputeInlineStats("school_staff_interaction", {
+      questions: { gc_staff_concern: { answer: true } },
+    })).toEqual({ answeredCount: 1, totalQuestions: 2 });
   });
 });

--- a/src/lib/visit-summary.test.ts
+++ b/src/lib/visit-summary.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import { ACTION_TYPE_VALUES, type ActionType } from "./visit-actions";
+import {
+  classifyActionCompletion,
+  computeAverageCompletion,
+  resolvePresetDateRange,
+  rollupActionTypes,
+  type ActionTypeRollupStatus,
+  type RemarkEntry,
+} from "./visit-summary";
+
+describe("rollupActionTypes", () => {
+  it("marks missing action types as not_started and ignores unknown action types", () => {
+    const rollup = rollupActionTypes([
+      { action_type: "classroom_observation", status: "completed" },
+      { action_type: "unknown_action", status: "completed" },
+    ]);
+
+    expect(rollup.classroom_observation).toBe("completed");
+    expect(rollup.principal_interaction).toBe("not_started");
+    expect(Object.keys(rollup)).toEqual(ACTION_TYPE_VALUES);
+    expect(rollup).not.toHaveProperty("unknown_action");
+
+    const exhaustive: Record<ActionType, true> = Object.fromEntries(
+      Object.keys(rollup).map((key) => [key, true])
+    ) as Record<ActionType, true>;
+    expect(Object.keys(exhaustive)).toHaveLength(7);
+  });
+
+  it("keeps the best status when a type has duplicate actions", () => {
+    const rollup = rollupActionTypes([
+      { action_type: "af_team_interaction", status: "pending" },
+      { action_type: "af_team_interaction", status: "in_progress" },
+      { action_type: "af_team_interaction", status: "completed" },
+      { action_type: "principal_interaction", status: "pending" },
+      { action_type: "principal_interaction", status: "in_progress" },
+      { action_type: "group_student_discussion", status: "pending" },
+    ]);
+
+    expect(rollup.af_team_interaction).toBe("completed");
+    expect(rollup.principal_interaction).toBe("in_progress");
+    expect(rollup.group_student_discussion).toBe("pending");
+  });
+});
+
+function makeRollup(
+  overrides: Partial<Record<ActionType, ActionTypeRollupStatus>>
+): Record<ActionType, ActionTypeRollupStatus> {
+  return Object.fromEntries(
+    ACTION_TYPE_VALUES.map((actionType) => [actionType, overrides[actionType] || "not_started"])
+  ) as Record<ActionType, ActionTypeRollupStatus>;
+}
+
+describe("classifyActionCompletion", () => {
+  it("classifies all action completion buckets and boundaries", () => {
+    expect(classifyActionCompletion(makeRollup({}))).toBe("none");
+
+    expect(classifyActionCompletion(makeRollup({
+      classroom_observation: "completed",
+      af_team_interaction: "completed",
+      individual_af_teacher_interaction: "completed",
+      principal_interaction: "completed",
+      group_student_discussion: "completed",
+      individual_student_discussion: "completed",
+    }))).toBe("partial");
+
+    expect(classifyActionCompletion(makeRollup({
+      classroom_observation: "completed",
+      af_team_interaction: "completed",
+      individual_af_teacher_interaction: "completed",
+      principal_interaction: "completed",
+      group_student_discussion: "completed",
+      individual_student_discussion: "completed",
+      school_staff_interaction: "pending",
+    }))).toBe("all_present");
+
+    expect(classifyActionCompletion(makeRollup({
+      classroom_observation: "completed",
+      af_team_interaction: "completed",
+      individual_af_teacher_interaction: "completed",
+      principal_interaction: "completed",
+      group_student_discussion: "completed",
+      individual_student_discussion: "completed",
+      school_staff_interaction: "completed",
+    }))).toBe("all_complete");
+  });
+});
+
+describe("computeAverageCompletion", () => {
+  it("returns null for zero visits, zero for no completions, and percentages otherwise", () => {
+    expect(computeAverageCompletion(0, 0)).toBeNull();
+    expect(computeAverageCompletion(0, 3)).toBe(0);
+    expect(computeAverageCompletion(7, 1)).toBe(100);
+    expect(computeAverageCompletion(7, 2)).toBe(50);
+  });
+});
+
+describe("resolvePresetDateRange", () => {
+  it("resolves all date presets relative to the provided IST day", () => {
+    expect(resolvePresetDateRange("1d", "2026-05-22")).toEqual({
+      from: "2026-05-22",
+      to: "2026-05-22",
+    });
+    expect(resolvePresetDateRange("7d", "2026-05-22")).toEqual({
+      from: "2026-05-16",
+      to: "2026-05-22",
+    });
+    expect(resolvePresetDateRange("30d", "2026-05-22")).toEqual({
+      from: "2026-04-23",
+      to: "2026-05-22",
+    });
+    expect(resolvePresetDateRange("90d", "2026-05-22")).toEqual({
+      from: "2026-02-22",
+      to: "2026-05-22",
+    });
+    expect(resolvePresetDateRange("1y", "2026-05-22")).toEqual({
+      from: "2025-05-23",
+      to: "2026-05-22",
+    });
+    expect(resolvePresetDateRange("all", "2026-05-22")).toBeNull();
+  });
+
+  it("uses Asia/Kolkata when a Date is provided", () => {
+    expect(resolvePresetDateRange("1d", new Date("2026-05-21T20:00:00.000Z"))).toEqual({
+      from: "2026-05-22",
+      to: "2026-05-22",
+    });
+  });
+});
+
+describe("RemarkEntry", () => {
+  it("exports the shared remark shape for action modules", () => {
+    const remark: RemarkEntry = { label: "Question", text: "Follow up required" };
+
+    expect(remark).toEqual({ label: "Question", text: "Follow up required" });
+  });
+});

--- a/src/lib/visit-summary.ts
+++ b/src/lib/visit-summary.ts
@@ -1,4 +1,32 @@
 import { ACTION_TYPE_VALUES, isActionType, type ActionType } from "./visit-actions";
+import {
+  computeInlineStats as computeAFTeamInlineStats,
+  extractRemarks as extractAFTeamRemarks,
+} from "./af-team-interaction";
+import {
+  computeInlineStats as computeClassroomInlineStats,
+  extractRemarks as extractClassroomRemarks,
+} from "./classroom-observation-rubric";
+import {
+  computeInlineStats as computeGroupStudentInlineStats,
+  extractRemarks as extractGroupStudentRemarks,
+} from "./group-student-discussion";
+import {
+  computeInlineStats as computeIndividualTeacherInlineStats,
+  extractRemarks as extractIndividualTeacherRemarks,
+} from "./individual-af-teacher-interaction";
+import {
+  computeInlineStats as computeIndividualStudentInlineStats,
+  extractRemarks as extractIndividualStudentRemarks,
+} from "./individual-student-discussion";
+import {
+  computeInlineStats as computePrincipalInlineStats,
+  extractRemarks as extractPrincipalRemarks,
+} from "./principal-interaction";
+import {
+  computeInlineStats as computeSchoolStaffInlineStats,
+  extractRemarks as extractSchoolStaffRemarks,
+} from "./school-staff-interaction";
 
 export type RemarkEntry = { label: string; text: string };
 
@@ -90,6 +118,48 @@ export function resolvePresetDateRange(
   const from = addDays(to, -(PRESET_DAYS[preset] - 1));
 
   return { from, to };
+}
+
+export function dispatchExtractRemarks(actionType: string, data: unknown): RemarkEntry[] {
+  switch (actionType) {
+    case "classroom_observation":
+      return extractClassroomRemarks(data);
+    case "af_team_interaction":
+      return extractAFTeamRemarks(data);
+    case "individual_af_teacher_interaction":
+      return extractIndividualTeacherRemarks(data);
+    case "principal_interaction":
+      return extractPrincipalRemarks(data);
+    case "group_student_discussion":
+      return extractGroupStudentRemarks(data);
+    case "individual_student_discussion":
+      return extractIndividualStudentRemarks(data);
+    case "school_staff_interaction":
+      return extractSchoolStaffRemarks(data);
+    default:
+      return [];
+  }
+}
+
+export function dispatchComputeInlineStats(actionType: string, data: unknown): unknown {
+  switch (actionType) {
+    case "classroom_observation":
+      return computeClassroomInlineStats(data);
+    case "af_team_interaction":
+      return computeAFTeamInlineStats(data);
+    case "individual_af_teacher_interaction":
+      return computeIndividualTeacherInlineStats(data);
+    case "principal_interaction":
+      return computePrincipalInlineStats(data);
+    case "group_student_discussion":
+      return computeGroupStudentInlineStats(data);
+    case "individual_student_discussion":
+      return computeIndividualStudentInlineStats(data);
+    case "school_staff_interaction":
+      return computeSchoolStaffInlineStats(data);
+    default:
+      return null;
+  }
 }
 
 function isRollupStatus(value: string): value is ActionTypeRollupStatus {

--- a/src/lib/visit-summary.ts
+++ b/src/lib/visit-summary.ts
@@ -1,0 +1,124 @@
+import { ACTION_TYPE_VALUES, isActionType, type ActionType } from "./visit-actions";
+
+export type RemarkEntry = { label: string; text: string };
+
+export type ActionTypeRollupStatus = "completed" | "in_progress" | "pending" | "not_started";
+export type ActionCompletionBucket = "none" | "partial" | "all_present" | "all_complete";
+export type DateRangePreset = "1d" | "7d" | "30d" | "90d" | "1y" | "all";
+
+const STATUS_RANK: Record<ActionTypeRollupStatus, number> = {
+  not_started: 0,
+  pending: 1,
+  in_progress: 2,
+  completed: 3,
+};
+
+const PRESET_DAYS: Record<Exclude<DateRangePreset, "all">, number> = {
+  "1d": 1,
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+  "1y": 365,
+};
+
+export function rollupActionTypes(
+  actions: Array<{ action_type: string; status: string }>
+): Record<ActionType, ActionTypeRollupStatus> {
+  const rollup = Object.fromEntries(
+    ACTION_TYPE_VALUES.map((actionType) => [actionType, "not_started"])
+  ) as Record<ActionType, ActionTypeRollupStatus>;
+
+  for (const action of actions) {
+    if (!isActionType(action.action_type)) {
+      continue;
+    }
+
+    if (!isRollupStatus(action.status)) {
+      continue;
+    }
+
+    if (STATUS_RANK[action.status] > STATUS_RANK[rollup[action.action_type]]) {
+      rollup[action.action_type] = action.status;
+    }
+  }
+
+  return rollup;
+}
+
+export function classifyActionCompletion(
+  rollup: Record<ActionType, ActionTypeRollupStatus>
+): ActionCompletionBucket {
+  const touchedCount = ACTION_TYPE_VALUES.filter(
+    (actionType) => rollup[actionType] !== "not_started"
+  ).length;
+  const completedCount = ACTION_TYPE_VALUES.filter(
+    (actionType) => rollup[actionType] === "completed"
+  ).length;
+
+  if (completedCount === ACTION_TYPE_VALUES.length) {
+    return "all_complete";
+  }
+  if (touchedCount === 0) {
+    return "none";
+  }
+  if (touchedCount === ACTION_TYPE_VALUES.length) {
+    return "all_present";
+  }
+  return "partial";
+}
+
+export function computeAverageCompletion(
+  completedTypeCountSum: number,
+  visitCount: number,
+  knownTypeCount = ACTION_TYPE_VALUES.length
+): number | null {
+  if (visitCount === 0) {
+    return null;
+  }
+  return (completedTypeCountSum / (visitCount * knownTypeCount)) * 100;
+}
+
+export function resolvePresetDateRange(
+  preset: string | undefined,
+  today: Date | string
+): { from: string; to: string } | null {
+  if (!isDateRangePreset(preset) || preset === "all") {
+    return null;
+  }
+
+  const to = toIstDateString(today);
+  const from = addDays(to, -(PRESET_DAYS[preset] - 1));
+
+  return { from, to };
+}
+
+function isRollupStatus(value: string): value is ActionTypeRollupStatus {
+  return value === "pending" || value === "in_progress" || value === "completed";
+}
+
+function isDateRangePreset(value: string | undefined): value is DateRangePreset {
+  return value === "1d" || value === "7d" || value === "30d" || value === "90d" || value === "1y" || value === "all";
+}
+
+function toIstDateString(value: Date | string): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Kolkata",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+  const partMap = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+
+  return `${partMap.year}-${partMap.month}-${partMap.day}`;
+}
+
+function addDays(yyyyMmDd: string, days: number): string {
+  const [year, month, day] = yyyyMmDd.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+
+  return date.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

Read-only admin dashboard for reviewing all PM school visits. Adds two new server-rendered pages (`/school-visit-summary` list and `/school-visit-summary/[id]` detail) accessible to admin and program_admin roles, with role-based redirects from `/visits`, header nav updates, and action detail back-link support.

**Key capabilities:**
- Paginated, sortable visit list with stat cards (total visits, unique PMs, completion %, avg completion)
- Tri-state action columns showing per-visit status for all 7 action types
- Cascading filter bar: school, PM, status, date (6 presets + manual range), completion bucket
- Detail page with metadata, GPS links, grouped actions with inline stats, and aggregated remarks
- Scope-aware access control reusing existing `buildVisitScopePredicate`
- All queries filter soft-deleted records (`deleted_at IS NULL`)
- Mobile-responsive card layout for small screens

**Architecture:**
- Pure function module (`visit-summary.ts`) for rollup, classification, averaging, date preset resolution
- Per-action-type `extractRemarks` and `computeInlineStats` added to all 7 existing modules
- Shared `GpsMapLink` component for GPS coordinate rendering
- Client-side filter bar with 300ms debounce and URL-based state

## Linked Issues

- Closes #52 — Visit Summary: list page with auth, sortable table, pagination, GPS links
- Closes #53 — Visit Summary: action rollup, stat cards, and tri-state columns
- Closes #54 — Visit Summary: route redirects, header nav, and action detail back-link
- Closes #55 — Visit Summary: filter bar with cascading dropdowns and date presets
- Closes #56 — Visit Summary: detail page with extractors, inline stats, and remarks
- Parent: #51

## Final Review

**Pass.** All 1865 unit tests passing across 111 files. All changed files pass ESLint cleanly. All acceptance criteria across 5 sub-issues verified.

Minor findings (non-blocking):
1. Dead code in `visits/page.tsx`: `isScopedRole` variable unreachable after admin/program_admin redirect
2. `nonEmptyString` helper duplicated across 7 action-type modules (could be shared utility)

## Human QA Checklist

### Access Control
- [ ] Admin user sees "Visit Summary" link in dashboard header nav
- [ ] Program admin sees "Visit Summary" link in dashboard header nav
- [ ] NVS-only program_admin does NOT see "Visit Summary" link
- [ ] PM does NOT see any visits nav link in dashboard
- [ ] Admin visiting `/visits` is redirected to `/school-visit-summary`
- [ ] Program admin visiting `/visits` is redirected to `/school-visit-summary`
- [ ] PM visiting `/visits` sees their own visit list (no redirect)
- [ ] Passcode user visiting `/visits` is redirected appropriately

### List Page (`/school-visit-summary`)
- [ ] Stat cards display correct aggregates (total visits, unique PMs, completion %, avg completion)
- [ ] Table is sortable by clicking column headers (visit_date, school, pm, status, duration, completion)
- [ ] Pagination works correctly (20 per page, page navigation)
- [ ] Action columns show correct tri-state indicators (completed/in-progress/not started)
- [ ] GPS "Start" and "End" links open Google Maps with correct coordinates
- [ ] Duration shows correctly for both completed and in-progress visits
- [ ] Mobile view shows card layout instead of table
- [ ] Empty state shows "No visits match your filters" message

### Filters
- [ ] School dropdown shows all schools in scope with multi-select
- [ ] PM dropdown shows all PMs in scope with multi-select
- [ ] Status filter works (in_progress / completed)
- [ ] Date presets work (Today, Last 7/30/90 days, This year, All time)
- [ ] Manual date range works and is mutually exclusive with presets
- [ ] Completion bucket filter works (all/complete/partial/none)
- [ ] Filters reset page to 1
- [ ] "Clear filters" button resets all filters
- [ ] CSV export button shows "Coming soon" tooltip (disabled)

### Detail Page (`/school-visit-summary/[id]`)
- [ ] Metadata section shows school, PM, date, status, timestamps, duration
- [ ] GPS section shows start/end coordinates with map links
- [ ] Actions grouped by type with inline stats chips
- [ ] "View full detail" links navigate to action detail with `?from=summary`
- [ ] Remarks section aggregates all non-empty remarks across actions
- [ ] Breadcrumb navigates back to list page

### Action Detail Back-links
- [ ] Action detail with `?from=summary` shows breadcrumb back to summary detail page
- [ ] Not-found state links back to `/school-visit-summary`
- [ ] Forbidden state links back to `/school-visit-summary`
- [ ] Missing/invalid `from` param falls back to `/visits`
