### PR TITLE
Filter curriculum topics by selected exam track

### DIFF
--- a/scripts/seed-curriculum-dummy-data.ts
+++ b/scripts/seed-curriculum-dummy-data.ts
@@ -124,6 +124,12 @@ const SEED_CASES: SeedCase[] = [
   },
 ];
 
+const EXAM_TRACK_CURRICULUM_IDS: Record<SeedCase["examTrack"], number> = {
+  jee_main: 1,
+  jee_advanced: 9,
+  neet: 2,
+};
+
 function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     mode: "seed",
@@ -278,7 +284,12 @@ async function fetchChaptersForCase(
      JOIN chapter ch ON ch.id = cfg.chapter_id
      JOIN grade g ON g.id = ch.grade_id
      JOIN subject s ON s.id = ch.subject_id
-     LEFT JOIN topic t ON t.chapter_id = ch.id
+     LEFT JOIN (
+       topic t
+       JOIN topic_curriculum tc
+         ON tc.topic_id = t.id
+        AND tc.curriculum_id = $5
+     ) ON t.chapter_id = ch.id
      WHERE cfg.is_in_syllabus = true
        AND cfg.exam_track = $1
        AND g.number = $2
@@ -306,6 +317,7 @@ async function fetchChaptersForCase(
       seedCase.grade,
       seedCase.subjectName,
       seedCase.chapterLimit,
+      EXAM_TRACK_CURRICULUM_IDS[seedCase.examTrack],
     ]
   );
 

--- a/src/app/api/curriculum/chapters/route.test.ts
+++ b/src/app/api/curriculum/chapters/route.test.ts
@@ -132,6 +132,11 @@ describe("GET /api/curriculum/chapters", () => {
         prescribedMinutes: 120,
       }),
     ]);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("JOIN topic_curriculum tc"),
+      ["neet", 12, 3, 2]
+    );
   });
 
   it("returns 403 for passcode users", async () => {

--- a/src/app/api/curriculum/logs/route.test.ts
+++ b/src/app/api/curriculum/logs/route.test.ts
@@ -168,7 +168,7 @@ describe("/api/curriculum/logs", () => {
     });
     expect(mockQuery).toHaveBeenLastCalledWith(
       expect.stringContaining("AND l.deleted_at IS NULL"),
-      ["70705", 1, 3, 4, "jee_main"]
+      ["70705", 1, 3, 4, "jee_main", 1]
     );
   });
 

--- a/src/app/api/curriculum/progress/route.test.ts
+++ b/src/app/api/curriculum/progress/route.test.ts
@@ -134,7 +134,7 @@ describe("GET /api/curriculum/progress", () => {
     expect(mockQuery).toHaveBeenNthCalledWith(
       5,
       expect.stringContaining("AND l.deleted_at IS NULL"),
-      ["70705", 1, 3, 4, "jee_main", 11]
+      ["70705", 1, 3, 4, "jee_main", 11, 1]
     );
   });
 
@@ -183,8 +183,8 @@ describe("GET /api/curriculum/progress", () => {
     });
     expect(mockQuery).toHaveBeenNthCalledWith(
       5,
-      expect.stringContaining("LEFT JOIN topic t ON t.chapter_id = ch.id"),
-      ["70705", 1, 3, 4, "jee_main", 11]
+      expect.stringContaining("JOIN topic_curriculum topic_scope"),
+      ["70705", 1, 3, 4, "jee_main", 11, 1]
     );
   });
 

--- a/src/components/curriculum/CurriculumTab.test.tsx
+++ b/src/components/curriculum/CurriculumTab.test.tsx
@@ -80,6 +80,7 @@ vi.mock("./SessionHistory", () => ({
 
 vi.mock("./LogSessionModal", () => ({
   default: (props: {
+    chapters: Chapter[];
     onSave: (payload: {
       date: string;
       durationMinutes: number;
@@ -91,7 +92,10 @@ vi.mock("./LogSessionModal", () => ({
     isSaving?: boolean;
     editLog?: { id: number } | null;
   }) => (
-    <div data-testid="log-session-modal">
+    <div
+      data-testid="log-session-modal"
+      data-chapters={JSON.stringify(props.chapters)}
+    >
       {props.editLog && <div>Editing log {props.editLog.id}</div>}
       {props.error && <div>{props.error}</div>}
       <button
@@ -208,6 +212,37 @@ const logsResponse = {
     },
   ],
 };
+const biologyProgressResponse = {
+  subjectTotalTimeMinutes: 30,
+  progress: {
+    2: {
+      chapterId: 2,
+      completedTopicIds: [201],
+      totalTimeMinutes: 30,
+      lastTaughtDate: "2026-02-16",
+      allTopicsCovered: false,
+      isChapterComplete: false,
+      chapterCompletedDate: null,
+    },
+  },
+};
+const biologyLogsResponse = {
+  logs: [
+    {
+      id: 20,
+      logDate: "2026-02-16",
+      durationMinutes: 30,
+      programId: 1,
+      gradeId: 4,
+      subjectId: 3,
+      examTrack: "neet",
+      topics: [{ topicId: 201, topicName: "Algae", chapterId: 2, chapterName: "Plant Kingdom" }],
+      isEditable: true,
+      createdAt: "2026-02-16T10:00:00.000Z",
+      updatedAt: "2026-02-16T10:00:00.000Z",
+    },
+  ],
+};
 
 function mockOkJson(body: unknown) {
   return Promise.resolve({ ok: true, json: async () => body });
@@ -227,14 +262,20 @@ function setupFetch() {
     if (url === "/api/curriculum/options?school_code=70705") {
       return mockOkJson(optionsResponse);
     }
+    if (url.includes("/api/curriculum/logs?") && url.includes("exam_track=neet")) {
+      return mockOkJson(biologyLogsResponse);
+    }
+    if (url.includes("/api/curriculum/progress?") && url.includes("exam_track=neet")) {
+      return mockOkJson(biologyProgressResponse);
+    }
+    if (url.includes("/api/curriculum/chapters?") && url.includes("exam_track=neet")) {
+      return mockOkJson({ chapters: biologyChapters });
+    }
     if (url.includes("/api/curriculum/logs?")) {
       return mockOkJson(logsResponse);
     }
     if (url.includes("/api/curriculum/progress?")) {
       return mockOkJson(progressResponse);
-    }
-    if (url.includes("exam_track=neet")) {
-      return mockOkJson({ chapters: biologyChapters });
     }
     return mockOkJson({ chapters: physicsChapters });
   });
@@ -323,7 +364,43 @@ describe("CurriculumTab", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "/api/curriculum/chapters?school_code=70705&program_id=1&exam_track=neet&grade=12&subject=Biology"
       );
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/curriculum/logs?school_code=70705&program_id=1&exam_track=neet&grade=12&subject=Biology"
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/curriculum/progress?school_code=70705&program_id=1&exam_track=neet&grade=12&subject=Biology"
+      );
     });
+
+    expect(screen.getByTestId("chapter-accordion")).toHaveAttribute(
+      "data-chapters",
+      JSON.stringify(biologyChapters)
+    );
+    expect(screen.getByTestId("progress-summary")).toHaveAttribute(
+      "data-subject-total-time-minutes",
+      "30"
+    );
+  });
+
+  it("opens Add Log with chapters from the active filter scope", async () => {
+    const user = userEvent.setup();
+    renderTab({ canEdit: true });
+
+    await screen.findByTestId("chapter-accordion");
+    await user.selectOptions(screen.getByLabelText("Exam Track"), "neet");
+    await waitFor(() =>
+      expect(screen.getByTestId("chapter-accordion")).toHaveAttribute(
+        "data-chapters",
+        JSON.stringify(biologyChapters)
+      )
+    );
+
+    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+
+    expect(screen.getByTestId("log-session-modal")).toHaveAttribute(
+      "data-chapters",
+      JSON.stringify(biologyChapters)
+    );
   });
 
   it("shows backend Logs and opens the Add Log modal", async () => {

--- a/src/components/curriculum/CurriculumTab.tsx
+++ b/src/components/curriculum/CurriculumTab.tsx
@@ -81,6 +81,19 @@ export default function CurriculumTab({
       : "chapters"
   );
 
+  const resetScopeInteractionState = useCallback(() => {
+    setLogError(null);
+    setCompletionError(null);
+    setEditingLog(null);
+    setIsLogSessionModalOpen(false);
+    setExpandedChapterIds([]);
+    setIsDataLoading(true);
+    setChapters([]);
+    setLogs([]);
+    setProgress({});
+    setSubjectTotalTimeMinutes(0);
+  }, []);
+
   useEffect(() => {
     let isCancelled = false;
 
@@ -131,6 +144,7 @@ export default function CurriculumTab({
       setLogs([]);
       setProgress({});
       setSubjectTotalTimeMinutes(0);
+      setIsDataLoading(false);
       return;
     }
 
@@ -145,6 +159,10 @@ export default function CurriculumTab({
       setError(null);
       setLogError(null);
       setCompletionError(null);
+      setChapters([]);
+      setLogs([]);
+      setProgress({});
+      setSubjectTotalTimeMinutes(0);
 
       const params = new URLSearchParams({
         school_code: schoolCode,
@@ -264,6 +282,7 @@ export default function CurriculumTab({
 
   function handleExamTrackChange(track: ExamTrack) {
     const first = selectFirstGradeSubject(options?.gradeSubjects ?? [], track);
+    resetScopeInteractionState();
     setSelectedExamTrack(track);
     setSelectedGrade(first?.grade ?? null);
     setSelectedSubject(first?.subject ?? null);
@@ -275,6 +294,7 @@ export default function CurriculumTab({
       selectedExamTrack,
       grade
     );
+    resetScopeInteractionState();
     setSelectedGrade(grade);
     setSelectedSubject(first?.subject ?? null);
   }
@@ -465,7 +485,10 @@ export default function CurriculumTab({
               <select
                 id="curriculum-program"
                 value={selectedProgramId ?? ""}
-                onChange={(event) => setSelectedProgramId(Number(event.target.value))}
+                onChange={(event) => {
+                  resetScopeInteractionState();
+                  setSelectedProgramId(Number(event.target.value));
+                }}
                 className="block w-36 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-accent focus:ring-1 focus:ring-accent/20"
               >
                 {options.programs.map((program) => (
@@ -534,7 +557,10 @@ export default function CurriculumTab({
               id="subject"
               value={selectedSubject ?? ""}
               disabled={subjectOptions.length === 0}
-              onChange={(event) => setSelectedSubject(event.target.value as SubjectName)}
+              onChange={(event) => {
+                resetScopeInteractionState();
+                setSelectedSubject(event.target.value as SubjectName);
+              }}
               className="block w-32 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-accent focus:ring-1 focus:ring-accent/20 disabled:bg-gray-100 disabled:text-gray-500"
             >
               {subjectOptions.map((option) => (
@@ -549,7 +575,7 @@ export default function CurriculumTab({
 
           {canEdit && (
             <button
-              disabled={!selectedProgramId || chapters.length === 0}
+              disabled={!selectedProgramId || isDataLoading || chapters.length === 0}
               onClick={() => {
                 setLogError(null);
                 setEditingLog(null);

--- a/src/lib/curriculum-config.test.ts
+++ b/src/lib/curriculum-config.test.ts
@@ -491,13 +491,15 @@ describe("curriculum config chapter option helpers", () => {
     });
 
     const sql = mockQuery.mock.calls[0][0] as string;
-    expect(sql).toContain("LEFT JOIN topic t ON t.chapter_id = ch.id");
+    expect(sql).toContain("JOIN topic_curriculum tc");
+    expect(sql).toContain("tc.curriculum_id = $2");
     expect(sql).toContain("cfg.exam_track = $1");
-    expect(sql).toContain("grade = $2::int");
-    expect(sql).toContain("subject_id::text = $3::text");
-    expect(sql).toContain("LOWER(chapter_name) LIKE $4::text");
+    expect(sql).toContain("grade = $3::int");
+    expect(sql).toContain("subject_id::text = $4::text");
+    expect(sql).toContain("LOWER(chapter_name) LIKE $5::text");
     expect(mockQuery.mock.calls[0][1]).toEqual([
       "jee_main",
+      1,
       11,
       "4",
       "%motion%",

--- a/src/lib/curriculum-config.ts
+++ b/src/lib/curriculum-config.ts
@@ -294,6 +294,11 @@ interface RemoveMutationRow extends CurriculumConfigQueryRow {
 }
 
 const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
+const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
+  jee_main: 1,
+  jee_advanced: 9,
+  neet: 2,
+};
 const SYLLABUS_STATUSES: CurriculumConfigSyllabusStatus[] = [
   "in_syllabus",
   "out_of_syllabus",
@@ -646,6 +651,7 @@ export async function getCurriculumConfigChapterOptions(
     buildChapterOptionsSql(),
     [
       params.examTrack,
+      EXAM_TRACK_CURRICULUM_IDS[params.examTrack],
       params.grade,
       params.subject,
       params.search ? `%${params.search.toLowerCase()}%` : null,
@@ -1108,7 +1114,12 @@ function buildChapterOptionsSql(): string {
       FROM chapter ch
       JOIN grade g ON g.id = ch.grade_id
       JOIN subject s ON s.id = ch.subject_id
-      LEFT JOIN topic t ON t.chapter_id = ch.id
+      LEFT JOIN (
+        topic t
+        JOIN topic_curriculum tc
+          ON tc.topic_id = t.id
+         AND tc.curriculum_id = $2
+      ) ON t.chapter_id = ch.id
       LEFT JOIN lms_chapter_exam_configs cfg
         ON cfg.chapter_id = ch.id
        AND cfg.exam_track = $1
@@ -1124,16 +1135,16 @@ function buildChapterOptionsSql(): string {
     )
     SELECT *
     FROM chapter_options
-    WHERE ($2::int IS NULL OR grade = $2::int)
-      AND (
-        $3::text IS NULL
-        OR subject_id::text = $3::text
-        OR LOWER(subject_name) = LOWER($3::text)
-      )
+    WHERE ($3::int IS NULL OR grade = $3::int)
       AND (
         $4::text IS NULL
-        OR LOWER(chapter_code) LIKE $4::text
-        OR LOWER(chapter_name) LIKE $4::text
+        OR subject_id::text = $4::text
+        OR LOWER(subject_name) = LOWER($4::text)
+      )
+      AND (
+        $5::text IS NULL
+        OR LOWER(chapter_code) LIKE $5::text
+        OR LOWER(chapter_name) LIKE $5::text
       )
     ORDER BY grade ASC, subject_name ASC, chapter_code ASC, chapter_name ASC
     LIMIT 50`;

--- a/src/lib/curriculum-logs.ts
+++ b/src/lib/curriculum-logs.ts
@@ -1,6 +1,7 @@
 import type { PoolClient } from "pg";
 import { query, withTransaction } from "./db";
 import {
+  curriculumIdForExamTrack,
   isExamTrack,
   isGradeNumber,
   isSubjectName,
@@ -174,6 +175,7 @@ export async function validateSelectedScope(params: {
       subject: SubjectName;
       gradeId: number;
       subjectId: number;
+      curriculumId: number;
     }
   | CurriculumValidationFailure
   | { ok: false; status: 403 | 404; error: string }
@@ -205,6 +207,7 @@ export async function validateSelectedScope(params: {
     subject: params.subject,
     gradeId: GRADE_IDS[params.grade],
     subjectId: SUBJECT_IDS[params.subject],
+    curriculumId: curriculumIdForExamTrack(params.examTrack),
   };
 }
 
@@ -222,6 +225,9 @@ async function loadValidTopics(params: {
        ch.name AS chapter_name
      FROM topic t
      JOIN chapter ch ON ch.id = t.chapter_id
+     JOIN topic_curriculum tc
+       ON tc.topic_id = t.id
+      AND tc.curriculum_id = $5
      JOIN grade g ON g.id = ch.grade_id
      JOIN lms_chapter_exam_configs cfg
        ON cfg.chapter_id = ch.id
@@ -230,7 +236,13 @@ async function loadValidTopics(params: {
      WHERE t.id = ANY($2::int[])
        AND g.number = $3
        AND ch.subject_id = $4`,
-    [params.examTrack, params.topicIds, params.grade, params.subjectId]
+    [
+      params.examTrack,
+      params.topicIds,
+      params.grade,
+      params.subjectId,
+      curriculumIdForExamTrack(params.examTrack),
+    ]
   );
 }
 
@@ -248,6 +260,9 @@ async function loadValidTopicsForStoredScope(params: {
        ch.name AS chapter_name
      FROM topic t
      JOIN chapter ch ON ch.id = t.chapter_id
+     JOIN topic_curriculum tc
+       ON tc.topic_id = t.id
+      AND tc.curriculum_id = $5
      JOIN lms_chapter_exam_configs cfg
        ON cfg.chapter_id = ch.id
       AND cfg.exam_track = $1
@@ -255,7 +270,13 @@ async function loadValidTopicsForStoredScope(params: {
      WHERE t.id = ANY($2::int[])
        AND ch.grade_id = $3
        AND ch.subject_id = $4`,
-    [params.examTrack, params.topicIds, params.gradeId, params.subjectId]
+    [
+      params.examTrack,
+      params.topicIds,
+      params.gradeId,
+      params.subjectId,
+      curriculumIdForExamTrack(params.examTrack),
+    ]
   );
 }
 
@@ -274,9 +295,16 @@ async function loadLogMutationScope(id: number): Promise<LogMutationScopeRow | n
              SELECT 1
              FROM lms_chapter_exam_configs current_cfg
              JOIN topic current_topic ON current_topic.chapter_id = current_cfg.chapter_id
+             JOIN topic_curriculum current_tc
+               ON current_tc.topic_id = current_topic.id
              WHERE current_topic.id = lt.topic_id
                AND current_cfg.exam_track = l.exam_track
                AND current_cfg.is_in_syllabus = true
+               AND current_tc.curriculum_id = CASE l.exam_track
+                 WHEN 'jee_main' THEN 1
+                 WHEN 'jee_advanced' THEN 9
+                 WHEN 'neet' THEN 2
+               END
            )
          ),
          false
@@ -421,13 +449,19 @@ export async function getCurriculumLogs(params: {
        EXISTS (
          SELECT 1
          FROM lms_chapter_exam_configs current_cfg
+         JOIN topic_curriculum current_tc
+           ON current_tc.topic_id = t.id
          WHERE current_cfg.chapter_id = ch.id
            AND current_cfg.exam_track = l.exam_track
            AND current_cfg.is_in_syllabus = true
+           AND current_tc.curriculum_id = $6
        ) AS topic_currently_in_syllabus
      FROM lms_curriculum_logs l
      JOIN lms_curriculum_log_topics lt ON lt.curriculum_log_id = l.id
      JOIN topic t ON t.id = lt.topic_id
+     JOIN topic_curriculum tc
+       ON tc.topic_id = t.id
+      AND tc.curriculum_id = $6
      JOIN chapter ch ON ch.id = t.chapter_id
      WHERE l.school_code = $1
        AND l.program_id = $2
@@ -442,6 +476,7 @@ export async function getCurriculumLogs(params: {
       scope.gradeId,
       scope.subjectId,
       scope.examTrack,
+      scope.curriculumId,
     ]
   );
 
@@ -467,13 +502,27 @@ export async function getCurriculumLogById(id: number): Promise<LmsCurriculumLog
        EXISTS (
          SELECT 1
          FROM lms_chapter_exam_configs current_cfg
+         JOIN topic_curriculum current_tc
+           ON current_tc.topic_id = t.id
          WHERE current_cfg.chapter_id = ch.id
            AND current_cfg.exam_track = l.exam_track
            AND current_cfg.is_in_syllabus = true
+           AND current_tc.curriculum_id = CASE l.exam_track
+             WHEN 'jee_main' THEN 1
+             WHEN 'jee_advanced' THEN 9
+             WHEN 'neet' THEN 2
+           END
        ) AS topic_currently_in_syllabus
      FROM lms_curriculum_logs l
      JOIN lms_curriculum_log_topics lt ON lt.curriculum_log_id = l.id
      JOIN topic t ON t.id = lt.topic_id
+     JOIN topic_curriculum tc
+       ON tc.topic_id = t.id
+      AND tc.curriculum_id = CASE l.exam_track
+        WHEN 'jee_main' THEN 1
+        WHEN 'jee_advanced' THEN 9
+        WHEN 'neet' THEN 2
+      END
      JOIN chapter ch ON ch.id = t.chapter_id
      WHERE l.id = $1
        AND l.deleted_at IS NULL

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -17,6 +17,11 @@ import type {
 export const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
 const CURRICULUM_PROGRAM_IDS: number[] = [PROGRAM_IDS.COE, PROGRAM_IDS.NODAL];
 const SUBJECT_ORDER: SubjectName[] = ["Physics", "Chemistry", "Maths", "Biology"];
+const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
+  jee_main: 1,
+  jee_advanced: 9,
+  neet: 2,
+};
 
 interface SchoolScopeRow {
   code: string;
@@ -105,6 +110,10 @@ export function isGradeNumber(value: number): value is GradeNumber {
 
 export function isSubjectName(value: string): value is SubjectName {
   return SUBJECT_ORDER.includes(value as SubjectName);
+}
+
+export function curriculumIdForExamTrack(examTrack: ExamTrack): number {
+  return EXAM_TRACK_CURRICULUM_IDS[examTrack];
 }
 
 function sortByCurriculumOrder<T extends { examTrack: ExamTrack; grade: number; subject: SubjectName }>(
@@ -271,6 +280,7 @@ export async function getCurriculumChapters(params: {
   if (!scope.allowedProgramIds.includes(params.programId)) {
     return { ok: false, status: 403, error: "Forbidden" };
   }
+  const curriculumId = curriculumIdForExamTrack(params.examTrack);
 
   const rows = await query<ChapterScopeRow>(
     `SELECT
@@ -291,7 +301,12 @@ export async function getCurriculumChapters(params: {
      JOIN chapter ch ON ch.id = cfg.chapter_id
      JOIN grade g ON g.id = ch.grade_id
      JOIN subject s ON s.id = ch.subject_id
-     LEFT JOIN topic t ON t.chapter_id = ch.id
+     LEFT JOIN (
+       topic t
+       JOIN topic_curriculum tc
+         ON tc.topic_id = t.id
+        AND tc.curriculum_id = $4
+     ) ON t.chapter_id = ch.id
      WHERE cfg.exam_track = $1
        AND cfg.is_in_syllabus = true
        AND g.number = $2
@@ -303,6 +318,7 @@ export async function getCurriculumChapters(params: {
       ({ Maths: 1, Chemistry: 2, Biology: 3, Physics: 4 } as Record<SubjectName, number>)[
         params.subject
       ],
+      curriculumId,
     ]
   );
 

--- a/src/lib/curriculum-progress.ts
+++ b/src/lib/curriculum-progress.ts
@@ -83,6 +83,9 @@ export async function getCurriculumProgress(params: {
          COUNT(*) OVER (PARTITION BY l.id) AS total_topics_in_log
        FROM lms_curriculum_logs l
        JOIN lms_curriculum_log_topics lt ON lt.curriculum_log_id = l.id
+       JOIN topic_curriculum tc
+         ON tc.topic_id = lt.topic_id
+        AND tc.curriculum_id = $7
        WHERE l.school_code = $1
          AND l.program_id = $2
          AND l.grade_id = $3
@@ -100,7 +103,12 @@ export async function getCurriculumProgress(params: {
      FROM lms_chapter_exam_configs cfg
      JOIN chapter ch ON ch.id = cfg.chapter_id
      JOIN grade g ON g.id = ch.grade_id
-     LEFT JOIN topic t ON t.chapter_id = ch.id
+     LEFT JOIN (
+       topic t
+       JOIN topic_curriculum topic_scope
+         ON topic_scope.topic_id = t.id
+        AND topic_scope.curriculum_id = $7
+     ) ON t.chapter_id = ch.id
      LEFT JOIN scoped_log_topics slt ON slt.topic_id = t.id
      WHERE cfg.exam_track = $5
        AND cfg.is_in_syllabus = true
@@ -114,6 +122,7 @@ export async function getCurriculumProgress(params: {
       scope.subjectId,
       scope.examTrack,
       scope.grade,
+      scope.curriculumId,
     ]
   );
 

--- a/src/lib/curriculum-schema.test.ts
+++ b/src/lib/curriculum-schema.test.ts
@@ -47,6 +47,8 @@ describe("curriculum schema preflight", () => {
         "lms_curriculum_logs",
         "log_date",
         "deleted_at",
+        "topic_curriculum",
+        "curriculum_id",
       ])
     );
   });

--- a/src/lib/curriculum-schema.ts
+++ b/src/lib/curriculum-schema.ts
@@ -31,6 +31,8 @@ const REQUIRED_COLUMNS: Array<{ table: string; column: string }> = [
   { table: "lms_curriculum_logs", column: "deleted_at" },
   { table: "lms_curriculum_log_topics", column: "curriculum_log_id" },
   { table: "lms_curriculum_log_topics", column: "topic_id" },
+  { table: "topic_curriculum", column: "topic_id" },
+  { table: "topic_curriculum", column: "curriculum_id" },
   { table: "lms_curriculum_chapter_completions", column: "school_code" },
   { table: "lms_curriculum_chapter_completions", column: "program_id" },
   { table: "lms_curriculum_chapter_completions", column: "chapter_id" },


### PR DESCRIPTION
## Summary
- Filter curriculum chapter topics through topic_curriculum for the selected exam track
- Apply the same topic scope to log validation, log reads, progress calculations, config picker counts, and dummy seeding
- Clear stale curriculum tab state while a new Program / Exam Track / Grade / Subject scope loads

## Tests
- npm test -- --run src/lib/curriculum-schema.test.ts src/app/api/curriculum/chapters/route.test.ts src/app/api/curriculum/progress/route.test.ts src/app/api/curriculum/logs/route.test.ts src/app/api/curriculum/logs/'[id]'/route.test.ts src/lib/curriculum-config.test.ts src/components/curriculum/CurriculumTab.test.tsx src/lib/curriculum-summary.test.ts src/app/curriculum-summary/config/CurriculumConfigTable.test.tsx
- npx eslint scripts/seed-curriculum-dummy-data.ts src/app/api/curriculum/chapters/route.test.ts src/app/api/curriculum/logs/route.test.ts src/app/api/curriculum/progress/route.test.ts src/components/curriculum/CurriculumTab.test.tsx src/components/curriculum/CurriculumTab.tsx src/lib/curriculum-config.test.ts src/lib/curriculum-config.ts src/lib/curriculum-logs.ts src/lib/curriculum-options.ts src/lib/curriculum-progress.ts src/lib/curriculum-schema.test.ts src/lib/curriculum-schema.ts