### PR TITLE
Fix quiz session grade source

### DIFF
--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -186,7 +186,7 @@ describe("GET /api/quiz-sessions", () => {
 });
 
 describe("POST /api/quiz-sessions", () => {
-  it("returns 400 when selected template grade does not match the selected batches", async () => {
+  it("returns 400 when selected template is missing grade metadata", async () => {
     const { POST } = await loadRouteModule();
     mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
     mocks.mockFetch.mockResolvedValueOnce(
@@ -196,7 +196,6 @@ describe("POST /api/quiz-sessions", () => {
         code: "PT-12",
         name: [{ resource: "Part Test 12", lang_code: "en" }],
         type_params: {
-          grade: 12,
           stream: "engineering",
           test_format: "part_test",
           test_purpose: "weekly_test",
@@ -225,7 +224,7 @@ describe("POST /api/quiz-sessions", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
-      error: "Selected template grade does not match selected batches",
+      error: "Selected template is missing grade metadata",
     });
     expect(mocks.mockFetch).toHaveBeenCalledTimes(1);
     expect(mocks.mockPublishMessage).not.toHaveBeenCalled();

--- a/src/app/api/quiz-sessions/route.ts
+++ b/src/app/api/quiz-sessions/route.ts
@@ -268,9 +268,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  if (!body.grade || !body.stream) {
+  if (!body.stream) {
     return NextResponse.json(
-      { error: "grade and stream are required" },
+      { error: "stream is required" },
       { status: 400 }
     );
   }
@@ -290,9 +290,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (selectedTemplate.grade !== null && selectedTemplate.grade !== Number(body.grade)) {
+  if (selectedTemplate.grade === null) {
     return NextResponse.json(
-      { error: "Selected template grade does not match selected batches" },
+      { error: "Selected template is missing grade metadata" },
       { status: 400 }
     );
   }
@@ -361,7 +361,7 @@ export async function POST(request: NextRequest) {
       batch_id: Array.isArray(body.classBatchIds)
         ? body.classBatchIds.join(",")
         : body.classBatchIds,
-      grade: Number(body.grade),
+      grade: selectedTemplate.grade,
       course: selectedTemplate.course,
       stream: body.stream,
       resource_id: selectedTemplate.id,

--- a/src/components/quiz-sessions/QuizSessionsTab.test.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.test.tsx
@@ -52,6 +52,32 @@ function makeBatches() {
   ];
 }
 
+function makeTargetProgramBatches() {
+  return [
+    {
+      id: 958,
+      name: "JNV CoE 2028 Engineering Quiz Batch",
+      batch_id: "EN-TP-2028-engg-C01",
+      parent_id: null,
+      program_id: 1,
+    },
+    {
+      id: 5541,
+      name: "CoE JNV Hassan 2028 Engineering",
+      batch_id: "EnableStudents_TP_2028_engg_C013",
+      parent_id: 958,
+      program_id: 1,
+    },
+    {
+      id: 5542,
+      name: "CoE JNV Kottayam 2028 Engineering",
+      batch_id: "EnableStudents_TP_2028_engg_C017",
+      parent_id: 958,
+      program_id: 1,
+    },
+  ];
+}
+
 function makeSessions() {
   return [
     {
@@ -313,9 +339,63 @@ describe("QuizSessionsTab", () => {
 
     const templateCallUrl = String(getFetchCalls(mockFetch, "/api/quiz-sessions/templates?")[0][0]);
     const templateParams = new URL(templateCallUrl, "http://localhost").searchParams;
-    expect(templateParams.get("grade")).toBe("11");
+    expect(templateParams.get("grade")).toBeNull();
     expect(templateParams.get("stream")).toBe("engineering");
     expect(templateParams.get("testFormat")).toBe("part_test");
+  });
+
+  it("creates a session from target-program batch IDs", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.startsWith("/api/quiz-sessions/batches")) {
+        return jsonResponse({ batches: makeTargetProgramBatches() });
+      }
+
+      if (url.startsWith("/api/quiz-sessions/templates")) {
+        return jsonResponse({ templates: [makeTemplate()] });
+      }
+
+      if (url.startsWith("/api/quiz-sessions?")) {
+        return jsonResponse({ sessions: [], hasMore: false });
+      }
+
+      if (url === "/api/quiz-sessions" && init?.method === "POST") {
+        createdPayload = JSON.parse(String(init.body));
+        return jsonResponse({ id: 99 });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    render(<QuizSessionsTab schoolId="school-1" canEdit />);
+
+    await user.click(await screen.findByRole("button", { name: "Create Quiz Session" }));
+    await user.click(screen.getByLabelText("CoE JNV Hassan 2028 Engineering"));
+    await user.click(screen.getByLabelText("CoE JNV Kottayam 2028 Engineering"));
+    await user.selectOptions(screen.getAllByRole("combobox")[1], "part_test");
+
+    expect(await screen.findByText("Part Test 11")).toBeInTheDocument();
+    await user.click(screen.getByText("Part Test 11"));
+    await user.click(screen.getByRole("button", { name: "Create Session" }));
+
+    await waitFor(() => {
+      expect(createdPayload).toMatchObject({
+        grade: 11,
+        parentBatchId: "EN-TP-2028-engg-C01",
+        classBatchIds: [
+          "EnableStudents_TP_2028_engg_C013",
+          "EnableStudents_TP_2028_engg_C017",
+        ],
+        stream: "engineering",
+      });
+    });
+
+    const templateCallUrl = String(getFetchCalls(mockFetch, "/api/quiz-sessions/templates?")[0][0]);
+    const templateParams = new URL(templateCallUrl, "http://localhost").searchParams;
+    expect(templateParams.get("grade")).toBeNull();
+    expect(templateParams.get("stream")).toBe("engineering");
   });
 
   it("shows compact sync status without manual sync controls", async () => {

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -69,7 +69,6 @@ interface QuizTemplateOption {
 
 interface BatchDerivation {
   error: string | null;
-  grade: number | null;
   stream: string;
   parentBatchId: string;
   parentBatchName: string;
@@ -92,13 +91,6 @@ function getCompactBatchLabel(values: string[] | undefined): string {
   if (!values?.length) return "-";
   if (values.length === 1) return values[0];
   return `${values[0]} +${values.length - 1}`;
-}
-
-function parseBatchGrade(batchId: string): number | null {
-  const parts = batchId.split("_");
-  if (parts.length < 2) return null;
-  const value = Number(parts[1]);
-  return Number.isNaN(value) ? null : value;
 }
 
 function formatDateTime(value: string | null | undefined): string {
@@ -939,7 +931,6 @@ function QuizSessionCreateModal({
     if (selectedRows.length === 0) {
       return {
         error: null,
-        grade: null,
         stream: "",
         parentBatchId: "",
         parentBatchName: "",
@@ -954,7 +945,6 @@ function QuizSessionCreateModal({
     if (parentIds.size !== 1) {
       return {
         error: "Selected class batches must belong to the same parent batch.",
-        grade: null,
         stream: "",
         parentBatchId: "",
         parentBatchName: "",
@@ -966,22 +956,6 @@ function QuizSessionCreateModal({
     if (!parentRow) {
       return {
         error: "Unable to find the parent batch for the selected class batches.",
-        grade: null,
-        stream: "",
-        parentBatchId: "",
-        parentBatchName: "",
-      };
-    }
-
-    const gradeSet = new Set(
-      selectedRows
-        .map((row) => parseBatchGrade(row.batch_id))
-        .filter((grade): grade is number => grade !== null)
-    );
-    if (gradeSet.size !== 1) {
-      return {
-        error: "Selected class batches must have the same grade.",
-        grade: null,
         stream: "",
         parentBatchId: "",
         parentBatchName: "",
@@ -991,8 +965,9 @@ function QuizSessionCreateModal({
     const streamSet = new Set(
       selectedRows
         .map((row) => {
-          if (row.batch_id.includes("_Engg_")) return "engineering";
-          if (row.batch_id.includes("_Med_")) return "medical";
+          const batchId = row.batch_id.toLowerCase();
+          if (batchId.includes("_engg_")) return "engineering";
+          if (batchId.includes("_med_")) return "medical";
           return "";
         })
         .filter(Boolean)
@@ -1000,7 +975,6 @@ function QuizSessionCreateModal({
     if (streamSet.size !== 1) {
       return {
         error: "Unable to derive stream from the selected class batches.",
-        grade: null,
         stream: "",
         parentBatchId: "",
         parentBatchName: "",
@@ -1009,7 +983,6 @@ function QuizSessionCreateModal({
 
     return {
       error: null,
-      grade: Array.from(gradeSet)[0],
       stream: Array.from(streamSet)[0],
       parentBatchId: parentRow.batch_id,
       parentBatchName: parentRow.name,
@@ -1024,11 +997,7 @@ function QuizSessionCreateModal({
   }, [startTime, endTimeEdited]);
 
   useEffect(() => {
-    if (
-      !batchDerivation.grade ||
-      !batchDerivation.stream ||
-      !testFormat
-    ) {
+    if (!batchDerivation.stream || !testFormat) {
       setTemplates([]);
       setSelectedTemplateId(null);
       setTemplateError(null);
@@ -1042,7 +1011,6 @@ function QuizSessionCreateModal({
 
       try {
         const params = new URLSearchParams({
-          grade: String(batchDerivation.grade),
           stream: batchDerivation.stream,
           testFormat,
         });
@@ -1073,7 +1041,6 @@ function QuizSessionCreateModal({
       cancelled = true;
     };
   }, [
-    batchDerivation.grade,
     batchDerivation.stream,
     testFormat,
   ]);
@@ -1113,11 +1080,14 @@ function QuizSessionCreateModal({
     if (classBatchIds.length === 0) return "At least one class batch is required.";
     if (batchDerivation.error) return batchDerivation.error;
     if (!batchDerivation.parentBatchId) return "Parent batch could not be derived.";
-    if (!batchDerivation.grade || !batchDerivation.stream) {
+    if (!batchDerivation.stream) {
       return "Batch details could not be derived.";
     }
     if (!testFormat) return "Test format is required.";
     if (!selectedTemplate) return "Please select a paper.";
+    if (selectedTemplate.grade === null) {
+      return "Selected paper is missing grade metadata.";
+    }
 
     if (timingMode === "schedule") {
       const start = new Date(startTime);
@@ -1140,7 +1110,7 @@ function QuizSessionCreateModal({
       return;
     }
 
-    if (!selectedTemplate || !batchDerivation.grade) return;
+    if (!selectedTemplate || selectedTemplate.grade === null) return;
 
     setSaving(true);
     setError(null);
@@ -1156,7 +1126,7 @@ function QuizSessionCreateModal({
       const payload = {
         name: name.trim() || getDefaultSessionName(selectedTemplate.name),
         resourceId: selectedTemplate.id,
-        grade: batchDerivation.grade,
+        grade: selectedTemplate.grade,
         parentBatchId: batchDerivation.parentBatchId,
         classBatchIds,
         stream: batchDerivation.stream,
@@ -1286,7 +1256,6 @@ function QuizSessionCreateModal({
                   </div>
 
                   {!classBatchIds.length ||
-                  !batchDerivation.grade ||
                   !batchDerivation.stream ||
                   batchDerivation.error ||
                   !testFormat ? (


### PR DESCRIPTION
## Summary
- stop deriving quiz session grade from selected class batch IDs
- fetch quiz templates by stream and test format only, then use the selected template grade for session creation
- keep parent-batch validation and make stream detection case-insensitive for new TP batch IDs

## Verification
- pnpm vitest run src/components/quiz-sessions/QuizSessionsTab.test.tsx src/app/api/quiz-sessions/route.test.ts src/app/api/quiz-sessions/templates/route.test.ts
- read-only DB sanity check for sample new school_batch mappings: JNV Hassan, JNV Medak, JNV Chamarajanagar, JNV Palghar