### PR TITLE
Show school name in admin user-management (Access column + chips)

### DIFF
--- a/src/app/admin/users/AddUserModal.test.tsx
+++ b/src/app/admin/users/AddUserModal.test.tsx
@@ -8,9 +8,15 @@ import AddUserModal from "./AddUserModal";
 
 const regions = ["North", "South", "East", "West"];
 
+const schoolCodeToName: Record<string, string> = {
+  SC001: "JNV Alpha",
+  SC002: "JNV Beta",
+};
+
 const defaultProps = {
   user: null,
   regions,
+  schoolCodeToName,
   onClose: vi.fn(),
   onSave: vi.fn(),
 };
@@ -306,8 +312,10 @@ describe("AddUserModal — school search (debounce)", () => {
       fireEvent.click(screen.getByText("Test School"));
     });
 
-    // School should appear as a chip
-    expect(screen.getByText("SC001")).toBeInTheDocument();
+    // Chip uses the page-level schoolCodeToName map (which has SC001 = "JNV Alpha").
+    // In production the search-result name and the map name come from the same
+    // DB column so they agree; in the test the fixture map wins.
+    expect(screen.getByText("JNV Alpha (SC001)")).toBeInTheDocument();
   });
 
   it("clears search results when level changes away from 1", async () => {
@@ -328,12 +336,20 @@ describe("AddUserModal — school search (debounce)", () => {
 // ---------------------------------------------------------------------------
 
 describe("AddUserModal — school chip management", () => {
-  it("shows pre-filled schools as chips in edit mode", () => {
+  it("shows pre-filled schools as chips with name + code in edit mode", () => {
     renderModal({
       user: { ...editUser, level: 1, school_codes: ["SC001", "SC002"], regions: null },
     });
-    expect(screen.getByText("SC001")).toBeInTheDocument();
-    expect(screen.getByText("SC002")).toBeInTheDocument();
+    expect(screen.getByText("JNV Alpha (SC001)")).toBeInTheDocument();
+    expect(screen.getByText("JNV Beta (SC002)")).toBeInTheDocument();
+  });
+
+  it("falls back to bare code when the school isn't in the map", () => {
+    renderModal({
+      user: { ...editUser, level: 1, school_codes: ["SC001", "MISSING"], regions: null },
+    });
+    expect(screen.getByText("JNV Alpha (SC001)")).toBeInTheDocument();
+    expect(screen.getByText("MISSING")).toBeInTheDocument();
   });
 
   it("removes school chip on × button click", async () => {
@@ -346,8 +362,8 @@ describe("AddUserModal — school chip management", () => {
     const removeButtons = screen.getAllByText("×");
     await user.click(removeButtons[0]);
 
-    expect(screen.queryByText("SC001")).not.toBeInTheDocument();
-    expect(screen.getByText("SC002")).toBeInTheDocument();
+    expect(screen.queryByText("JNV Alpha (SC001)")).not.toBeInTheDocument();
+    expect(screen.getByText("JNV Beta (SC002)")).toBeInTheDocument();
   });
 });
 

--- a/src/app/admin/users/AddUserModal.tsx
+++ b/src/app/admin/users/AddUserModal.tsx
@@ -27,6 +27,14 @@ interface AddUserModalProps {
   regions: string[];
   onClose: () => void;
   onSave: () => void;
+  /**
+   * Code → display name for every JNV school. Used to render chips for
+   * pre-existing school_codes when editing a user (the search-results path
+   * already knows the name; this fills the gap for codes that came in from
+   * the user_permission row). Codes missing from the map fall back to the
+   * raw code (e.g. a school that's since been deleted).
+   */
+  schoolCodeToName: Record<string, string>;
 }
 
 interface School {
@@ -37,7 +45,11 @@ interface School {
 
 const labelClassName = "block text-sm font-medium text-gray-700";
 
-export default function AddUserModal({ user, regions, onClose, onSave }: AddUserModalProps) {
+export default function AddUserModal({ user, regions, schoolCodeToName, onClose, onSave }: AddUserModalProps) {
+  const labelForSchool = (code: string) => {
+    const name = schoolCodeToName[code];
+    return name ? `${name} (${code})` : code;
+  };
   const [email, setEmail] = useState(user?.email || "");
   const [fullName, setFullName] = useState(user?.full_name || "");
   const [level, setLevel] = useState(user?.level || 1);
@@ -351,10 +363,11 @@ export default function AddUserModal({ user, regions, onClose, onSave }: AddUser
                         key={code}
                         className="inline-flex items-center rounded-full bg-hover-bg px-3 py-1 text-sm text-accent-hover"
                       >
-                        {code}
+                        {labelForSchool(code)}
                         <button
                           type="button"
                           onClick={() => removeSchool(code)}
+                          aria-label={`Remove ${labelForSchool(code)}`}
                           className="ml-2 text-accent hover:text-accent-hover"
                         >
                           &times;

--- a/src/app/admin/users/UserList.test.tsx
+++ b/src/app/admin/users/UserList.test.tsx
@@ -76,10 +76,16 @@ const users = [
 
 const regions = ["North", "South", "East", "West"];
 
+const schoolCodeToName: Record<string, string> = {
+  SCH001: "JNV Bhavnagar",
+  SCH002: "JNV Mumbai",
+};
+
 function renderList(
   overrides: {
     initialUsers?: typeof users;
     regions?: string[];
+    schoolCodeToName?: Record<string, string>;
     currentUserEmail?: string;
   } = {}
 ) {
@@ -87,6 +93,7 @@ function renderList(
     <UserList
       initialUsers={overrides.initialUsers ?? users}
       regions={overrides.regions ?? regions}
+      schoolCodeToName={overrides.schoolCodeToName ?? schoolCodeToName}
       currentUserEmail={overrides.currentUserEmail ?? currentUserEmail}
     />
   );
@@ -188,9 +195,21 @@ describe("UserList", () => {
       expect(screen.getByText("North, South")).toBeInTheDocument();
     });
 
-    it("shows school codes for level 1 users", () => {
+    it("shows school names (with code in parens) for level 1 users", () => {
       renderList();
-      expect(screen.getByText("SCH001, SCH002")).toBeInTheDocument();
+      expect(screen.getByText("JNV Bhavnagar (SCH001)")).toBeInTheDocument();
+      expect(screen.getByText("JNV Mumbai (SCH002)")).toBeInTheDocument();
+    });
+
+    it("falls back to raw code when a school is missing from the map", () => {
+      renderList({
+        initialUsers: [
+          { ...users[2], school_codes: ["SCH001", "ORPHAN_CODE"] },
+        ],
+        schoolCodeToName: { SCH001: "JNV Bhavnagar" },
+      });
+      expect(screen.getByText("JNV Bhavnagar (SCH001)")).toBeInTheDocument();
+      expect(screen.getByText("ORPHAN_CODE")).toBeInTheDocument();
     });
 
     it("shows 'No regions assigned' for level 2 user with null regions", () => {

--- a/src/app/admin/users/UserList.tsx
+++ b/src/app/admin/users/UserList.tsx
@@ -19,6 +19,13 @@ interface UserPermission {
 interface UserListProps {
   initialUsers: UserPermission[];
   regions: string[];
+  /**
+   * Map of school code → display name for every JNV school. Used to render the
+   * Access column as "Name (CODE)" instead of bare codes, and to label the
+   * selected-school chips in AddUserModal. Codes missing from the map fall
+   * back to the raw code (e.g. a school that's been deleted).
+   */
+  schoolCodeToName: Record<string, string>;
   currentUserEmail: string;
 }
 
@@ -54,7 +61,11 @@ const PROGRAM_LABELS: Record<number, string> = {
   64: "NVS",
 };
 
-export default function UserList({ initialUsers, regions, currentUserEmail }: UserListProps) {
+export default function UserList({ initialUsers, regions, schoolCodeToName, currentUserEmail }: UserListProps) {
+  const labelForSchool = (code: string) => {
+    const name = schoolCodeToName[code];
+    return name ? `${name} (${code})` : code;
+  };
   const [users, setUsers] = useState(initialUsers);
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingUser, setEditingUser] = useState<UserPermission | null>(null);
@@ -191,8 +202,14 @@ export default function UserList({ initialUsers, regions, currentUserEmail }: Us
                     <span className="text-gray-400">All JNV schools</span>
                   ) : user.level === 2 ? (
                     <span>{user.regions?.join(", ") || "No regions assigned"}</span>
+                  ) : user.school_codes && user.school_codes.length > 0 ? (
+                    <div className="flex flex-col gap-0.5">
+                      {user.school_codes.map((code) => (
+                        <span key={code}>{labelForSchool(code)}</span>
+                      ))}
+                    </div>
                   ) : (
-                    <span>{user.school_codes?.join(", ") || "No schools assigned"}</span>
+                    <span>No schools assigned</span>
                   )}
                 </td>
                 <td className="whitespace-nowrap px-3 py-4 text-sm">
@@ -223,6 +240,7 @@ export default function UserList({ initialUsers, regions, currentUserEmail }: Us
         <AddUserModal
           user={editingUser}
           regions={regions}
+          schoolCodeToName={schoolCodeToName}
           onClose={() => {
             setShowAddModal(false);
             setEditingUser(null);

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -71,6 +71,11 @@ const mockRegions = [
   { region: "Rajasthan", school_count: "12" },
 ];
 
+const mockSchoolNames = [
+  { code: "70705", name: "JNV Bhavnagar" },
+  { code: "14042", name: "JNV Mumbai" },
+];
+
 // ---- tests ----
 
 describe("UsersPage (server component)", () => {
@@ -102,13 +107,14 @@ describe("UsersPage (server component)", () => {
     expect(mockIsAdmin).toHaveBeenCalledWith("admin@avantifellows.org");
   });
 
-  it("fetches users and regions and renders UserList for admin", async () => {
+  it("fetches users, regions, and school names and renders UserList for admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
-    // query is called twice: once for users, once for regions
+    // query is called three times: users, regions, schools
     mockQuery
       .mockResolvedValueOnce(mockUsers)
-      .mockResolvedValueOnce(mockRegions);
+      .mockResolvedValueOnce(mockRegions)
+      .mockResolvedValueOnce(mockSchoolNames);
 
     const jsx = await UsersPage();
     render(jsx);
@@ -129,10 +135,14 @@ describe("UsersPage (server component)", () => {
     const props = JSON.parse(userList.getAttribute("data-props")!);
     expect(props.initialUsers).toEqual(mockUsers);
     expect(props.regions).toEqual(["Delhi", "Rajasthan"]);
+    expect(props.schoolCodeToName).toEqual({
+      "70705": "JNV Bhavnagar",
+      "14042": "JNV Mumbai",
+    });
     expect(props.currentUserEmail).toBe("admin@avantifellows.org");
 
-    // Verify both queries were called
-    expect(mockQuery).toHaveBeenCalledTimes(2);
+    // Verify all three queries were called
+    expect(mockQuery).toHaveBeenCalledTimes(3);
     // Users query
     const usersSql = mockQuery.mock.calls[0][0];
     expect(usersSql).toContain("user_permission");
@@ -141,12 +151,19 @@ describe("UsersPage (server component)", () => {
     const regionsSql = mockQuery.mock.calls[1][0];
     expect(regionsSql).toContain("af_school_category = 'JNV'");
     expect(regionsSql).toContain("GROUP BY region");
+    // Schools query
+    const schoolsSql = mockQuery.mock.calls[2][0];
+    expect(schoolsSql).toContain("SELECT code, name FROM school");
+    expect(schoolsSql).toContain("af_school_category = 'JNV'");
   });
 
-  it("renders with empty users and regions", async () => {
+  it("renders with empty users, regions, and schools", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
-    mockQuery.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
 
     const jsx = await UsersPage();
     render(jsx);
@@ -157,6 +174,7 @@ describe("UsersPage (server component)", () => {
     const props = JSON.parse(userList.getAttribute("data-props")!);
     expect(props.initialUsers).toEqual([]);
     expect(props.regions).toEqual([]);
+    expect(props.schoolCodeToName).toEqual({});
     expect(props.currentUserEmail).toBe("admin@avantifellows.org");
   });
 });

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -23,6 +23,11 @@ interface Region {
   school_count: string;
 }
 
+interface SchoolNameRow {
+  code: string;
+  name: string;
+}
+
 async function getUsers(): Promise<UserPermission[]> {
   return query<UserPermission>(
     `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name
@@ -41,6 +46,15 @@ async function getRegions(): Promise<Region[]> {
   );
 }
 
+async function getSchoolCodeToName(): Promise<Record<string, string>> {
+  const rows = await query<SchoolNameRow>(
+    `SELECT code, name FROM school WHERE af_school_category = 'JNV'`
+  );
+  const map: Record<string, string> = {};
+  for (const r of rows) map[r.code] = r.name;
+  return map;
+}
+
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
 
@@ -53,7 +67,11 @@ export default async function UsersPage() {
     redirect("/dashboard");
   }
 
-  const [users, regions] = await Promise.all([getUsers(), getRegions()]);
+  const [users, regions, schoolCodeToName] = await Promise.all([
+    getUsers(),
+    getRegions(),
+    getSchoolCodeToName(),
+  ]);
 
   return (
     <div className="min-h-screen bg-bg">
@@ -86,6 +104,7 @@ export default async function UsersPage() {
         <UserList
           initialUsers={users}
           regions={regions.map(r => r.region)}
+          schoolCodeToName={schoolCodeToName}
           currentUserEmail={session.user.email}
         />
       </main>


### PR DESCRIPTION
## Summary

The user-management UI showed bare school codes everywhere school assignment surfaced:
- **Access column** on the user list (e.g. \`SC001, SC002\`)
- **Selected-school chips** in AddUserModal after picking from search

Codes alone are unreadable; admins were having to cross-reference each code against the school directory. Replace with \`Name (Code)\` so the name is the primary thing seen, code is preserved for unambiguous lookups.

## How

- \`page.tsx\` fetches a school code → name map server-side (one query, ~few-hundred JNV rows) and passes a \`schoolCodeToName: Record<string, string>\` prop through \`UserList\` into \`AddUserModal\`.
- \`UserList\` renders each assigned school on its own line in the Access column using a small \`labelForSchool\` helper.
- \`AddUserModal\` uses the same helper for the selected-school chips and the chip remove-button aria-label.
- Falls back to the bare code if a school is missing from the map (e.g. a school that's since been deleted) — both surfaces tested.

## Test plan

- [x] \`npm run test\` — 1917/1917 pass (93 in \`src/app/admin/users/\`, +2 new for the new behavior + fallback).
- [x] Lint clean.
- [ ] Visual check on staging: open user-management → confirm Access column shows \"Name (Code)\" stacked per school; open Add User → assign a level-1 user to a school → confirm chips show name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)