### PR TITLE
Tag LMS quiz sessions without name prefix

### DIFF
--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -361,6 +361,8 @@ describe("POST /api/quiz-sessions", () => {
         gurukul_format_type: "omr",
         status: "pending",
         has_synced_to_bq: false,
+        created_by: ADMIN_SESSION.user.email,
+        created_from: "lms",
       },
     });
     expect(mocks.mockPublishMessage).toHaveBeenCalledWith({

--- a/src/app/api/quiz-sessions/route.ts
+++ b/src/app/api/quiz-sessions/route.ts
@@ -20,7 +20,6 @@ import {
 
 const DB_SERVICE_URL = process.env.DB_SERVICE_URL;
 const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN;
-const LMS_SESSION_PREFIX = "[LMS] ";
 
 interface SessionRow {
   id: number;
@@ -56,9 +55,7 @@ interface CreateQuizSessionBody {
 }
 
 function getDefaultSessionName(baseName: string): string {
-  return baseName.startsWith(LMS_SESSION_PREFIX)
-    ? baseName
-    : `${LMS_SESSION_PREFIX}${baseName}`;
+  return baseName.trim();
 }
 
 async function getBatchesForSchool(
@@ -403,6 +400,8 @@ export async function POST(request: NextRequest) {
       test_takers_count: 100,
       status: "pending",
       date_created: utcToISTDate(new Date().toISOString()),
+      created_by: session.user.email,
+      created_from: "lms",
     },
   };
 

--- a/src/components/quiz-sessions/QuizSessionsTab.test.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.test.tsx
@@ -168,7 +168,7 @@ describe("QuizSessionsTab", () => {
         sessions = [
           {
             id: 99,
-            name: String(createdPayload.name || "[LMS] Part Test 11"),
+            name: String(createdPayload.name || "Part Test 11"),
             start_time: String(createdPayload.startTime),
             end_time: String(createdPayload.endTime),
             is_active: true,
@@ -290,7 +290,7 @@ describe("QuizSessionsTab", () => {
         parentBatchId: "EnableStudents_11_Engg",
         classBatchIds: ["EnableStudents_11_Engg_A", "EnableStudents_11_Engg_B"],
         stream: "engineering",
-        name: "[LMS] Part Test 11",
+        name: "Part Test 11",
         showAnswers: false,
         showScores: true,
         shuffle: false,
@@ -301,7 +301,7 @@ describe("QuizSessionsTab", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(screen.queryByRole("heading", { name: "Create Quiz Session" })).not.toBeInTheDocument();
-      expect(screen.getByText("[LMS] Part Test 11")).toBeInTheDocument();
+      expect(screen.getByText("Part Test 11")).toBeInTheDocument();
       expect(screen.getByText("Processing")).toBeInTheDocument();
       expect(screen.getByText("Queued")).toBeInTheDocument();
     });

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -78,12 +78,9 @@ interface BatchDerivation {
 const PER_PAGE = 50;
 const DEFAULT_DURATION_HOURS = 4;
 const AUTO_SYNC_INTERVAL_MINUTES = 30;
-const LMS_SESSION_PREFIX = "[LMS] ";
 
 function getDefaultSessionName(baseName: string): string {
-  return baseName.startsWith(LMS_SESSION_PREFIX)
-    ? baseName
-    : `${LMS_SESSION_PREFIX}${baseName}`;
+  return baseName.trim();
 }
 
 function getCompactBatchLabel(values: string[] | undefined): string {


### PR DESCRIPTION
## Summary
- stop prefixing LMS-created quiz session names with [LMS]
- store created_by and created_from metadata for LMS-created quiz sessions

## Verification
- source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm test -- --run src/app/api/quiz-sessions/route.test.ts src/components/quiz-sessions/QuizSessionsTab.test.tsx