### PR TITLE
Remove quiz session toggle action icon

### DIFF
--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -826,17 +826,9 @@ export default function QuizSessionsTab({
                     setMenuState(null);
                   }}
                   disabled={sessionProcessing || busy}
-                  className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
+                  className="block w-full px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
                 >
-                  <span>{enabled ? "Disable Session" : "Enable Session"}</span>
-                  <span
-                    className={`text-base leading-none ${
-                      enabled ? "text-accent" : "text-red-700"
-                    }`}
-                    aria-hidden="true"
-                  >
-                    {enabled ? "✓" : "✕"}
-                  </span>
+                  {enabled ? "Disable Session" : "Enable Session"}
                 </button>
                 {endNowAvailable ? (
                   <button


### PR DESCRIPTION
## Summary
- remove the trailing tick/cross from the Enable/Disable Session dropdown action
- keep the row styled consistently with the other action menu items

## Verification
- source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm test -- --run src/components/quiz-sessions/QuizSessionsTab.test.tsx