### PR TITLE
Restrict student search to the current academic year cohort

### DIFF
--- a/src/app/api/students/search/route.test.ts
+++ b/src/app/api/students/search/route.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/db", () => ({ query: vi.fn() }));
 import { getServerSession } from "next-auth";
 import { getAccessibleSchoolCodes } from "@/lib/permissions";
 import { query } from "@/lib/db";
+import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
 import { GET } from "./route";
 import { NO_SESSION, ADMIN_SESSION } from "../../__test-utils__/api-test-helpers";
 
@@ -59,8 +60,13 @@ describe("GET /api/students/search", () => {
     expect(json).toEqual(results);
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining("af_school_category = 'JNV'"),
-      ["%john%"],
+      ["%john%", CURRENT_ACADEMIC_YEAR],
     );
+    // Current-cohort rule shared with the canonical roster: results are
+    // restricted to students enrolled for the current academic year.
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("er.academic_year = $2");
+    expect(sql).not.toContain("s.grade_id");
   });
 
   it("searches specific schools when user has limited access", async () => {
@@ -73,7 +79,9 @@ describe("GET /api/students/search", () => {
     expect(res.status).toBe(200);
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining("sch.code = ANY($1)"),
-      [["70705", "70706"], "%test%"],
+      [["70705", "70706"], "%test%", CURRENT_ACADEMIC_YEAR],
     );
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("er.academic_year = $3");
   });
 });

--- a/src/app/api/students/search/route.ts
+++ b/src/app/api/students/search/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getAccessibleSchoolCodes } from "@/lib/permissions";
 import { query } from "@/lib/db";
+import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
 
 interface StudentSearchResult {
   user_id: string;
@@ -58,7 +59,16 @@ export async function GET(request: NextRequest) {
       JOIN group_user gu ON gu.user_id = u.id
       JOIN "group" g ON gu.group_id = g.id AND g.type = 'school'
       JOIN school sch ON g.child_id = sch.id
-      LEFT JOIN grade gr ON s.grade_id = gr.id
+      -- Same current-cohort rule as the canonical school roster: only
+      -- students enrolled for the current academic year. Passed-out cohorts
+      -- keep is_current=true grade records forever, so the year filter is
+      -- what excludes them. Grade comes from the enrollment record (the
+      -- roster's source), not the stale student.grade_id column.
+      JOIN enrollment_record er ON er.user_id = u.id
+        AND er.group_type = 'grade'
+        AND er.is_current = true
+        AND er.academic_year = $2
+      LEFT JOIN grade gr ON er.group_id = gr.id
       WHERE sch.af_school_category = 'JNV'
         AND (
           u.first_name ILIKE $1
@@ -69,7 +79,7 @@ export async function GET(request: NextRequest) {
         )
       ORDER BY u.first_name, u.last_name
       LIMIT 20`,
-      [searchPattern]
+      [searchPattern, CURRENT_ACADEMIC_YEAR]
     );
   } else {
     // User has access to specific schools only
@@ -88,7 +98,13 @@ export async function GET(request: NextRequest) {
       JOIN group_user gu ON gu.user_id = u.id
       JOIN "group" g ON gu.group_id = g.id AND g.type = 'school'
       JOIN school sch ON g.child_id = sch.id
-      LEFT JOIN grade gr ON s.grade_id = gr.id
+      -- See the all-schools query above: current-cohort rule shared with the
+      -- canonical school roster.
+      JOIN enrollment_record er ON er.user_id = u.id
+        AND er.group_type = 'grade'
+        AND er.is_current = true
+        AND er.academic_year = $3
+      LEFT JOIN grade gr ON er.group_id = gr.id
       WHERE sch.code = ANY($1)
         AND sch.af_school_category = 'JNV'
         AND (
@@ -100,7 +116,7 @@ export async function GET(request: NextRequest) {
         )
       ORDER BY u.first_name, u.last_name
       LIMIT 20`,
-      [schoolCodes, searchPattern]
+      [schoolCodes, searchPattern, CURRENT_ACADEMIC_YEAR]
     );
   }
 


### PR DESCRIPTION
Closes the last gap from the student-list audit (follow-up to #119).

## Audit summary

| Surface | Status |
|---|---|
| Enrollment tab roster | ✅ canonical `getSchoolRoster` (#119) |
| Performance test deep-dive | ✅ roster (#119) |
| PM visit student picker (`/api/pm/students`) | ✅ roster (#119) |
| Dashboard grade counts | ✅ already had the `academic_year` filter |
| BQ-backed surfaces | ✅ cohort-correct via `academic_year` in dim/fact |
| **Dashboard global student search** | ❌ **fixed here** |

## The gap

`GET /api/students/search` joined school membership with no enrollment filter and read grade from `student.grade_id` — a third, stale grade source. Passed-out students appeared in search results wearing their old "Grade 12" badge and dead-ended on school rosters that (correctly) no longer list them.

## Fix

Both query variants now inner-join the current academic year's grade `enrollment_record` (same rule as the canonical roster) and take grade from it. Students who dropped out this year remain findable (they hold a current-year record), matching the Enrollment tab's dropout section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)