### PR TITLE
Staff Management v1 + centre-seat access model (resolveScope, strict exclusivity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "db:setup-permissions": "npx ts-node scripts/setup-permissions.ts",
     "centres:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-centres.ts",
+    "staff:backfill": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/backfill-staff.ts",
     "centres:seed-options": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/seed-centre-options.ts",
     "curriculum:seed-dummy": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/seed-curriculum-dummy-data.ts",
     "deploy:staging": "./scripts/deploy.sh staging",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:setup-permissions": "npx ts-node scripts/setup-permissions.ts",
     "centres:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-centres.ts",
     "staff:backfill": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/backfill-staff.ts",
+    "staff:clear-seated-scope": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/clear-seated-school-codes.ts",
     "centres:seed-options": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/seed-centre-options.ts",
     "curriculum:seed-dummy": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/seed-curriculum-dummy-data.ts",
     "deploy:staging": "./scripts/deploy.sh staging",

--- a/scripts/backfill-staff.ts
+++ b/scripts/backfill-staff.ts
@@ -1,0 +1,125 @@
+/**
+ * Backfill teachers/PMs from user_permission into user/teacher/staff +
+ * centre_positions. See src/lib/staff-backfill.ts for the rules.
+ *
+ * Usage:
+ *   npm run staff:backfill                       # dry-run against .env.local (staging)
+ *   npm run staff:backfill -- --apply
+ *   npm run staff:backfill -- --env-file=.env.production
+ *   npm run staff:backfill -- --sheet=path.tsv --hr=path.json
+ */
+
+import * as dotenv from "dotenv";
+import type { BackfillMode, BackfillReport } from "../src/lib/staff-backfill";
+
+interface CliOptions {
+  mode: BackfillMode;
+  envFile: string;
+  sheetPath: string;
+  hrPath: string;
+  verbose: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    mode: "dry-run",
+    envFile: ".env.local",
+    sheetPath: "docs/ai/teacher-staff/review-sheet-latest.tsv",
+    hrPath: "docs/ai/teacher-staff/hr-employees.json",
+    verbose: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") options.help = true;
+    else if (arg === "--apply") options.mode = "apply";
+    else if (arg === "--dry-run") options.mode = "dry-run";
+    else if (arg === "--verbose" || arg === "-v") options.verbose = true;
+    else if (arg.startsWith("--env=")) options.envFile = `.env.${arg.slice(6)}`;
+    else if (arg.startsWith("--env-file=")) options.envFile = arg.slice(11);
+    else if (arg.startsWith("--sheet=")) options.sheetPath = arg.slice(8);
+    else if (arg.startsWith("--hr=")) options.hrPath = arg.slice(5);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printReport(report: BackfillReport, verbose: boolean): void {
+  console.log(`Staff backfill (${report.mode})`);
+  if (!report.ok && report.error) console.error(report.error);
+
+  const c = report.counts;
+  console.log(`Source rows: ${c.sourceTeachers} teachers, ${c.sourcePms} PMs`);
+  console.log(`Skipped (test account / excluded): ${c.skipped}`);
+  console.log(`Users: ${c.usersToCreate} to create, ${c.usersLinked} linked to existing`);
+  console.log(
+    `Teachers: ${c.teachersToCreate} to create, ${c.teachersLinkedExisting} existing rows updated; ` +
+      `${c.teachersWithCode} with AF code, ${c.teachersWithoutCode} WITHOUT code (fill via admin UI)`
+  );
+  console.log(
+    `Staff (PMs): ${c.staffToCreate} to create, ${c.staffPendingNoCode} pending (no code -> no staff row yet)`
+  );
+  console.log(`Seats: ${c.seatsToCreate} to create, ${c.seatsExisting} already present`);
+
+  const skipped = report.plans.filter((p) => p.skipped);
+  if (skipped.length > 0) {
+    console.log(`\nSkipped people:`);
+    for (const p of skipped) console.log(`- ${p.email} (${p.skipReason})`);
+  }
+
+  if (report.warnings.length > 0) {
+    console.log(`\nWarnings / gaps (${report.warnings.length}):`);
+    for (const w of report.warnings) console.log(`- ${w}`);
+  }
+
+  if (verbose) {
+    console.log(`\nPer-person plan:`);
+    for (const p of report.plans) {
+      if (p.skipped) continue;
+      const seats = p.seats
+        .map((s) => `${s.role}@${s.centreName}`)
+        .join(", ");
+      console.log(
+        `- ${p.email} [${p.role}] code=${p.code ?? "—"} (${p.codeSource}) user=${p.userAction}` +
+          (p.role === "teacher" ? ` teacher=${p.teacherAction}` : ` staff=${p.staffAction}`) +
+          (seats ? ` seats: ${seats}` : "")
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(
+      `Usage: npm run staff:backfill -- [--apply|--dry-run] [--env-file=.env.local] [--sheet=path.tsv] [--hr=path.json] [--verbose]`
+    );
+    return;
+  }
+
+  dotenv.config({ path: options.envFile, quiet: true });
+
+  const [{ runStaffBackfill }, dbModule] = await Promise.all([
+    import("../src/lib/staff-backfill"),
+    import("../src/lib/db"),
+  ]);
+
+  try {
+    const report = await runStaffBackfill({
+      mode: options.mode,
+      sheetPath: options.sheetPath,
+      hrPath: options.hrPath,
+    });
+    printReport(report, options.verbose);
+    if (!report.ok) process.exitCode = 1;
+  } finally {
+    await dbModule.default.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/clear-seated-school-codes.ts
+++ b/scripts/clear-seated-school-codes.ts
@@ -1,0 +1,103 @@
+/**
+ * One-time migration: clear explicit user_permission.school_codes/regions for
+ * everyone holding a centre seat, so seats become the sole source of school
+ * scope (strict per-user exclusivity). See src/lib/clear-seated-scope.ts.
+ *
+ * Usage:
+ *   npm run staff:clear-seated-scope                      # dry-run vs .env.local (staging)
+ *   npm run staff:clear-seated-scope -- --apply
+ *   npm run staff:clear-seated-scope -- --env-file=.env.production --apply
+ *
+ * Run dry-run first and read the STRANDED worklist: those people lose access to
+ * uncovered schools on clear — ops must create/link the missing centres + seats
+ * before (or right after) applying.
+ */
+
+import * as dotenv from "dotenv";
+import type {
+  ClearSeatedScopeMode,
+  ClearSeatedScopeReport,
+} from "../src/lib/clear-seated-scope";
+
+interface CliOptions {
+  mode: ClearSeatedScopeMode;
+  envFile: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    mode: "dry-run",
+    envFile: ".env.local",
+    help: false,
+  };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") options.help = true;
+    else if (arg === "--apply") options.mode = "apply";
+    else if (arg === "--dry-run") options.mode = "dry-run";
+    else if (arg.startsWith("--env=")) options.envFile = `.env.${arg.slice(6)}`;
+    else if (arg.startsWith("--env-file=")) options.envFile = arg.slice(11);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printReport(report: ClearSeatedScopeReport): void {
+  console.log(`Clear seated school scope (${report.mode})`);
+  if (!report.ok && report.error) console.error(report.error);
+  console.log(
+    `Seated users still carrying explicit school_codes/regions: ${report.usersWithExplicitScope}`
+  );
+  console.log(
+    `${report.mode === "apply" ? "Cleared" : "Would clear"}: ${report.usersCleared}`
+  );
+
+  if (report.strandedUsers.length > 0) {
+    console.log(
+      `\n⚠️  STRANDED (${report.strandedUsers.length}) — seated people whose school_codes are NOT all seat-covered.`
+    );
+    console.log(
+      `   These schools LOSE access on clear. Ops: create/link the centres + seats for them.`
+    );
+    for (const u of report.strandedUsers) {
+      console.log(
+        `   - ${u.email} (user_id=${u.userId}) loses: ${u.uncoveredCodes.join(", ")} | ` +
+          `seats cover: ${u.seatSchoolCodes.join(", ") || "(none)"}`
+      );
+    }
+  } else {
+    console.log(
+      `\nNo stranded users — every seated person's school_codes are fully seat-covered.`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(
+      `Usage: npm run staff:clear-seated-scope -- [--apply|--dry-run] [--env-file=.env.local]`
+    );
+    return;
+  }
+
+  dotenv.config({ path: options.envFile, quiet: true });
+
+  const [{ runClearSeatedScope }, dbModule] = await Promise.all([
+    import("../src/lib/clear-seated-scope"),
+    import("../src/lib/db"),
+  ]);
+
+  try {
+    const report = await runClearSeatedScope({ mode: options.mode });
+    printReport(report);
+    if (!report.ok) process.exitCode = 1;
+  } finally {
+    await dbModule.default.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -78,6 +78,15 @@ export default async function AdminPage() {
             </Card>
           </Link>
 
+          <Link href="/admin/staff">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Staff Management</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Manage AF teachers, PMs, employee codes, and Centre seats.
+              </p>
+            </Card>
+          </Link>
+
           <Link href="/admin/centres/config">
             <Card className="block p-6">
               <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Option Configuration</h3>

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import StaffGrid from "./StaffGrid";
+import type {
+  StaffRosterFilters,
+  StaffRosterRow,
+  StaffRosterSummary,
+} from "@/lib/staff-shared";
+
+const FILTERS: StaffRosterFilters = {
+  search: "",
+  kind: "all",
+  code: "all",
+  exited: "exclude",
+  centreId: null,
+};
+
+const SUMMARY: StaffRosterSummary = {
+  total: 3,
+  teachers: 2,
+  staff: 0,
+  pending: 1,
+  missingCode: 2,
+  exited: 0,
+  vacantSeats: 4,
+};
+
+const ROWS: StaffRosterRow[] = [
+  {
+    kind: "teacher",
+    recordId: 10,
+    userId: 70,
+    name: "Asha Teacher",
+    email: "asha@avantifellows.org",
+    employeeCode: "AF101",
+    subjectName: "Physics",
+    staffType: null,
+    designation: "Senior Teacher",
+    exitDate: null,
+    seats: [{ id: 44, centreId: 8, centreName: "JNV Adilabad - CoE", role: "physics" }],
+  },
+  {
+    kind: "teacher",
+    recordId: 11,
+    userId: 71,
+    name: "Binu Codeless",
+    email: "binu@avantifellows.org",
+    employeeCode: null,
+    subjectName: null,
+    staffType: null,
+    designation: null,
+    exitDate: null,
+    seats: [],
+  },
+  {
+    kind: "pending_pm",
+    recordId: 5,
+    userId: null,
+    name: "Pending Pm",
+    email: "pm@avantifellows.org",
+    employeeCode: null,
+    subjectName: null,
+    staffType: "program_manager",
+    designation: null,
+    exitDate: null,
+    seats: [],
+  },
+];
+
+function stubFetch(
+  handler?: (url: string, init?: RequestInit) => Response | undefined
+) {
+  const mockFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const handled = handler?.(url, init);
+    if (handled) return handled;
+    if (url.startsWith("/api/admin/centres")) {
+      return new Response(
+        JSON.stringify({
+          rows: [
+            { id: 8, name: "JNV Adilabad - CoE" },
+            { id: 3, name: "JNV Bengaluru" },
+          ],
+        }),
+        { status: 200 }
+      );
+    }
+    if (url.startsWith("/api/admin/staff?")) {
+      return new Response(JSON.stringify({ rows: ROWS, summary: SUMMARY }), {
+        status: 200,
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", mockFetch);
+  return mockFetch;
+}
+
+function renderGrid() {
+  return render(
+    <StaffGrid
+      initialRows={ROWS}
+      initialSummary={SUMMARY}
+      initialFilters={FILTERS}
+    />
+  );
+}
+
+describe("StaffGrid", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders summary stats and groups rows by centre", () => {
+    stubFetch();
+    renderGrid();
+    expect(screen.getByText("Missing AF ID")).toBeTruthy();
+    // Appears as the group header and as the card's Centre field
+    expect(screen.getAllByText("JNV Adilabad - CoE").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("No Centre assigned")).toBeTruthy();
+    expect(screen.getByText("Asha Teacher")).toBeTruthy();
+    expect(screen.getByText("AF101")).toBeTruthy();
+    expect(screen.getAllByText("No AF ID")).toHaveLength(2);
+    expect(screen.getByText("PM (no staff record)")).toBeTruthy();
+  });
+
+  it("shows labeled fields on the card", () => {
+    stubFetch();
+    renderGrid();
+    expect(screen.getAllByText("Role").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Centre").length).toBeGreaterThan(0);
+    expect(screen.getByText("Physics")).toBeTruthy();
+  });
+
+  it("offers a Centre filter fed by the centres API", async () => {
+    stubFetch();
+    renderGrid();
+    const select = screen.getByLabelText("Filter by Centre");
+    await waitFor(() => {
+      expect(select.querySelectorAll("option").length).toBe(3); // All + 2 centres
+    });
+  });
+
+  it("saves an AF code for a teacher via PATCH from the edit modal", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url.startsWith("/api/admin/staff/teachers/") && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Edit Binu Codeless"));
+    fireEvent.change(screen.getByLabelText("Employee code"), {
+      target: { value: "af202" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff/teachers/11",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ teacher_id: "AF202" }),
+        })
+      );
+    });
+    // Modal closes after a successful save
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Employee code")).toBeNull();
+    });
+  });
+
+  it("creates a staff record for a pending PM via POST", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url === "/api/admin/staff/members" && init?.method === "POST") {
+        return new Response(JSON.stringify({ ok: true }), { status: 201 });
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Edit Pending Pm"));
+    fireEvent.change(screen.getByLabelText("Employee code"), {
+      target: { value: "AF300" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff/members",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            user_permission_id: 5,
+            employee_code: "AF300",
+          }),
+        })
+      );
+    });
+  });
+
+  it("surfaces action errors inside the modal", async () => {
+    stubFetch((url, init) => {
+      if (url.startsWith("/api/admin/staff/teachers/") && init?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ error: "Employee code AF1 is already used" }),
+          { status: 409 }
+        );
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Edit Binu Codeless"));
+    fireEvent.change(screen.getByLabelText("Employee code"), {
+      target: { value: "AF1" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Employee code AF1 is already used")).toBeTruthy();
+    });
+  });
+
+  it("vacates a seat from the edit modal via PATCH with user_id null", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url === "/api/admin/staff/positions/44" && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Edit Asha Teacher"));
+    fireEvent.click(
+      screen.getByLabelText("Remove Physics assignment at JNV Adilabad - CoE")
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff/positions/44",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ user_id: null }),
+        })
+      );
+    });
+  });
+
+  it("requires arming before marking exited", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url.startsWith("/api/admin/staff/teachers/") && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Edit Asha Teacher"));
+    expect(screen.queryByText("Confirm exit")).toBeNull();
+    fireEvent.click(screen.getByText("Mark exited…"));
+    fireEvent.click(screen.getByText("Confirm exit"));
+
+    await waitFor(() => {
+      const exitCall = mockFetch.mock.calls.find(
+        (call) => String(call[0]) === "/api/admin/staff/teachers/10"
+      );
+      expect(exitCall).toBeTruthy();
+      expect(String((exitCall![1] as RequestInit).body)).toContain("exit_date");
+    });
+  });
+
+  it("hides the Edit button for not-backfilled teachers", () => {
+    stubFetch();
+    render(
+      <StaffGrid
+        initialRows={[
+          {
+            ...ROWS[1],
+            kind: "pending_teacher",
+            name: "Pending Teacher",
+          },
+        ]}
+        initialSummary={SUMMARY}
+        initialFilters={FILTERS}
+      />
+    );
+    expect(screen.queryByLabelText("Edit Pending Teacher")).toBeNull();
+  });
+});

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -114,6 +114,11 @@ export default function StaffGrid({
   const [seatRoleDraft, setSeatRoleDraft] = useState<SeatRole>("physics");
   const [actionError, setActionError] = useState("");
   const [actionBusy, setActionBusy] = useState(false);
+  // Seat id awaiting a "remove anyway" confirmation (the server flagged it as
+  // the person's last seat). Null when no confirmation is pending.
+  const [confirmVacateSeatId, setConfirmVacateSeatId] = useState<number | null>(
+    null
+  );
 
   const modalRow = useMemo(
     () => (modalKey === null ? null : (rows.find((row) => rowKey(row) === modalKey) ?? null)),
@@ -194,6 +199,7 @@ export default function StaffGrid({
   const closeModal = () => {
     setModalKey(null);
     setActionError("");
+    setConfirmVacateSeatId(null);
   };
 
   const runAction = async (
@@ -296,14 +302,36 @@ export default function StaffGrid({
     );
   };
 
-  const vacateSeat = (seatId: number) => {
-    return runAction(() =>
-      fetch(`/api/admin/staff/positions/${seatId}`, {
+  // Vacate a seat. The server blocks removing a person's *last* seat (409 with
+  // code "last_seat") unless force=true; on that block we surface an inline
+  // "remove anyway" confirmation rather than failing silently.
+  const vacateSeat = async (seatId: number, force = false) => {
+    setActionBusy(true);
+    setActionError("");
+    try {
+      const url = `/api/admin/staff/positions/${seatId}${force ? "?force=true" : ""}`;
+      const response = await fetch(url, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ user_id: null }),
-      })
-    );
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        if (response.status === 409 && data.code === "last_seat") {
+          setConfirmVacateSeatId(seatId);
+          return false;
+        }
+        throw new Error(data.error || "Action failed");
+      }
+      setConfirmVacateSeatId(null);
+      await fetchRoster(filters);
+      return true;
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Action failed");
+      return false;
+    } finally {
+      setActionBusy(false);
+    }
   };
 
   const canEdit = (row: StaffRosterRow) => row.kind !== "pending_teacher";
@@ -570,16 +598,40 @@ export default function StaffGrid({
                         <span>
                           {SEAT_ROLE_LABELS[seat.role]} @ {seat.centreName}
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => void vacateSeat(seat.id)}
-                          disabled={actionBusy}
-                          className="text-danger hover:text-danger/80"
-                          aria-label={`Remove ${SEAT_ROLE_LABELS[seat.role]} assignment at ${seat.centreName}`}
-                          title="Remove assignment (keeps the position open)"
-                        >
-                          <X className="h-4 w-4" />
-                        </button>
+                        {confirmVacateSeatId === seat.id ? (
+                          <span className="flex items-center gap-2">
+                            <span className="text-xs text-brand-coral">
+                              Only seat — remove anyway?
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => void vacateSeat(seat.id, true)}
+                              disabled={actionBusy}
+                              className="text-xs font-bold text-danger hover:text-danger/80"
+                            >
+                              Remove
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmVacateSeatId(null)}
+                              disabled={actionBusy}
+                              className="text-xs text-text-muted hover:text-text"
+                            >
+                              Cancel
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => void vacateSeat(seat.id)}
+                            disabled={actionBusy}
+                            className="text-danger hover:text-danger/80"
+                            aria-label={`Remove ${SEAT_ROLE_LABELS[seat.role]} assignment at ${seat.centreName}`}
+                            title="Remove assignment (keeps the position open)"
+                          >
+                            <X className="h-4 w-4" />
+                          </button>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -1,0 +1,705 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Building2, Edit2, Plus, Search, UserX, X } from "lucide-react";
+
+import StatCard from "@/components/StatCard";
+import { Badge, Button, Card, Input, Modal, Select } from "@/components/ui";
+import { DetailField } from "@/components/ui/DetailField";
+import {
+  SEAT_ROLES,
+  type RosterCodeFilter,
+  type RosterKindFilter,
+  type SeatRole,
+  type StaffRosterFilters,
+  type StaffRosterRow,
+  type StaffRosterSummary,
+} from "@/lib/staff-shared";
+
+interface StaffGridProps {
+  initialRows: StaffRosterRow[];
+  initialSummary: StaffRosterSummary;
+  initialFilters: StaffRosterFilters;
+}
+
+interface CentreOptionItem {
+  id: number;
+  name: string;
+}
+
+const KIND_LABELS: Record<StaffRosterRow["kind"], string> = {
+  teacher: "Teacher",
+  staff: "PM / Staff",
+  pending_teacher: "Teacher (not backfilled)",
+  pending_pm: "PM (no staff record)",
+};
+
+const ROLE_LABELS: Record<StaffRosterRow["kind"], string> = {
+  teacher: "Teacher",
+  staff: "PM",
+  pending_teacher: "Teacher",
+  pending_pm: "PM",
+};
+
+const SEAT_ROLE_LABELS: Record<SeatRole, string> = {
+  physics: "Physics",
+  chemistry: "Chemistry",
+  maths: "Maths",
+  biology: "Biology",
+  apc: "APC",
+  pm: "PM",
+};
+
+function rowKey(row: StaffRosterRow): string {
+  return `${row.kind}:${row.recordId}`;
+}
+
+interface CentreGroup {
+  centreId: number | null;
+  centreName: string;
+  rows: StaffRosterRow[];
+}
+
+function groupByCentre(rows: StaffRosterRow[]): CentreGroup[] {
+  const groups = new Map<number, CentreGroup>();
+  const unassigned: CentreGroup = {
+    centreId: null,
+    centreName: "No Centre assigned",
+    rows: [],
+  };
+
+  for (const row of rows) {
+    if (row.seats.length === 0) {
+      unassigned.rows.push(row);
+      continue;
+    }
+    const seen = new Set<number>();
+    for (const seat of row.seats) {
+      if (seen.has(seat.centreId)) continue;
+      seen.add(seat.centreId);
+      let group = groups.get(seat.centreId);
+      if (!group) {
+        group = { centreId: seat.centreId, centreName: seat.centreName, rows: [] };
+        groups.set(seat.centreId, group);
+      }
+      group.rows.push(row);
+    }
+  }
+
+  const sorted = [...groups.values()].sort((a, b) =>
+    a.centreName.localeCompare(b.centreName)
+  );
+  if (unassigned.rows.length > 0) sorted.push(unassigned);
+  return sorted;
+}
+
+export default function StaffGrid({
+  initialRows,
+  initialSummary,
+  initialFilters,
+}: StaffGridProps) {
+  const [rows, setRows] = useState(initialRows);
+  const [summary, setSummary] = useState(initialSummary);
+  const [filters, setFilters] = useState<StaffRosterFilters>(initialFilters);
+  const [loading, setLoading] = useState(false);
+  const [tableError, setTableError] = useState("");
+  const [centres, setCentres] = useState<CentreOptionItem[]>([]);
+
+  // Edit modal state
+  const [modalKey, setModalKey] = useState<string | null>(null);
+  const [codeDraft, setCodeDraft] = useState("");
+  const [exitDraft, setExitDraft] = useState("");
+  const [exitArmed, setExitArmed] = useState(false);
+  const [seatCentreDraft, setSeatCentreDraft] = useState("");
+  const [seatRoleDraft, setSeatRoleDraft] = useState<SeatRole>("physics");
+  const [actionError, setActionError] = useState("");
+  const [actionBusy, setActionBusy] = useState(false);
+
+  const modalRow = useMemo(
+    () => (modalKey === null ? null : (rows.find((row) => rowKey(row) === modalKey) ?? null)),
+    [modalKey, rows]
+  );
+
+  const fetchRoster = useCallback(async (nextFilters: StaffRosterFilters) => {
+    setLoading(true);
+    setTableError("");
+    try {
+      const params = new URLSearchParams();
+      if (nextFilters.search) params.set("search", nextFilters.search);
+      if (nextFilters.kind !== "all") params.set("kind", nextFilters.kind);
+      if (nextFilters.code !== "all") params.set("code", nextFilters.code);
+      if (nextFilters.exited === "include") params.set("exited", "include");
+      if (nextFilters.centreId !== null)
+        params.set("centre", String(nextFilters.centreId));
+      const response = await fetch(`/api/admin/staff?${params.toString()}`);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to load roster");
+      setRows(data.rows);
+      setSummary(data.summary);
+    } catch (error) {
+      setTableError(
+        error instanceof Error ? error.message : "Failed to load roster"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Debounced refetch when filters change.
+  useEffect(() => {
+    if (filters === initialFilters) return;
+    const timeout = window.setTimeout(() => {
+      void fetchRoster(filters);
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [filters, initialFilters, fetchRoster]);
+
+  // Centres list for the filter + add-seat picker.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const response = await fetch("/api/admin/centres?limit=100");
+        const data = await response.json();
+        if (response.ok && Array.isArray(data.rows)) {
+          setCentres(
+            data.rows.map((row: { id: number; name: string }) => ({
+              id: row.id,
+              name: row.name,
+            }))
+          );
+        }
+      } catch {
+        // Filter falls back to the centres present in roster rows.
+      }
+    })();
+  }, []);
+
+  const groups = useMemo(() => {
+    const grouped = groupByCentre(rows);
+    return filters.centreId === null
+      ? grouped
+      : grouped.filter((group) => group.centreId === filters.centreId);
+  }, [rows, filters.centreId]);
+
+  const openModal = (row: StaffRosterRow) => {
+    setModalKey(rowKey(row));
+    setCodeDraft(row.employeeCode ?? "");
+    setExitDraft(new Date().toISOString().slice(0, 10));
+    setExitArmed(false);
+    setSeatCentreDraft("");
+    setSeatRoleDraft(row.kind === "teacher" ? "physics" : "pm");
+    setActionError("");
+  };
+
+  const closeModal = () => {
+    setModalKey(null);
+    setActionError("");
+  };
+
+  const runAction = async (
+    action: () => Promise<Response>,
+    { closeOnSuccess = false } = {}
+  ) => {
+    setActionBusy(true);
+    setActionError("");
+    try {
+      const response = await action();
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const fieldError =
+          data.fields && typeof data.fields === "object"
+            ? Object.values(data.fields as Record<string, string>)[0]
+            : undefined;
+        throw new Error(fieldError || data.error || "Action failed");
+      }
+      await fetchRoster(filters);
+      if (closeOnSuccess) closeModal();
+      return true;
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Action failed");
+      return false;
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const saveCode = (row: StaffRosterRow) => {
+    const code = codeDraft.trim().toUpperCase();
+    if (!code || code === row.employeeCode) {
+      closeModal();
+      return Promise.resolve(true);
+    }
+    if (row.kind === "teacher") {
+      return runAction(
+        () =>
+          fetch(`/api/admin/staff/teachers/${row.recordId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ teacher_id: code }),
+          }),
+        { closeOnSuccess: true }
+      );
+    }
+    if (row.kind === "staff") {
+      return runAction(
+        () =>
+          fetch(`/api/admin/staff/members/${row.recordId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ employee_code: code }),
+          }),
+        { closeOnSuccess: true }
+      );
+    }
+    // pending_pm: creating the staff record IS setting the code
+    return runAction(
+      () =>
+        fetch(`/api/admin/staff/members`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            user_permission_id: row.recordId,
+            employee_code: code,
+          }),
+        }),
+      { closeOnSuccess: true }
+    );
+  };
+
+  const saveExit = (row: StaffRosterRow) => {
+    const url =
+      row.kind === "teacher"
+        ? `/api/admin/staff/teachers/${row.recordId}`
+        : `/api/admin/staff/members/${row.recordId}`;
+    return runAction(
+      () =>
+        fetch(url, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ exit_date: exitDraft }),
+        }),
+      { closeOnSuccess: true }
+    );
+  };
+
+  const addSeat = (row: StaffRosterRow) => {
+    return runAction(() =>
+      fetch(`/api/admin/staff/positions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          centre_id: Number(seatCentreDraft),
+          role: seatRoleDraft,
+          user_id: row.userId,
+        }),
+      })
+    );
+  };
+
+  const vacateSeat = (seatId: number) => {
+    return runAction(() =>
+      fetch(`/api/admin/staff/positions/${seatId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_id: null }),
+      })
+    );
+  };
+
+  const canEdit = (row: StaffRosterRow) => row.kind !== "pending_teacher";
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatCard label="People" value={summary.total} size="sm" />
+        <StatCard label="Teachers" value={summary.teachers} size="sm" />
+        <StatCard label="PM / Staff" value={summary.staff} size="sm" />
+        <StatCard label="Pending" value={summary.pending} size="sm" color="brand-amber" />
+        <StatCard
+          label="Missing AF ID"
+          value={summary.missingCode}
+          size="sm"
+          color="brand-coral"
+        />
+        <StatCard label="Open positions" value={summary.vacantSeats} size="sm" />
+      </div>
+
+      <Card className="p-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end">
+          <div className="flex-1">
+            <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+              Search
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+              <Input
+                value={filters.search}
+                onChange={(event) =>
+                  setFilters({ ...filters, search: event.target.value })
+                }
+                placeholder="Name, email or AF code"
+                className="pl-9"
+                aria-label="Search staff"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+              Centre
+            </label>
+            <Select
+              value={filters.centreId === null ? "" : String(filters.centreId)}
+              onChange={(event) =>
+                setFilters({
+                  ...filters,
+                  centreId: event.target.value
+                    ? Number(event.target.value)
+                    : null,
+                })
+              }
+              aria-label="Filter by Centre"
+            >
+              <option value="">All Centres</option>
+              {centres.map((centre) => (
+                <option key={centre.id} value={centre.id}>
+                  {centre.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+              Type
+            </label>
+            <Select
+              value={filters.kind}
+              onChange={(event) =>
+                setFilters({
+                  ...filters,
+                  kind: event.target.value as RosterKindFilter,
+                })
+              }
+              aria-label="Filter by type"
+            >
+              <option value="all">All</option>
+              <option value="teacher">Teachers</option>
+              <option value="staff">PM / Staff</option>
+              <option value="pending_teacher">Pending teachers</option>
+              <option value="pending_pm">Pending PMs</option>
+            </Select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+              AF code
+            </label>
+            <Select
+              value={filters.code}
+              onChange={(event) =>
+                setFilters({
+                  ...filters,
+                  code: event.target.value as RosterCodeFilter,
+                })
+              }
+              aria-label="Filter by AF code"
+            >
+              <option value="all">All</option>
+              <option value="missing">Missing</option>
+              <option value="present">Present</option>
+            </Select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+              Exited
+            </label>
+            <Select
+              value={filters.exited}
+              onChange={(event) =>
+                setFilters({
+                  ...filters,
+                  exited:
+                    event.target.value === "include" ? "include" : "exclude",
+                })
+              }
+              aria-label="Filter exited"
+            >
+              <option value="exclude">Hide exited</option>
+              <option value="include">Show exited</option>
+            </Select>
+          </div>
+        </div>
+      </Card>
+
+      {tableError && (
+        <div className="rounded-md border border-danger/30 bg-danger-bg p-3 text-sm text-danger">
+          {tableError}
+        </div>
+      )}
+
+      {loading && (
+        <p className="text-sm text-text-muted" role="status">
+          Loading roster…
+        </p>
+      )}
+
+      {groups.length === 0 && !loading && (
+        <Card className="p-6 text-sm text-text-muted">
+          No people match the current filters.
+        </Card>
+      )}
+
+      {groups.map((group) => (
+        <section key={group.centreId ?? "none"}>
+          <div className="mb-2 flex items-center gap-2">
+            <Building2 className="h-4 w-4 text-text-muted" />
+            <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+              {group.centreName}
+            </h2>
+            <span className="text-xs font-mono text-text-muted">
+              {group.rows.length}
+            </span>
+          </div>
+          <div className="space-y-2">
+            {group.rows.map((row) => (
+              <Card key={`${group.centreId}:${rowKey(row)}`} className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-bold text-text-primary">
+                        {row.name || "(no name)"}
+                      </span>
+                      {row.employeeCode ? (
+                        <Badge variant="success">{row.employeeCode}</Badge>
+                      ) : row.exitDate ? null : (
+                        <Badge variant="danger">No AF ID</Badge>
+                      )}
+                      {(row.kind === "pending_teacher" ||
+                        row.kind === "pending_pm") && (
+                        <Badge variant="warning">{KIND_LABELS[row.kind]}</Badge>
+                      )}
+                      {row.exitDate && (
+                        <Badge variant="warning">Exited {row.exitDate}</Badge>
+                      )}
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 md:grid-cols-4">
+                      <DetailField label="Email" value={row.email ?? "—"} />
+                      <DetailField label="Role" value={ROLE_LABELS[row.kind]} />
+                      <DetailField
+                        label="Subject"
+                        value={row.subjectName ?? "—"}
+                      />
+                      <DetailField
+                        label="Centre"
+                        value={
+                          group.centreId !== null
+                            ? group.centreName
+                            : row.seats.length > 0
+                              ? [...new Set(row.seats.map((seat) => seat.centreName))].join(", ")
+                              : "—"
+                        }
+                      />
+                    </div>
+                  </div>
+                  {canEdit(row) && (
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => openModal(row)}
+                      aria-label={`Edit ${row.name || row.email}`}
+                    >
+                      <Edit2 className="mr-1 h-4 w-4" /> Edit
+                    </Button>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <Modal open={modalRow !== null} onClose={closeModal} className="max-w-xl">
+        {modalRow && (
+          <div className="p-6">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-lg font-bold text-text-primary">
+                  {modalRow.name || "(no name)"}
+                </h3>
+                <p className="text-sm text-text-muted">
+                  {KIND_LABELS[modalRow.kind]} · {modalRow.email ?? "—"}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="text-text-muted hover:text-text-primary"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="mt-5">
+              <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                {modalRow.kind === "pending_pm"
+                  ? "AF code (creates the staff record)"
+                  : "AF code"}
+              </label>
+              <Input
+                value={codeDraft}
+                onChange={(event) => setCodeDraft(event.target.value)}
+                placeholder="AF123"
+                aria-label="Employee code"
+                className="w-40"
+              />
+            </div>
+
+            {modalRow.userId !== null && (
+              <div className="mt-5">
+                <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-text-muted">
+                  Assigned Centres
+                </h4>
+                {modalRow.seats.length === 0 ? (
+                  <p className="text-sm text-text-muted">No Centre assigned</p>
+                ) : (
+                  <ul className="flex flex-wrap gap-2">
+                    {modalRow.seats.map((seat) => (
+                      <li
+                        key={seat.id}
+                        className="flex items-center gap-2 rounded-md border border-border bg-bg-card-alt px-2 py-1 text-sm"
+                      >
+                        <span>
+                          {SEAT_ROLE_LABELS[seat.role]} @ {seat.centreName}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => void vacateSeat(seat.id)}
+                          disabled={actionBusy}
+                          className="text-danger hover:text-danger/80"
+                          aria-label={`Remove ${SEAT_ROLE_LABELS[seat.role]} assignment at ${seat.centreName}`}
+                          title="Remove assignment (keeps the position open)"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <div className="mt-4">
+                  <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-text-muted">
+                    Assign new Centre
+                  </h4>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <Select
+                      value={seatCentreDraft}
+                      onChange={(event) => setSeatCentreDraft(event.target.value)}
+                      aria-label="Assign centre"
+                      className="min-w-0 flex-1"
+                    >
+                      <option value="">Select Centre…</option>
+                      {centres.map((centre) => (
+                        <option key={centre.id} value={centre.id}>
+                          {centre.name}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      value={seatRoleDraft}
+                      onChange={(event) =>
+                        setSeatRoleDraft(event.target.value as SeatRole)
+                      }
+                      aria-label="Assign role"
+                      className="sm:w-36"
+                    >
+                      {SEAT_ROLES.map((role) => (
+                        <option key={role} value={role}>
+                          {SEAT_ROLE_LABELS[role]}
+                        </option>
+                      ))}
+                    </Select>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => void addSeat(modalRow)}
+                      disabled={actionBusy || !seatCentreDraft}
+                      className="shrink-0 whitespace-nowrap"
+                    >
+                      <Plus className="mr-1 h-4 w-4" /> Assign
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {(modalRow.kind === "teacher" || modalRow.kind === "staff") &&
+              !modalRow.exitDate && (
+                <div className="mt-5 rounded-md border border-danger/30 bg-danger-bg/40 p-3">
+                  <h4 className="text-xs font-bold uppercase tracking-wide text-danger">
+                    Mark exited
+                  </h4>
+                  {exitArmed ? (
+                    <div className="mt-2 flex items-end gap-2">
+                      <span>
+                        <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                          Exit date
+                        </label>
+                        <Input
+                          type="date"
+                          value={exitDraft}
+                          onChange={(event) => setExitDraft(event.target.value)}
+                          aria-label="Exit date"
+                        />
+                      </span>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        onClick={() => void saveExit(modalRow)}
+                        disabled={actionBusy || !exitDraft}
+                      >
+                        <UserX className="mr-1 h-4 w-4" /> Confirm exit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => setExitArmed(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-sm text-text-muted">
+                      Removes all Centre assignments and revokes LMS access.{" "}
+                      <button
+                        type="button"
+                        onClick={() => setExitArmed(true)}
+                        className="font-bold text-danger hover:underline"
+                      >
+                        Mark exited…
+                      </button>
+                    </p>
+                  )}
+                </div>
+              )}
+
+            {actionError && (
+              <p className="mt-4 text-sm text-danger" role="alert">
+                {actionError}
+              </p>
+            )}
+
+            <div className="mt-6 flex justify-end gap-2">
+              <Button variant="secondary" onClick={closeModal}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => void saveCode(modalRow)}
+                disabled={actionBusy}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/admin/staff/page.tsx
+++ b/src/app/admin/staff/page.tsx
@@ -1,0 +1,83 @@
+import { getServerSession } from "next-auth";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { authOptions } from "@/lib/auth";
+import { isAdmin } from "@/lib/permissions";
+import { getStaffRoster } from "@/lib/staff-admin";
+import StaffGrid from "./StaffGrid";
+
+interface StaffPageProps {
+  searchParams?:
+    | Promise<{ [key: string]: string | string[] | undefined }>
+    | { [key: string]: string | string[] | undefined };
+}
+
+export default async function StaffPage({ searchParams }: StaffPageProps = {}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    redirect("/");
+  }
+
+  const admin = await isAdmin(session.user.email);
+  if (!admin) {
+    redirect("/dashboard");
+  }
+
+  const resolvedSearchParams = searchParams
+    ? await Promise.resolve(searchParams)
+    : {};
+
+  const rosterResult = await getStaffRoster({
+    searchParams: resolvedSearchParams,
+  });
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <header className="bg-bg-card border-b border-border shadow-sm">
+        <div className="flex w-full justify-between px-4 py-4 sm:px-6 lg:px-8 items-center">
+          <div className="flex items-center gap-3">
+            <Link href="/admin" className="text-text-muted hover:text-text-primary p-1 -m-1">
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </Link>
+            <div>
+              <h1 className="text-xl sm:text-2xl font-bold text-text-primary uppercase tracking-tight">Staff Management</h1>
+              <p className="text-xs text-text-muted font-mono">{session.user.email}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/admin/centres"
+              className="text-sm font-bold uppercase text-accent hover:text-accent-hover"
+            >
+              Centres
+            </Link>
+            <Link
+              href="/api/auth/signout"
+              className="text-sm font-bold text-danger hover:text-danger/80"
+            >
+              Sign out
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        {rosterResult.ok ? (
+          <StaffGrid
+            initialRows={rosterResult.rows}
+            initialSummary={rosterResult.summary}
+            initialFilters={rosterResult.filters}
+          />
+        ) : (
+          <div className="rounded-md border border-danger/30 bg-danger-bg p-4 text-sm text-danger">
+            Staff management schema unavailable
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/users/UserList.test.tsx
+++ b/src/app/admin/users/UserList.test.tsx
@@ -230,6 +230,34 @@ describe("UserList", () => {
       expect(screen.getByText("No schools assigned")).toBeInTheDocument();
     });
 
+    it("renders centre-assignment chips alongside explicit scope", () => {
+      renderList({
+        initialUsers: [
+          {
+            ...users[2],
+            school_codes: ["SCH001"],
+            centres: [{ centreName: "JNV Udupi", role: "chemistry" }],
+          },
+        ],
+      });
+      expect(screen.getByText("JNV Udupi · chemistry")).toBeInTheDocument();
+      expect(screen.getByText("JNV Bhavnagar (SCH001)")).toBeInTheDocument();
+    });
+
+    it("shows centre chips (not 'No schools assigned') for a seated teacher whose school_codes were cleared", () => {
+      renderList({
+        initialUsers: [
+          {
+            ...users[2],
+            school_codes: null,
+            centres: [{ centreName: "JNV Udupi", role: "chemistry" }],
+          },
+        ],
+      });
+      expect(screen.getByText("JNV Udupi · chemistry")).toBeInTheDocument();
+      expect(screen.queryByText("No schools assigned")).not.toBeInTheDocument();
+    });
+
     it("renders fallback for unknown role", () => {
       renderList({
         initialUsers: [

--- a/src/app/admin/users/UserList.tsx
+++ b/src/app/admin/users/UserList.tsx
@@ -4,6 +4,11 @@ import { useState } from "react";
 import AddUserModal from "./AddUserModal";
 import { Button } from "@/components/ui";
 
+interface CentreAssignment {
+  centreName: string;
+  role: string;
+}
+
 interface UserPermission {
   id: number;
   email: string;
@@ -14,6 +19,7 @@ interface UserPermission {
   program_ids: number[] | null;
   read_only: boolean;
   full_name: string | null;
+  centres?: CentreAssignment[];
 }
 
 interface UserListProps {
@@ -198,19 +204,34 @@ export default function UserList({ initialUsers, regions, schoolCodeToName, curr
                   )}
                 </td>
                 <td className="px-3 py-4 text-sm text-gray-500">
-                  {user.level === 3 ? (
-                    <span className="text-gray-400">All JNV schools</span>
-                  ) : user.level === 2 ? (
-                    <span>{user.regions?.join(", ") || "No regions assigned"}</span>
-                  ) : user.school_codes && user.school_codes.length > 0 ? (
-                    <div className="flex flex-col gap-0.5">
-                      {user.school_codes.map((code) => (
-                        <span key={code}>{labelForSchool(code)}</span>
-                      ))}
-                    </div>
-                  ) : (
-                    <span>No schools assigned</span>
-                  )}
+                  <div className="flex flex-col gap-1">
+                    {user.centres && user.centres.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {user.centres.map((centre, i) => (
+                          <span
+                            key={`${centre.centreName}-${centre.role}-${i}`}
+                            className="inline-flex px-2 py-0.5 text-xs rounded-full bg-hover-bg text-accent-hover"
+                            title="Centre assignment — manage in Staff"
+                          >
+                            {centre.centreName} &middot; {centre.role}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {user.level === 3 ? (
+                      <span className="text-gray-400">All JNV schools</span>
+                    ) : user.level === 2 && user.regions && user.regions.length > 0 ? (
+                      <span>{user.regions.join(", ")}</span>
+                    ) : user.level === 1 && user.school_codes && user.school_codes.length > 0 ? (
+                      <div className="flex flex-col gap-0.5">
+                        {user.school_codes.map((code) => (
+                          <span key={code}>{labelForSchool(code)}</span>
+                        ))}
+                      </div>
+                    ) : user.centres && user.centres.length > 0 ? null : (
+                      <span>{user.level === 2 ? "No regions assigned" : "No schools assigned"}</span>
+                    )}
+                  </div>
                 </td>
                 <td className="whitespace-nowrap px-3 py-4 text-sm">
                   <Button

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -6,6 +6,11 @@ import { query } from "@/lib/db";
 import Link from "next/link";
 import UserList from "./UserList";
 
+interface CentreAssignment {
+  centreName: string;
+  role: string;
+}
+
 interface UserPermission {
   id: number;
   email: string;
@@ -16,6 +21,7 @@ interface UserPermission {
   program_ids: number[] | null;
   read_only: boolean;
   full_name: string | null;
+  centres: CentreAssignment[];
 }
 
 interface Region {
@@ -30,7 +36,16 @@ interface SchoolNameRow {
 
 async function getUsers(): Promise<UserPermission[]> {
   return query<UserPermission>(
-    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name
+    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name,
+            COALESCE((
+              SELECT json_agg(
+                       json_build_object('centreName', c.name, 'role', cp.role)
+                       ORDER BY c.name, cp.role
+                     )
+              FROM centre_positions cp
+              JOIN centres c ON c.id = cp.centre_id
+              WHERE cp.user_id = user_permission.user_id AND cp.deleted_at IS NULL
+            ), '[]'::json) AS centres
      FROM user_permission
      ORDER BY level DESC, role, email`
   );

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { isAdmin } from "@/lib/permissions";
+import { CENTRE_ASSIGNMENTS_SUBQUERY } from "@/lib/centres";
 import { query } from "@/lib/db";
 import Link from "next/link";
 import UserList from "./UserList";
@@ -37,15 +38,7 @@ interface SchoolNameRow {
 async function getUsers(): Promise<UserPermission[]> {
   return query<UserPermission>(
     `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name,
-            COALESCE((
-              SELECT json_agg(
-                       json_build_object('centreName', c.name, 'role', cp.role)
-                       ORDER BY c.name, cp.role
-                     )
-              FROM centre_positions cp
-              JOIN centres c ON c.id = cp.centre_id
-              WHERE cp.user_id = user_permission.user_id AND cp.deleted_at IS NULL
-            ), '[]'::json) AS centres
+            ${CENTRE_ASSIGNMENTS_SUBQUERY}
      FROM user_permission
      ORDER BY level DESC, role, email`
   );

--- a/src/app/api/admin/staff/members/[id]/route.ts
+++ b/src/app/api/admin/staff/members/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  requireStaffAdmin,
+  safeStaffApiError,
+  updateStaffMember,
+} from "@/lib/staff-admin";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const { id } = await params;
+  const staffId = Number.parseInt(id, 10);
+  if (!Number.isInteger(staffId) || staffId <= 0) {
+    return NextResponse.json({ error: "Invalid staff id" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await updateStaffMember({
+    id: staffId,
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/staff/members/route.ts
+++ b/src/app/api/admin/staff/members/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  createStaffMember,
+  requireStaffAdmin,
+  safeStaffApiError,
+} from "@/lib/staff-admin";
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createStaffMember({
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/api/admin/staff/positions/[id]/route.ts
+++ b/src/app/api/admin/staff/positions/[id]/route.ts
@@ -42,6 +42,7 @@ export async function PATCH(
   const result = await updatePosition({
     id: positionId,
     body: (body ?? {}) as Record<string, unknown>,
+    force: request.nextUrl.searchParams.get("force") === "true",
   });
   if (!result.ok) {
     return NextResponse.json(safeStaffApiError(result), {
@@ -53,7 +54,7 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await getServerSession(authOptions);
@@ -67,7 +68,10 @@ export async function DELETE(
     return NextResponse.json({ error: "Invalid position id" }, { status: 400 });
   }
 
-  const result = await deletePosition({ id: positionId });
+  const result = await deletePosition({
+    id: positionId,
+    force: request.nextUrl.searchParams.get("force") === "true",
+  });
   if (!result.ok) {
     return NextResponse.json(safeStaffApiError(result), {
       status: result.status,

--- a/src/app/api/admin/staff/positions/[id]/route.ts
+++ b/src/app/api/admin/staff/positions/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  deletePosition,
+  requireStaffAdmin,
+  safeStaffApiError,
+  updatePosition,
+} from "@/lib/staff-admin";
+
+async function parsePositionId(
+  params: Promise<{ id: string }>
+): Promise<number | null> {
+  const { id } = await params;
+  const positionId = Number.parseInt(id, 10);
+  return Number.isInteger(positionId) && positionId > 0 ? positionId : null;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const positionId = await parsePositionId(params);
+  if (positionId === null) {
+    return NextResponse.json({ error: "Invalid position id" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await updatePosition({
+    id: positionId,
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const positionId = await parsePositionId(params);
+  if (positionId === null) {
+    return NextResponse.json({ error: "Invalid position id" }, { status: 400 });
+  }
+
+  const result = await deletePosition({ id: positionId });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/staff/positions/route.ts
+++ b/src/app/api/admin/staff/positions/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  createPosition,
+  requireStaffAdmin,
+  safeStaffApiError,
+} from "@/lib/staff-admin";
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createPosition({
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/api/admin/staff/route.test.ts
+++ b/src/app/api/admin/staff/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetServerSession, mockRequireStaffAdmin, mockGetStaffRoster } =
+  vi.hoisted(() => ({
+    mockGetServerSession: vi.fn(),
+    mockRequireStaffAdmin: vi.fn(),
+    mockGetStaffRoster: vi.fn(),
+  }));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/staff-admin", () => ({
+  requireStaffAdmin: mockRequireStaffAdmin,
+  getStaffRoster: mockGetStaffRoster,
+  safeStaffApiError: (result: { error: string }) => ({ error: result.error }),
+}));
+
+import { GET } from "./route";
+
+function rosterRequest(url = "http://localhost/api/admin/staff") {
+  return new NextRequest(new URL(url));
+}
+
+describe("GET /api/admin/staff", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockRequireStaffAdmin.mockResolvedValue({
+      ok: true,
+      email: "admin@avantifellows.org",
+    });
+  });
+
+  it("propagates guard failures", async () => {
+    mockRequireStaffAdmin.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      error: "Unauthorized",
+    });
+    expect((await GET(rosterRequest())).status).toBe(401);
+
+    mockRequireStaffAdmin.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: "Forbidden",
+    });
+    expect((await GET(rosterRequest())).status).toBe(403);
+  });
+
+  it("passes query params through and returns the roster", async () => {
+    mockGetStaffRoster.mockResolvedValueOnce({
+      ok: true,
+      filters: { search: "asha", kind: "teacher", code: "missing", exited: "exclude" },
+      rows: [],
+      summary: { total: 0 },
+    });
+
+    const response = await GET(
+      rosterRequest("http://localhost/api/admin/staff?search=asha&kind=teacher&code=missing")
+    );
+    expect(response.status).toBe(200);
+    expect(mockGetStaffRoster).toHaveBeenCalledWith({
+      searchParams: { search: "asha", kind: "teacher", code: "missing" },
+    });
+    const data = await response.json();
+    expect(data).toHaveProperty("rows");
+    expect(data).toHaveProperty("summary");
+    expect(data).toHaveProperty("filters");
+  });
+
+  it("returns 503 when the schema is unavailable", async () => {
+    mockGetStaffRoster.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      error: "Staff management schema unavailable",
+      details: ["staff.id"],
+    });
+    const response = await GET(rosterRequest());
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Staff management schema unavailable",
+    });
+  });
+});

--- a/src/app/api/admin/staff/route.ts
+++ b/src/app/api/admin/staff/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  getStaffRoster,
+  requireStaffAdmin,
+  safeStaffApiError,
+} from "@/lib/staff-admin";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const searchParams = Object.fromEntries(
+    request.nextUrl.searchParams.entries()
+  );
+  const result = await getStaffRoster({ searchParams });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({
+    filters: result.filters,
+    rows: result.rows,
+    summary: result.summary,
+  });
+}

--- a/src/app/api/admin/staff/teachers/[id]/route.test.ts
+++ b/src/app/api/admin/staff/teachers/[id]/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetServerSession, mockRequireStaffAdmin, mockUpdateTeacherRecord } =
+  vi.hoisted(() => ({
+    mockGetServerSession: vi.fn(),
+    mockRequireStaffAdmin: vi.fn(),
+    mockUpdateTeacherRecord: vi.fn(),
+  }));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/staff-admin", () => ({
+  requireStaffAdmin: mockRequireStaffAdmin,
+  updateTeacherRecord: mockUpdateTeacherRecord,
+  safeStaffApiError: (result: { error: string; fields?: Record<string, string> }) =>
+    result.fields ? { error: result.error, fields: result.fields } : { error: result.error },
+}));
+
+import { PATCH } from "./route";
+import {
+  jsonRequest,
+  routeParams,
+} from "../../../../__test-utils__/api-test-helpers";
+
+describe("PATCH /api/admin/staff/teachers/[id]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockRequireStaffAdmin.mockResolvedValue({
+      ok: true,
+      email: "admin@avantifellows.org",
+    });
+  });
+
+  it("propagates guard failures", async () => {
+    mockRequireStaffAdmin.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: "Forbidden",
+    });
+    const response = await PATCH(
+      jsonRequest("http://localhost/api/admin/staff/teachers/1", {
+        method: "PATCH",
+        body: { teacher_id: "AF1" },
+      }) as never,
+      routeParams({ id: "1" })
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects bad ids and bad JSON", async () => {
+    const response = await PATCH(
+      jsonRequest("http://localhost/api/admin/staff/teachers/abc", {
+        method: "PATCH",
+        body: {},
+      }) as never,
+      routeParams({ id: "abc" })
+    );
+    expect(response.status).toBe(400);
+
+    const badJson = new Request("http://localhost/api/admin/staff/teachers/1", {
+      method: "PATCH",
+      body: "{nope",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect((await PATCH(badJson as never, routeParams({ id: "1" }))).status).toBe(400);
+  });
+
+  it("maps lib results to responses", async () => {
+    mockUpdateTeacherRecord.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      error: "taken",
+    });
+    const conflict = await PATCH(
+      jsonRequest("http://localhost/api/admin/staff/teachers/1", {
+        method: "PATCH",
+        body: { teacher_id: "AF1" },
+      }) as never,
+      routeParams({ id: "1" })
+    );
+    expect(conflict.status).toBe(409);
+
+    mockUpdateTeacherRecord.mockResolvedValueOnce({ ok: true });
+    const success = await PATCH(
+      jsonRequest("http://localhost/api/admin/staff/teachers/1", {
+        method: "PATCH",
+        body: { teacher_id: "AF1" },
+      }) as never,
+      routeParams({ id: "1" })
+    );
+    expect(success.status).toBe(200);
+    expect(mockUpdateTeacherRecord).toHaveBeenCalledWith({
+      id: 1,
+      body: { teacher_id: "AF1" },
+    });
+  });
+});

--- a/src/app/api/admin/staff/teachers/[id]/route.ts
+++ b/src/app/api/admin/staff/teachers/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  requireStaffAdmin,
+  safeStaffApiError,
+  updateTeacherRecord,
+} from "@/lib/staff-admin";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const { id } = await params;
+  const teacherId = Number.parseInt(id, 10);
+  if (!Number.isInteger(teacherId) || teacherId <= 0) {
+    return NextResponse.json({ error: "Invalid teacher id" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await updateTeacherRecord({
+    id: teacherId,
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { isAdmin } from "@/lib/permissions";
+import { CENTRE_ASSIGNMENTS_SUBQUERY } from "@/lib/centres";
 import { query } from "@/lib/db";
 
 // Disable Next.js caching for this route
@@ -35,15 +36,7 @@ export async function GET() {
     updated_at: string;
   }>(
     `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name,
-            COALESCE((
-              SELECT json_agg(
-                       json_build_object('centreName', c.name, 'role', cp.role)
-                       ORDER BY c.name, cp.role
-                     )
-              FROM centre_positions cp
-              JOIN centres c ON c.id = cp.centre_id
-              WHERE cp.user_id = user_permission.user_id AND cp.deleted_at IS NULL
-            ), '[]'::json) AS centres,
+            ${CENTRE_ASSIGNMENTS_SUBQUERY},
             inserted_at, updated_at
      FROM user_permission
      ORDER BY level DESC, role, email`

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -30,10 +30,21 @@ export async function GET() {
     program_ids: number[] | null;
     read_only: boolean;
     full_name: string | null;
+    centres: { centreName: string; role: string }[];
     inserted_at: string;
     updated_at: string;
   }>(
-    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name, inserted_at, updated_at
+    `SELECT id, email, level, role, school_codes, regions, program_ids, read_only, full_name,
+            COALESCE((
+              SELECT json_agg(
+                       json_build_object('centreName', c.name, 'role', cp.role)
+                       ORDER BY c.name, cp.role
+                     )
+              FROM centre_positions cp
+              JOIN centres c ON c.id = cp.centre_id
+              WHERE cp.user_id = user_permission.user_id AND cp.deleted_at IS NULL
+            ), '[]'::json) AS centres,
+            inserted_at, updated_at
      FROM user_permission
      ORDER BY level DESC, role, email`
   );

--- a/src/app/api/curriculum/chapters/[chapterId]/completion/route.test.ts
+++ b/src/app/api/curriculum/chapters/[chapterId]/completion/route.test.ts
@@ -7,12 +7,16 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query, withTransaction } from "@/lib/db";

--- a/src/app/api/curriculum/chapters/[chapterId]/completion/route.ts
+++ b/src/app/api/curriculum/chapters/[chapterId]/completion/route.ts
@@ -8,7 +8,7 @@ import {
   unmarkChapterComplete,
   validateChapterCompletionDeltas,
 } from "@/lib/curriculum-chapter-completion";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -29,7 +29,7 @@ async function requireCurriculumEditAccess(session: CurriculumSession) {
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   if (!permission || !access.canEdit) {
     return {

--- a/src/app/api/curriculum/chapters/route.test.ts
+++ b/src/app/api/curriculum/chapters/route.test.ts
@@ -4,12 +4,16 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query } from "@/lib/db";

--- a/src/app/api/curriculum/chapters/route.ts
+++ b/src/app/api/curriculum/chapters/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { checkCurriculumSchema } from "@/lib/curriculum-schema";
 import { getCurriculumChapters } from "@/lib/curriculum-options";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -24,7 +24,7 @@ async function requireCurriculumViewAccess(session: CurriculumSession) {
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   if (!permission || !access.canView) {
     return {

--- a/src/app/api/curriculum/logs/[id]/route.test.ts
+++ b/src/app/api/curriculum/logs/[id]/route.test.ts
@@ -7,12 +7,16 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query, withTransaction } from "@/lib/db";

--- a/src/app/api/curriculum/logs/[id]/route.ts
+++ b/src/app/api/curriculum/logs/[id]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { checkCurriculumSchema } from "@/lib/curriculum-schema";
 import { deleteCurriculumLog, updateCurriculumLog } from "@/lib/curriculum-logs";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -26,7 +26,7 @@ async function requireCurriculumEditAccess(session: CurriculumSession) {
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   if (!permission || !access.canEdit) {
     return {

--- a/src/app/api/curriculum/logs/route.test.ts
+++ b/src/app/api/curriculum/logs/route.test.ts
@@ -7,12 +7,16 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query, withTransaction } from "@/lib/db";

--- a/src/app/api/curriculum/logs/route.ts
+++ b/src/app/api/curriculum/logs/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { checkCurriculumSchema } from "@/lib/curriculum-schema";
 import { createCurriculumLog, getCurriculumLogs } from "@/lib/curriculum-logs";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -27,7 +27,7 @@ async function requireCurriculumAccess(
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   const allowed = mode === "view" ? access.canView : access.canEdit;
   if (!permission || !allowed) {

--- a/src/app/api/curriculum/options/route.test.ts
+++ b/src/app/api/curriculum/options/route.test.ts
@@ -4,12 +4,16 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query } from "@/lib/db";

--- a/src/app/api/curriculum/options/route.ts
+++ b/src/app/api/curriculum/options/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { checkCurriculumSchema } from "@/lib/curriculum-schema";
 import { getCurriculumOptions } from "@/lib/curriculum-options";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -24,7 +24,7 @@ async function requireCurriculumViewAccess(session: CurriculumSession) {
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   if (!permission || !access.canView) {
     return {

--- a/src/app/api/curriculum/progress/route.test.ts
+++ b/src/app/api/curriculum/progress/route.test.ts
@@ -4,12 +4,16 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  getFeatureAccess: vi.fn(),
-  getUserPermission: vi.fn(),
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("@/lib/permissions", () => {
+  const getUserPermission = vi.fn();
+  return {
+    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    getFeatureAccess: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { getServerSession } from "next-auth";
 import { query } from "@/lib/db";

--- a/src/app/api/curriculum/progress/route.ts
+++ b/src/app/api/curriculum/progress/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { checkCurriculumSchema } from "@/lib/curriculum-schema";
 import { getCurriculumProgress } from "@/lib/curriculum-progress";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 
 type CurriculumSession = {
   user?: { email?: string | null } | null;
@@ -24,7 +24,7 @@ async function requireCurriculumViewAccess(session: CurriculumSession) {
     };
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   const access = getFeatureAccess(permission, "curriculum");
   if (!permission || !access.canView) {
     return {

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/start/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/start/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/[id]/actions/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/[id]/complete/route.test.ts
+++ b/src/app/api/pm/visits/[id]/complete/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/[id]/route.test.ts
+++ b/src/app/api/pm/visits/[id]/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/api/pm/visits/route.test.ts
+++ b/src/app/api/pm/visits/route.test.ts
@@ -5,9 +5,11 @@ vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/permissions")>();
+  const getUserPermission = vi.fn();
   return {
     ...actual,
-    getUserPermission: vi.fn(),
+    getUserPermission,
+    getResolvedPermission: getUserPermission,
     getFeatureAccess: vi.fn(),
   };
 });

--- a/src/app/curriculum-summary/page.test.tsx
+++ b/src/app/curriculum-summary/page.test.tsx
@@ -38,6 +38,7 @@ vi.mock("next/navigation", () => ({
 }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
+  getResolvedPermission: mockGetUserPermission,
   getFeatureAccess: mockGetFeatureAccess,
   getProgramContextSync: mockGetProgramContextSync,
 }));

--- a/src/app/curriculum-summary/page.tsx
+++ b/src/app/curriculum-summary/page.tsx
@@ -28,7 +28,7 @@ import {
 import {
   getFeatureAccess,
   getProgramContextSync,
-  getUserPermission,
+  getResolvedPermission,
 } from "@/lib/permissions";
 
 interface PageProps {
@@ -64,7 +64,7 @@ export default async function CurriculumSummaryPage({ searchParams }: PageProps)
   }
 
   const email = session.user.email;
-  const permission = await getUserPermission(email);
+  const permission = await getResolvedPermission(email);
 
   if (!permission) {
     redirect("/dashboard");

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
+  getResolvedPermission: mockGetUserPermission,
   getProgramContextSync: mockGetProgramContextSync,
   getFeatureAccess: mockGetFeatureAccess,
   getAccessibleSchoolCodes: mockGetAccessibleSchoolCodes,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import {
   getAccessibleSchoolCodes,
-  getUserPermission,
+  getResolvedPermission,
   getProgramContextSync,
   getFeatureAccess,
 } from "@/lib/permissions";
@@ -204,7 +204,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
     redirect(`/school/${session.schoolCode}`);
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
 
   if (!permission) {
     return (

--- a/src/app/school-visit-summary/[id]/page.test.tsx
+++ b/src/app/school-visit-summary/[id]/page.test.tsx
@@ -29,6 +29,7 @@ vi.mock("next/navigation", () => ({
 }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
+  getResolvedPermission: mockGetUserPermission,
   getFeatureAccess: mockGetFeatureAccess,
 }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -6,7 +6,7 @@ import GpsMapLink from "@/components/visits/GpsMapLink";
 import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getUserPermission, getResolvedPermission } from "@/lib/permissions";
 import {
   ACTION_TYPE_VALUES,
   ACTION_TYPES,
@@ -412,7 +412,7 @@ export default async function SchoolVisitSummaryDetailPage({ params }: PageProps
     redirect("/");
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   if (!permission) {
     redirect("/dashboard");
   }

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -26,6 +26,7 @@ vi.mock("next/navigation", () => ({
 }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
+  getResolvedPermission: mockGetUserPermission,
   getFeatureAccess: mockGetFeatureAccess,
 }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -8,7 +8,7 @@ import VisitSummaryFilterBar from "@/components/visits/VisitSummaryFilterBar";
 import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
-import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission, type UserPermission } from "@/lib/permissions";
 import { ACTION_TYPES, ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
 import {
   resolvePresetDateRange,
@@ -912,7 +912,7 @@ export default async function SchoolVisitSummaryPage({ searchParams }: PageProps
     redirect("/");
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   if (!permission) {
     redirect("/dashboard");
   }

--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -38,6 +38,7 @@ vi.mock("@/lib/permissions", async (importOriginal) => {
   return {
     ...actual,
     getUserPermission: mockGetUserPermission,
+    getResolvedPermission: mockGetUserPermission,
     getProgramContextSync: mockGetProgramContextSync,
     getFeatureAccess: mockGetFeatureAccess,
   };

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
-  getUserPermission,
+  getResolvedPermission,
   getProgramContextSync,
   getFeatureAccess,
   canAccessSchoolSync,
@@ -132,7 +132,7 @@ export default async function SchoolPage({ params }: PageProps) {
 
   // Single DB call for permission — reuse everywhere
   const permission = !isPasscodeUser && session.user?.email
-    ? await getUserPermission(session.user.email)
+    ? await getResolvedPermission(session.user.email)
     : null;
 
   // For Google users, check school access

--- a/src/app/visits/[id]/actions/[actionId]/page.test.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/lib/permissions", async (importOriginal) => {
   return {
     ...actual,
     getUserPermission: mockGetUserPermission,
+    getResolvedPermission: mockGetUserPermission,
     getFeatureAccess: mockGetFeatureAccess,
   };
 });

--- a/src/app/visits/[id]/actions/[actionId]/page.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import ActionDetailForm from "@/components/visits/ActionDetailForm";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
-import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getFeatureAccess, getResolvedPermission } from "@/lib/permissions";
 import { buildVisitsActor, canEditVisit, canViewVisit } from "@/lib/visits-policy";
 
 interface VisitRow {
@@ -133,7 +133,7 @@ export default async function VisitActionDetailPage({ params, searchParams }: Pa
     redirect("/");
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   if (!permission) {
     redirect("/dashboard");
   }

--- a/src/app/visits/[id]/page.test.tsx
+++ b/src/app/visits/[id]/page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/permissions", async (importOriginal) => {
   return {
     ...actual,
     getUserPermission: mockGetUserPermission,
+    getResolvedPermission: mockGetUserPermission,
     getFeatureAccess: mockGetFeatureAccess,
   };
 });

--- a/src/app/visits/[id]/page.tsx
+++ b/src/app/visits/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { getUserPermission, getFeatureAccess } from "@/lib/permissions";
+import { getResolvedPermission, getFeatureAccess } from "@/lib/permissions";
 import { query } from "@/lib/db";
 import Link from "next/link";
 import CompleteVisitButton from "@/components/visits/CompleteVisitButton";
@@ -112,7 +112,7 @@ export default async function VisitDetailPage({ params }: PageProps) {
     redirect("/");
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   if (!getFeatureAccess(permission, "visits").canView) {
     redirect("/dashboard");
   }

--- a/src/app/visits/page.test.tsx
+++ b/src/app/visits/page.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
+  getResolvedPermission: mockGetUserPermission,
   getFeatureAccess: mockGetFeatureAccess,
 }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { getUserPermission, getFeatureAccess } from "@/lib/permissions";
+import { getUserPermission, getResolvedPermission, getFeatureAccess } from "@/lib/permissions";
 import { query } from "@/lib/db";
 import {
   buildVisitScopePredicate,
@@ -130,7 +130,7 @@ export default async function VisitsListPage({ searchParams }: PageProps) {
     redirect("/");
   }
 
-  const permission = await getUserPermission(session.user.email);
+  const permission = await getResolvedPermission(session.user.email);
   if (!permission) {
     redirect("/dashboard");
   }

--- a/src/lib/admin-guard.ts
+++ b/src/lib/admin-guard.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared admin-surface helpers used by both the Centre management
+ * (`centres.ts`) and Staff management (`staff-admin.ts`) domains.
+ *
+ * Both surfaces enforce the same admin policy (passcode users blocked, only
+ * `user_permission.role === "admin"` allowed) and the same cached
+ * schema-readiness degrade (503 until the migration lands). Keeping that policy
+ * and the (easy-to-get-wrong) cache-reset-on-failure dance in one place stops
+ * the two surfaces from drifting apart.
+ */
+import { getUserPermission, type UserPermission } from "./permissions";
+
+export type AdminSession = {
+  user?: { email?: string | null } | null;
+  isPasscodeUser?: boolean;
+} | null;
+
+export type AdminGuardResult =
+  | { ok: true; email: string; permission: UserPermission }
+  | { ok: false; status: 401 | 403; error: "Unauthorized" | "Forbidden" };
+
+// Passcode users and any non-`admin` Google role are rejected; only
+// `user_permission.role === "admin"` passes.
+export async function requireAdmin(
+  session: AdminSession
+): Promise<AdminGuardResult> {
+  const email = session?.user?.email;
+  if (!email) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+  if (session.isPasscodeUser) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+  const permission = await getUserPermission(email);
+  if (permission?.role !== "admin") {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+  return { ok: true, email, permission };
+}
+
+export interface SchemaChecker<S extends { ok: boolean }> {
+  check: () => Promise<S>;
+  reset: () => void;
+}
+
+// Wrap a schema-readiness loader with the shared cache policy: memoise on
+// success, clear the cache on an unavailable result (so a missing column is
+// re-checked next request once the migration lands), and clear + rethrow on any
+// query error rather than caching a rejected promise.
+export function makeSchemaChecker<S extends { ok: boolean }>(
+  load: () => Promise<S>
+): SchemaChecker<S> {
+  let cached: Promise<S> | null = null;
+
+  function check(): Promise<S> {
+    cached ??= load().then(
+      (status) => {
+        if (!status.ok) cached = null;
+        return status;
+      },
+      (error) => {
+        cached = null;
+        throw error;
+      }
+    );
+    return cached;
+  }
+
+  function reset(): void {
+    cached = null;
+  }
+
+  return { check, reset };
+}

--- a/src/lib/centres.ts
+++ b/src/lib/centres.ts
@@ -1,7 +1,22 @@
 import { query } from "./db";
-import { getUserPermission, type UserPermission } from "./permissions";
+import { type UserPermission } from "./permissions";
+import { makeSchemaChecker, requireAdmin } from "./admin-guard";
 
 export type CentreOptionSetCode = "type" | "category" | "sub_category" | "stream";
+
+// Correlated subquery yielding a user's active centre assignments as a JSON
+// array of { centreName, role }, aliased `centres`. Embed inside a SELECT over
+// `user_permission` (it references `user_permission.user_id`). Shared by the
+// admin users page and the /api/admin/users route so they can't drift.
+export const CENTRE_ASSIGNMENTS_SUBQUERY = `COALESCE((
+  SELECT json_agg(
+           json_build_object('centreName', c.name, 'role', cp.role)
+           ORDER BY c.name, cp.role
+         )
+  FROM centre_positions cp
+  JOIN centres c ON c.id = cp.centre_id
+  WHERE cp.user_id = user_permission.user_id AND cp.deleted_at IS NULL
+), '[]'::json) AS centres`;
 
 export interface CentreSchemaReady {
   ok: true;
@@ -318,8 +333,6 @@ const REQUIRED_CENTRE_COLUMNS: Array<{ table: string; column: string }> = [
   { table: "centres", column: "updated_at" },
 ];
 
-let cachedCentreSchemaStatus: Promise<CentreSchemaStatus> | null = null;
-
 export function fixedCentreOptionSetCodes(): CentreOptionSetCode[] {
   return [...FIXED_OPTION_SET_CODES];
 }
@@ -348,41 +361,17 @@ export function isActiveCentreOptionCode(
 export async function requireCentreAdmin(
   session: CentreAdminSession
 ): Promise<CentreAdminResult> {
-  const email = session?.user?.email;
-  if (!email) {
-    return { ok: false, status: 401, error: "Unauthorized" };
-  }
-
-  if (session.isPasscodeUser) {
-    return { ok: false, status: 403, error: "Forbidden" };
-  }
-
-  const permission = await getUserPermission(email);
-  if (permission?.role !== "admin") {
-    return { ok: false, status: 403, error: "Forbidden" };
-  }
-
-  return { ok: true, email, permission };
+  return requireAdmin(session);
 }
 
-export async function checkCentreManagementSchema(): Promise<CentreSchemaStatus> {
-  cachedCentreSchemaStatus ??= loadCentreSchemaStatus().then(
-    (status) => {
-      if (!status.ok) {
-        cachedCentreSchemaStatus = null;
-      }
-      return status;
-    },
-    (error) => {
-      cachedCentreSchemaStatus = null;
-      throw error;
-    }
-  );
-  return cachedCentreSchemaStatus;
+const centreSchemaChecker = makeSchemaChecker(loadCentreSchemaStatus);
+
+export function checkCentreManagementSchema(): Promise<CentreSchemaStatus> {
+  return centreSchemaChecker.check();
 }
 
 export function resetCentreSchemaCheckForTests() {
-  cachedCentreSchemaStatus = null;
+  centreSchemaChecker.reset();
 }
 
 export async function getCentreOptionSets(): Promise<CentreOptionSetsResult> {

--- a/src/lib/clear-seated-scope.test.ts
+++ b/src/lib/clear-seated-scope.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./db", () => ({ query: vi.fn() }));
+
+import { query } from "./db";
+import { runClearSeatedScope } from "./clear-seated-scope";
+
+const mockQuery = vi.mocked(query);
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+const SEATED_ROWS = [
+  // fully seat-covered: single-school teacher → clean per-user
+  {
+    user_id: "10",
+    email: "teacher@af.org",
+    school_codes: ["70705"],
+    regions: null,
+    seat_school_codes: ["70705"],
+  },
+  // partially covered: PM seated at 1 of 2 schools → "99999" is stranded
+  {
+    user_id: "20",
+    email: "pm@af.org",
+    school_codes: ["70705", "99999"],
+    regions: null,
+    seat_school_codes: ["70705"],
+  },
+];
+
+describe("runClearSeatedScope", () => {
+  it("dry-run reports who would be cleared + stranded, and issues NO update", async () => {
+    mockQuery.mockResolvedValueOnce(SEATED_ROWS);
+
+    const report = await runClearSeatedScope({ mode: "dry-run" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1); // read only, no UPDATE
+    expect(report.mode).toBe("dry-run");
+    expect(report.usersWithExplicitScope).toBe(2);
+    expect(report.usersCleared).toBe(2); // would-clear count
+    expect(report.strandedUsers.map((u) => u.email)).toEqual(["pm@af.org"]);
+    expect(report.strandedUsers[0].uncoveredCodes).toEqual(["99999"]);
+  });
+
+  it("apply issues the bulk clear and reports the RETURNING count", async () => {
+    mockQuery
+      .mockResolvedValueOnce(SEATED_ROWS) // read
+      .mockResolvedValueOnce([{ user_id: 10 }, { user_id: 20 }]); // UPDATE ... RETURNING
+
+    const report = await runClearSeatedScope({ mode: "apply" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const updateSql = mockQuery.mock.calls[1][0] as string;
+    expect(updateSql).toContain("UPDATE user_permission");
+    expect(updateSql).toContain("SET school_codes = NULL, regions = NULL");
+    expect(report.usersCleared).toBe(2);
+    expect(report.strandedUsers).toHaveLength(1);
+  });
+
+  it("is idempotent: no seated users with explicit scope → no UPDATE", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        user_id: "10",
+        email: "teacher@af.org",
+        school_codes: null,
+        regions: null,
+        seat_school_codes: ["70705"],
+      },
+    ]);
+
+    const report = await runClearSeatedScope({ mode: "apply" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1); // read only — nothing to clear
+    expect(report.usersWithExplicitScope).toBe(0);
+    expect(report.usersCleared).toBe(0);
+    expect(report.strandedUsers).toHaveLength(0);
+  });
+
+  it("treats regions-only seated users as needing a clear", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          user_id: "30",
+          email: "region@af.org",
+          school_codes: null,
+          regions: ["West"],
+          seat_school_codes: ["70705"],
+        },
+      ])
+      .mockResolvedValueOnce([{ user_id: 30 }]);
+
+    const report = await runClearSeatedScope({ mode: "apply" });
+
+    expect(report.usersWithExplicitScope).toBe(1);
+    expect(report.usersCleared).toBe(1);
+    expect(report.strandedUsers).toHaveLength(0); // no school_codes → nothing uncovered
+  });
+});

--- a/src/lib/clear-seated-scope.ts
+++ b/src/lib/clear-seated-scope.ts
@@ -1,0 +1,112 @@
+/**
+ * One-time data migration for strict per-user exclusivity.
+ *
+ * Once centre seats are the source of truth for a seated person's school scope
+ * (see resolveScope + the seat-assignment clearing in staff-admin), any explicit
+ * `user_permission.school_codes`/`regions` they still carry from before the
+ * cutover is stale and must be cleared — otherwise a later seat move leaves the
+ * old school reachable (the move-doesn't-revoke bug).
+ *
+ * This clears explicit scope for every active person holding ≥1 active seat. It
+ * is LOUD about "stranded" people: those whose `school_codes` include a school
+ * that NO seat covers (e.g. the centre isn't created/linked yet). Clearing their
+ * scope removes access to those schools until ops creates the missing seats, so
+ * the dry-run worklist is the ops to-do list. Idempotent: re-running clears
+ * nothing once scopes are already null.
+ */
+import { query } from "./db";
+
+export type ClearSeatedScopeMode = "dry-run" | "apply";
+
+export interface SeatedScopeRow {
+  userId: number;
+  email: string;
+  schoolCodes: string[];
+  regions: string[];
+  seatSchoolCodes: string[];
+  // school_codes not covered by any of this person's seats — access lost on clear.
+  uncoveredCodes: string[];
+}
+
+export interface ClearSeatedScopeReport {
+  mode: ClearSeatedScopeMode;
+  ok: boolean;
+  error?: string;
+  // Seated people still carrying explicit school_codes/regions (would be / were cleared).
+  usersWithExplicitScope: number;
+  usersCleared: number;
+  // Seated people who lose access to ≥1 uncovered school on clear (ops worklist).
+  strandedUsers: SeatedScopeRow[];
+  rows: SeatedScopeRow[];
+}
+
+export async function runClearSeatedScope(opts: {
+  mode: ClearSeatedScopeMode;
+}): Promise<ClearSeatedScopeReport> {
+  // Every active (non-revoked) person holding ≥1 active seat, with their explicit
+  // scope and the school codes their seats cover (centre_positions → centres.school_id).
+  const raw = await query<{
+    user_id: number | string;
+    email: string;
+    school_codes: string[] | null;
+    regions: string[] | null;
+    seat_school_codes: string[] | null;
+  }>(
+    `SELECT up.user_id,
+            lower(up.email) AS email,
+            up.school_codes,
+            up.regions,
+            array_agg(DISTINCT s.code) FILTER (WHERE s.code IS NOT NULL) AS seat_school_codes
+     FROM user_permission up
+     JOIN centre_positions cp ON cp.user_id = up.user_id AND cp.deleted_at IS NULL
+     LEFT JOIN centres c ON c.id = cp.centre_id
+     LEFT JOIN school s ON s.id = c.school_id
+     WHERE up.revoked_at IS NULL
+     GROUP BY up.user_id, up.email, up.school_codes, up.regions
+     ORDER BY lower(up.email)`
+  );
+
+  const rows: SeatedScopeRow[] = raw.map((r) => {
+    const schoolCodes = r.school_codes ?? [];
+    const seatSchoolCodes = r.seat_school_codes ?? [];
+    const seatSet = new Set(seatSchoolCodes);
+    return {
+      userId: Number(r.user_id),
+      email: r.email,
+      schoolCodes,
+      regions: r.regions ?? [],
+      seatSchoolCodes,
+      uncoveredCodes: schoolCodes.filter((code) => !seatSet.has(code)),
+    };
+  });
+
+  const toClear = rows.filter(
+    (r) => r.schoolCodes.length > 0 || r.regions.length > 0
+  );
+  const strandedUsers = rows.filter((r) => r.uncoveredCodes.length > 0);
+
+  let usersCleared = toClear.length; // dry-run = would-clear count
+  if (opts.mode === "apply" && toClear.length > 0) {
+    const cleared = await query<{ user_id: number }>(
+      `UPDATE user_permission up
+       SET school_codes = NULL, regions = NULL, updated_at = now()
+       WHERE up.revoked_at IS NULL
+         AND (up.school_codes IS NOT NULL OR up.regions IS NOT NULL)
+         AND EXISTS (
+           SELECT 1 FROM centre_positions cp
+           WHERE cp.user_id = up.user_id AND cp.deleted_at IS NULL
+         )
+       RETURNING up.user_id`
+    );
+    usersCleared = cleared.length;
+  }
+
+  return {
+    mode: opts.mode,
+    ok: true,
+    usersWithExplicitScope: toClear.length,
+    usersCleared,
+    strandedUsers,
+    rows,
+  };
+}

--- a/src/lib/curriculum-summary.test.ts
+++ b/src/lib/curriculum-summary.test.ts
@@ -13,6 +13,7 @@ vi.mock("./curriculum-schema", () => ({
 }));
 
 import {
+  buildCommonQueryParams,
   getCurriculumSummary,
   normalizeCurriculumSummaryPageSize,
   normalizeCurriculumSummarySearchParams,
@@ -941,5 +942,49 @@ describe("curriculum summary", () => {
       "ORDER BY page_row_order ASC, coverage_sequence ASC NULLS LAST, chapter_code ASC, chapter_sort_name ASC, chapter_id ASC"
     );
     expect(mockQuery.mock.calls[4][1].slice(-2)).toEqual([10, 10]);
+  });
+});
+
+describe("buildCommonQueryParams (seat-aware scope)", () => {
+  const emptyFilters = normalizeCurriculumSummarySearchParams({}, "2026-06-13");
+
+  it("passes the resolved scope set (explicit ∪ seats) as the level-1 school param ($2)", () => {
+    const params = buildCommonQueryParams(
+      {
+        ...pmPermission,
+        level: 1,
+        role: "teacher",
+        school_codes: ["70705"],
+        scope: { schools: new Set(["70705", "99999"]), centres: new Set([5]) },
+      },
+      emptyFilters
+    );
+    expect(params[0]).toBe(false); // $1: level === 3
+    expect(new Set(params[1] as string[])).toEqual(new Set(["70705", "99999"])); // $2
+    expect(params[2]).toBeNull(); // $3: regions
+  });
+
+  it("falls back to raw school_codes for level 1 when scope is unresolved", () => {
+    const params = buildCommonQueryParams(
+      { ...pmPermission, level: 1, role: "teacher", school_codes: ["70705"], regions: null },
+      emptyFilters
+    );
+    expect(params[1]).toEqual(["70705"]);
+  });
+
+  it("includes level-2 seat schools in $2 while regions flow through $3", () => {
+    const params = buildCommonQueryParams(
+      {
+        ...pmPermission,
+        level: 2,
+        role: "admin",
+        school_codes: null,
+        regions: ["West"],
+        scope: { schools: new Set(["55555"]), centres: new Set([9]) },
+      },
+      emptyFilters
+    );
+    expect(params[1]).toEqual(["55555"]); // $2 seat schools
+    expect(params[2]).toEqual(["West"]); // $3 regions
   });
 });

--- a/src/lib/curriculum-summary.ts
+++ b/src/lib/curriculum-summary.ts
@@ -374,13 +374,26 @@ export async function getCurriculumSummary(
   };
 }
 
-function buildCommonQueryParams(
+export function buildCommonQueryParams(
   permission: UserPermission,
   filters: CurriculumSummaryFilters
 ): unknown[] {
+  // Scoped-universe SQL ($2) ORs a school-code match with the ($3) region match.
+  // Feed the resolved scope set into $2 so seat-derived schools are included:
+  // for level 1 it already unions explicit school_codes with seats; for level 2
+  // it carries seats (regions still flow through $3). Falls back to raw
+  // school_codes when scope isn't resolved, preserving pre-seat behaviour. This
+  // is what keeps seated staff in the summary once strict-exclusivity clears
+  // their explicit school_codes.
+  const scopeSchools =
+    permission.scope && permission.scope.schools !== "all"
+      ? [...permission.scope.schools]
+      : permission.level === 1
+        ? permission.school_codes ?? []
+        : null;
   return [
     permission.level === 3,
-    permission.level === 1 ? permission.school_codes ?? [] : null,
+    scopeSchools && scopeSchools.length > 0 ? scopeSchools : null,
     permission.level === 2 ? permission.regions ?? [] : null,
     CURRICULUM_PROGRAM_IDS,
     permission.role === "admin",

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -4,6 +4,12 @@ import {
   getFeatureAccess,
   ownsRecord,
   getProgramContextSync,
+  resolveScope,
+  getResolvedPermission,
+  canAccessSchoolSync,
+  canAccessCentreSync,
+  hasMultipleSchools,
+  getAccessibleSchoolCodes,
   PROGRAM_IDS,
   type UserPermission,
 } from "./permissions";
@@ -319,6 +325,7 @@ describe("getUserPermission", () => {
         regions: ["West"],
         program_ids: [1, 64],
         read_only: false,
+        user_id: "42",
       },
     ]);
 
@@ -331,6 +338,7 @@ describe("getUserPermission", () => {
       regions: ["West"],
       program_ids: [1, 64],
       read_only: false,
+      user_id: 42,
     });
   });
 
@@ -381,6 +389,158 @@ describe("getUserPermission", () => {
 
     const result = await getUserPermission("admin@avantifellows.org");
     expect(result!.level).toBe(3);
+  });
+});
+
+describe("resolveScope", () => {
+  it("returns all/all for level 3 (short-circuit, no DB)", async () => {
+    const scope = await resolveScope(makePermission({ level: 3, role: "admin" }));
+    expect(scope.schools).toBe("all");
+    expect(scope.centres).toBe("all");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("seeds level-1 school_codes and unions seat-derived schools", async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ centre_id: 5 }, { centre_id: 6 }]) // centresForUser
+      .mockResolvedValueOnce([{ code: "99999" }]); // schoolCodesForCentres
+    const scope = await resolveScope(
+      makePermission({ level: 1, school_codes: ["70705"], user_id: 42 })
+    );
+    expect(scope.schools).toEqual(new Set(["70705", "99999"]));
+    expect(scope.centres).toEqual(new Set([5, 6]));
+  });
+
+  it("skips the seat lookup entirely when user_id is null", async () => {
+    const scope = await resolveScope(
+      makePermission({ level: 1, school_codes: ["70705"], user_id: null })
+    );
+    expect(scope.schools).toEqual(new Set(["70705"]));
+    expect(scope.centres).toEqual(new Set());
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not seed school_codes for level 2 (regions are the mechanism)", async () => {
+    const scope = await resolveScope(
+      makePermission({ level: 2, school_codes: ["70705"], regions: ["West"], user_id: null })
+    );
+    expect(scope.schools).toEqual(new Set());
+  });
+
+  it("degrades to explicit-only scope when the centre query throws", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("relation centre_positions does not exist"));
+    const scope = await resolveScope(
+      makePermission({ level: 1, school_codes: ["70705"], user_id: 42 })
+    );
+    expect(scope.schools).toEqual(new Set(["70705"]));
+    expect(scope.centres).toEqual(new Set());
+  });
+});
+
+describe("getResolvedPermission", () => {
+  it("returns null when there is no active permission row", async () => {
+    mockQuery.mockResolvedValueOnce([]); // getUserPermission
+    expect(await getResolvedPermission("nobody@x.com")).toBeNull();
+  });
+
+  it("attaches resolved scope (explicit ∪ seats) to the permission", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "t@x.com",
+          level: 1,
+          role: "teacher",
+          school_codes: ["70705"],
+          regions: null,
+          program_ids: [1],
+          read_only: false,
+          user_id: "42",
+        },
+      ]) // getUserPermission
+      .mockResolvedValueOnce([{ centre_id: 5 }]) // centresForUser
+      .mockResolvedValueOnce([{ code: "99999" }]); // schoolCodesForCentres
+    const p = await getResolvedPermission("t@x.com");
+    expect(p?.scope?.schools).toEqual(new Set(["70705", "99999"]));
+    expect(p?.scope?.centres).toEqual(new Set([5]));
+  });
+});
+
+describe("canAccessSchoolSync (seat-derived scope)", () => {
+  it("grants a seat-derived school not in school_codes (level 1)", () => {
+    const p = makePermission({
+      level: 1,
+      school_codes: ["70705"],
+      scope: { schools: new Set(["70705", "99999"]), centres: new Set([5]) },
+    });
+    expect(canAccessSchoolSync(p, "99999")).toBe(true); // seat school
+    expect(canAccessSchoolSync(p, "70705")).toBe(true); // explicit
+    expect(canAccessSchoolSync(p, "11111")).toBe(false); // neither
+  });
+
+  it("behaves exactly as before when scope is absent (bare permission)", () => {
+    const p = makePermission({ level: 1, school_codes: ["70705"] });
+    expect(canAccessSchoolSync(p, "70705")).toBe(true);
+    expect(canAccessSchoolSync(p, "99999")).toBe(false);
+  });
+
+  it("level-2 region check is unaffected by an empty seat set", () => {
+    const p = makePermission({
+      level: 2,
+      school_codes: null,
+      regions: ["West"],
+      scope: { schools: new Set(), centres: new Set() },
+    });
+    expect(canAccessSchoolSync(p, "70705", "West")).toBe(true);
+    expect(canAccessSchoolSync(p, "70705", "East")).toBe(false);
+  });
+});
+
+describe("canAccessCentreSync", () => {
+  it("grants held centres, denies others, and short-circuits level-3", () => {
+    const seated = makePermission({
+      scope: { schools: new Set(), centres: new Set([5, 6]) },
+    });
+    expect(canAccessCentreSync(seated, 5)).toBe(true);
+    expect(canAccessCentreSync(seated, 7)).toBe(false);
+
+    const admin = makePermission({
+      level: 3,
+      role: "admin",
+      scope: { schools: "all", centres: "all" },
+    });
+    expect(canAccessCentreSync(admin, 999)).toBe(true);
+
+    expect(canAccessCentreSync(makePermission(), 5)).toBe(false); // no scope
+    expect(canAccessCentreSync(null, 5)).toBe(false);
+  });
+});
+
+describe("seat-derived scope in getAccessibleSchoolCodes / hasMultipleSchools", () => {
+  it("getAccessibleSchoolCodes unions seat schools for level 1 (scope present, no extra query)", async () => {
+    const perm = makePermission({
+      level: 1,
+      school_codes: ["70705"],
+      scope: { schools: new Set(["70705", "99999"]), centres: new Set([5]) },
+    });
+    const result = await getAccessibleSchoolCodes("t@af.org", perm);
+    expect(new Set(result as string[])).toEqual(new Set(["70705", "99999"]));
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("hasMultipleSchools is true when the resolved scope spans >1 school", () => {
+    const single = makePermission({
+      level: 1,
+      school_codes: ["70705"],
+      scope: { schools: new Set(["70705"]), centres: new Set() },
+    });
+    expect(hasMultipleSchools(single)).toBe(false);
+
+    const seatedElsewhere = makePermission({
+      level: 1,
+      school_codes: ["70705"],
+      scope: { schools: new Set(["70705", "99999"]), centres: new Set([5]) },
+    });
+    expect(hasMultipleSchools(seatedElsewhere)).toBe(true);
   });
 });
 

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -427,13 +427,29 @@ describe("resolveScope", () => {
     expect(scope.schools).toEqual(new Set());
   });
 
-  it("degrades to explicit-only scope when the centre query throws", async () => {
-    mockQuery.mockRejectedValueOnce(new Error("relation centre_positions does not exist"));
+  it("degrades to explicit-only scope when the centre tables are missing", async () => {
+    // undefined_table (42P01): the seat migration hasn't run on this env.
+    const missingTable = Object.assign(
+      new Error("relation centre_positions does not exist"),
+      { code: "42P01" }
+    );
+    mockQuery.mockRejectedValueOnce(missingTable);
     const scope = await resolveScope(
       makePermission({ level: 1, school_codes: ["70705"], user_id: 42 })
     );
     expect(scope.schools).toEqual(new Set(["70705"]));
     expect(scope.centres).toEqual(new Set());
+  });
+
+  it("propagates a transient centre-query error instead of silently emptying scope", async () => {
+    // A non-schema error (e.g. connection reset) must not be swallowed — doing
+    // so would hand a seated user an empty scope and lock them out silently.
+    mockQuery.mockRejectedValueOnce(new Error("connection terminated"));
+    await expect(
+      resolveScope(
+        makePermission({ level: 1, school_codes: ["70705"], user_id: 42 })
+      )
+    ).rejects.toThrow("connection terminated");
   });
 });
 

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -334,6 +334,15 @@ describe("getUserPermission", () => {
     });
   });
 
+  it("excludes revoked (exited) rows via revoked_at IS NULL", async () => {
+    mockQuery.mockResolvedValueOnce([]); // revoked person -> no active row
+    const result = await getUserPermission("exited@avantifellows.org");
+    expect(result).toBeNull();
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("revoked_at IS NULL");
+  });
+
   it("returns null when no rows found", async () => {
     mockQuery.mockResolvedValueOnce([]);
     const result = await getUserPermission("unknown@example.com");

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -158,6 +158,10 @@ const SCHOOL_PASSCODES: SchoolPasscode[] = [
 export async function getUserPermission(
   email: string
 ): Promise<UserPermission | null> {
+  // `revoked_at IS NULL` is the single enforcement point for "marked exited":
+  // a revoked person resolves to no permissions everywhere this is called —
+  // login lands on pages that gate on it, isAdmin, canAccessSchool, the admin
+  // guards.
   const results = await query<{
     email: string;
     level: number;
@@ -169,7 +173,7 @@ export async function getUserPermission(
   }>(
     `SELECT email, level, role, school_codes, regions, program_ids, read_only
      FROM user_permission
-     WHERE LOWER(email) = LOWER($1)`,
+     WHERE LOWER(email) = LOWER($1) AND revoked_at IS NULL`,
     [email]
   );
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -236,6 +236,15 @@ async function schoolCodesForCentres(centreIds: number[]): Promise<string[]> {
   return rows.map((r) => r.code);
 }
 
+// True only for Postgres "undefined_table" / "undefined_column" errors — the
+// signal that the centre-seat schema hasn't been migrated on this environment
+// yet. Used to scope resolveScope's degrade-to-explicit fallback to that case
+// alone (transient failures must propagate, not silently empty the scope).
+function isMissingSchemaError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === "42P01" || code === "42703";
+}
+
 // Resolve a permission's effective scope: explicit school_codes ∪ centre-seat-
 // derived schools. Regions stay handled lazily by canAccessSchoolSync's level-2
 // branch (no eager region→school expansion here, so level-2 semantics are
@@ -259,10 +268,14 @@ export async function resolveScope(p: UserPermission): Promise<ResolvedScope> {
       for (const code of await schoolCodesForCentres(centreIds)) {
         schools.add(code);
       }
-    } catch {
-      // centre tables missing on an env (or a transient error) → degrade to
-      // explicit-only scope. Fails toward *less* access (deny), never throws on
-      // the auth hot path.
+    } catch (err) {
+      // The centre tables/columns may not exist yet on an environment that
+      // hasn't run the seat migration — degrade to explicit-only scope in that
+      // one case. Any other error (a transient DB failure) must propagate:
+      // swallowing it would silently hand a *seated* staff member an empty
+      // scope (their explicit school_codes were cleared by strict exclusivity),
+      // i.e. lock them out of their own data while showing no error.
+      if (!isMissingSchemaError(err)) throw err;
     }
   }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -132,6 +132,24 @@ export interface UserPermission {
   regions?: string[] | null;
   program_ids?: number[] | null;
   read_only?: boolean;
+  // db-service `user` PK (user_permission.user_id, live prod + staging via #545).
+  // Carried so the scope resolver can find this person's centre seats without a
+  // second email→user lookup. Selected in getUserPermission (single column, no
+  // join — the hot path stays lean).
+  user_id?: number | null;
+  // Effective school/centre scope, populated only by getResolvedPermission /
+  // resolveScope (NOT by getUserPermission). When present, canAccessSchoolSync
+  // grants seat-derived schools on top of the level switch. Absent on a bare
+  // getUserPermission result, which behaves exactly as before.
+  scope?: ResolvedScope;
+}
+
+// Effective, DB-resolved access scope. `schools` is the union of explicit
+// school_codes/regions and centre-seat-derived schools; `centres` is the set of
+// centres the person holds a seat at. "all" short-circuits for level-3 admins.
+export interface ResolvedScope {
+  schools: Set<string> | "all";
+  centres: Set<number> | "all";
 }
 
 // Program permission context
@@ -170,8 +188,9 @@ export async function getUserPermission(
     regions: string[] | null;
     program_ids: number[] | null;
     read_only: boolean;
+    user_id: number | string | null;
   }>(
-    `SELECT email, level, role, school_codes, regions, program_ids, read_only
+    `SELECT email, level, role, school_codes, regions, program_ids, read_only, user_id
      FROM user_permission
      WHERE LOWER(email) = LOWER($1) AND revoked_at IS NULL`,
     [email]
@@ -188,7 +207,76 @@ export async function getUserPermission(
     regions: row.regions,
     program_ids: row.program_ids,
     read_only: row.read_only,
+    user_id: row.user_id == null ? null : Number(row.user_id),
   };
+}
+
+// Centre ids the user holds an active seat at (centre_positions.user_id).
+async function centresForUser(userId: number): Promise<number[]> {
+  const rows = await query<{ centre_id: number | string }>(
+    `SELECT DISTINCT centre_id
+     FROM centre_positions
+     WHERE user_id = $1 AND deleted_at IS NULL`,
+    [userId]
+  );
+  return rows.map((r) => Number(r.centre_id));
+}
+
+// School codes for a set of centres (centres.school_id → school.code). Returns
+// [] for empty input rather than issuing a `= ANY('{}')` query.
+async function schoolCodesForCentres(centreIds: number[]): Promise<string[]> {
+  if (centreIds.length === 0) return [];
+  const rows = await query<{ code: string }>(
+    `SELECT DISTINCT s.code
+     FROM centres c
+     JOIN school s ON s.id = c.school_id
+     WHERE c.id = ANY($1) AND c.school_id IS NOT NULL`,
+    [centreIds]
+  );
+  return rows.map((r) => r.code);
+}
+
+// Resolve a permission's effective scope: explicit school_codes ∪ centre-seat-
+// derived schools. Regions stay handled lazily by canAccessSchoolSync's level-2
+// branch (no eager region→school expansion here, so level-2 semantics are
+// unchanged). The union is additive and safe today because backfilled seats were
+// derived from school_codes (seat schools ⊆ school_codes); strict per-user
+// exclusivity (B2) makes seats the sole source for seated staff.
+export async function resolveScope(p: UserPermission): Promise<ResolvedScope> {
+  if (p.level === 3) return { schools: "all", centres: "all" };
+
+  // school_codes is the level-1 scope mechanism; level-2's explicit scope is
+  // regions (kept lazy in canAccessSchoolSync's switch), so only seed school_codes
+  // for level 1 — seeding it for level 2 would over-grant the additive check and
+  // diverge from the level switch.
+  const schools = new Set<string>(p.level === 1 ? p.school_codes ?? [] : []);
+  const centres = new Set<number>();
+
+  if (p.user_id != null) {
+    try {
+      const centreIds = await centresForUser(p.user_id);
+      centreIds.forEach((id) => centres.add(id));
+      for (const code of await schoolCodesForCentres(centreIds)) {
+        schools.add(code);
+      }
+    } catch {
+      // centre tables missing on an env (or a transient error) → degrade to
+      // explicit-only scope. Fails toward *less* access (deny), never throws on
+      // the auth hot path.
+    }
+  }
+
+  return { schools, centres };
+}
+
+// getUserPermission + resolved scope. Use this (not getUserPermission) anywhere
+// school/centre access is actually decided, so canAccessSchoolSync sees seats.
+export async function getResolvedPermission(
+  email: string
+): Promise<UserPermission | null> {
+  const permission = await getUserPermission(email);
+  if (!permission) return null;
+  return { ...permission, scope: await resolveScope(permission) };
 }
 
 export function getSchoolByPasscode(passcode: string): string | null {
@@ -202,6 +290,18 @@ export function canAccessSchoolSync(
   schoolRegion?: string
 ): boolean {
   if (!permission) return false;
+  // Seat-derived scope (populated by getResolvedPermission) grants access
+  // additively, regardless of level — a teacher seated at a centre reaches that
+  // centre's school even if it isn't in their explicit school_codes. Absent
+  // scope (bare getUserPermission) falls straight through to the level switch,
+  // so existing callers are unaffected.
+  if (
+    permission.scope &&
+    permission.scope.schools !== "all" &&
+    permission.scope.schools.has(schoolCode)
+  ) {
+    return true;
+  }
   switch (permission.level) {
     case 3: return true;
     case 2: return permission.regions?.includes(schoolRegion || "") || false;
@@ -210,13 +310,26 @@ export function canAccessSchoolSync(
   }
 }
 
+// Centre-native access check for callers that hold a centre id directly. Reads
+// the resolved seat set; level-3 (scope "all") reaches every centre.
+export function canAccessCentreSync(
+  permission: UserPermission | null,
+  centreId: number
+): boolean {
+  if (!permission) return false;
+  if (permission.scope?.centres === "all") return true;
+  return permission.scope?.centres instanceof Set
+    ? permission.scope.centres.has(centreId)
+    : false;
+}
+
 export async function canAccessSchool(
   email: string | null,
   schoolCode: string,
   schoolRegion?: string
 ): Promise<boolean> {
   if (!email) return false;
-  const permission = await getUserPermission(email);
+  const permission = await getResolvedPermission(email);
   // For level-2 (region) users, look up the school's region if not provided
   if (permission?.level === 2 && !schoolRegion) {
     const result = await query<{ region: string }>(
@@ -231,20 +344,31 @@ export async function canAccessSchool(
 export function hasMultipleSchools(permission: UserPermission | null): boolean {
   if (!permission) return false;
   return permission.level >= 2 ||
-    (permission.school_codes !== null && (permission.school_codes?.length ?? 0) > 1);
+    (permission.school_codes !== null && (permission.school_codes?.length ?? 0) > 1) ||
+    (permission.scope?.schools instanceof Set && permission.scope.schools.size > 1);
 }
 
 export async function getAccessibleSchoolCodes(
   email: string,
   existingPermission?: UserPermission | null
 ): Promise<string[] | "all"> {
-  const permission = existingPermission !== undefined ? existingPermission : await getUserPermission(email);
+  const permission =
+    existingPermission !== undefined
+      ? existingPermission
+      : await getResolvedPermission(email);
   if (!permission) return [];
 
   if (permission.level === 3) return "all";
-  if (permission.level === 1) return permission.school_codes || [];
 
-  // Level 2: fetch all school codes in the user's assigned regions
+  // Resolved scope = explicit school_codes ∪ centre-seat schools. Resolve here
+  // if the caller handed us a bare (unresolved) permission so seat schools are
+  // still included.
+  const scope = permission.scope ?? (await resolveScope(permission));
+  if (scope.schools === "all") return "all";
+
+  const codes = new Set<string>(scope.schools);
+
+  // Level 2: also expand the user's assigned regions to concrete JNV codes.
   if (permission.level === 2 && permission.regions && permission.regions.length > 0) {
     const schools = await query<{ code: string }>(
       `SELECT code FROM school
@@ -252,10 +376,10 @@ export async function getAccessibleSchoolCodes(
          AND region = ANY($1)`,
       [permission.regions]
     );
-    return schools.map((s) => s.code);
+    for (const s of schools) codes.add(s.code);
   }
 
-  return [];
+  return [...codes];
 }
 
 export async function isAdmin(email: string): Promise<boolean> {
@@ -331,7 +455,7 @@ export async function canAccessStudent(
 
   const email = session.user?.email;
   if (!email) return false;
-  const permission = await getUserPermission(email);
+  const permission = await getResolvedPermission(email);
   if (!canAccessSchoolSync(permission, school.code, school.region || undefined)) {
     // Level-2 region users may still match via the async fallback path that
     // canAccessSchool does (querying school.region when not provided). We've

--- a/src/lib/quiz-session-access.ts
+++ b/src/lib/quiz-session-access.ts
@@ -3,7 +3,7 @@ import { query } from "@/lib/db";
 import {
   canAccessSchoolSync,
   getFeatureAccess,
-  getUserPermission,
+  getResolvedPermission,
   type UserPermission,
 } from "@/lib/permissions";
 
@@ -25,7 +25,7 @@ export async function requireQuizSessionAccess(
   email: string,
   mode: QuizSessionAccessMode
 ): Promise<QuizSessionAccessResult> {
-  const permission = await getUserPermission(email);
+  const permission = await getResolvedPermission(email);
   const access = getFeatureAccess(permission, "quiz_sessions");
 
   if ((mode === "view" && !access.canView) || (mode === "edit" && !access.canEdit)) {

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -378,6 +378,7 @@ describe("createStaffMember", () => {
       },
     ]);
     mockQuery.mockResolvedValueOnce([]); // code clash check
+    mockQuery.mockResolvedValueOnce([]); // existing-user-by-email lookup (none)
     mockClientQuery.mockResolvedValueOnce({ rows: [{ id: "99" }] }); // user insert
 
     const result = await createStaffMember({
@@ -391,6 +392,37 @@ describe("createStaffMember", () => {
     expect(calls[1][0]).toContain("UPDATE user_permission SET user_id");
     expect(calls[2][0]).toContain("INSERT INTO staff");
     expect(calls[2][1]).toEqual([99, "AF7", null]);
+  });
+
+  it("reuses an existing user found by email instead of inserting a duplicate", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: 5,
+        email: "pm@avantifellows.org",
+        full_name: "Pending Pm Person",
+        role: "program_manager",
+        user_id: null,
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([]); // code clash check
+    mockQuery.mockResolvedValueOnce([{ id: "70" }]); // existing user found by email
+    mockQuery.mockResolvedValueOnce([]); // staff clash check (none)
+
+    const result = await createStaffMember({
+      body: { user_permission_id: 5, employee_code: "AF7" },
+    });
+    expect(result).toEqual({ ok: true });
+
+    const calls = mockClientQuery.mock.calls;
+    // No "user" INSERT — the existing id 70 is reused.
+    expect(calls.some(([sql]) => String(sql).includes(`INSERT INTO "user"`))).toBe(
+      false
+    );
+    expect(calls[0][0]).toContain("UPDATE user_permission SET user_id");
+    expect(calls[0][1]).toEqual([70, 5]);
+    expect(calls[1][0]).toContain("INSERT INTO staff");
+    expect(calls[1][1]).toEqual([70, "AF7", null]);
   });
 
   it("409s when the code or person already exists", async () => {
@@ -480,6 +512,7 @@ describe("positions", () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
     mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user
+    mockQuery.mockResolvedValueOnce([{ level: 1 }]); // region-level guard (not level 2)
     mockQuery.mockResolvedValueOnce([]); // duplicate check (none)
     expect(
       await createPosition({ body: { centre_id: 8, role: "physics", user_id: 70 } })
@@ -496,15 +529,32 @@ describe("positions", () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
     mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user
+    mockQuery.mockResolvedValueOnce([{ level: 1 }]); // region-level guard (not level 2)
     mockQuery.mockResolvedValueOnce([{ id: 44 }]); // duplicate
     expect(
       await createPosition({ body: { centre_id: 8, role: "physics", user_id: 70 } })
     ).toMatchObject({ ok: false, status: 409 });
   });
 
+  it("createPosition rejects seating a region-level (level-2) user", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user
+    mockQuery.mockResolvedValueOnce([{ level: 2 }]); // region-level user → blocked
+    expect(
+      await createPosition({ body: { centre_id: 8, role: "physics", user_id: 70 } })
+    ).toMatchObject({ ok: false, status: 422 });
+    // No transaction / insert happened.
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
   it("updatePosition vacates a seat without clearing scope", async () => {
     mockSchemaReady();
-    mockQuery.mockResolvedValueOnce([{ id: 44, centre_id: 8, role: "physics" }]);
+    // Occupant 70 has another active seat, so vacating this one isn't a strand.
+    mockQuery.mockResolvedValueOnce([
+      { id: 44, centre_id: 8, role: "physics", user_id: 70 },
+    ]);
+    mockQuery.mockResolvedValueOnce([{ id: 99 }]); // isLastActiveSeat → not last
     expect(await updatePosition({ id: 44, body: { user_id: null } })).toEqual({
       ok: true,
     });
@@ -518,10 +568,35 @@ describe("positions", () => {
     ).toBe(false);
   });
 
+  it("updatePosition refuses to vacate an occupant's only seat unless forced", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 44, centre_id: 8, role: "physics", user_id: 70 },
+    ]); // position
+    mockQuery.mockResolvedValueOnce([]); // isLastActiveSeat → no other seats → last
+    const blocked = await updatePosition({ id: 44, body: { user_id: null } });
+    expect(blocked).toMatchObject({ ok: false, status: 409, code: "last_seat" });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+
+    // With force the vacate proceeds (no last-seat check query needed).
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([
+      { id: 44, centre_id: 8, role: "physics", user_id: 70 },
+    ]);
+    expect(
+      await updatePosition({ id: 44, body: { user_id: null }, force: true })
+    ).toEqual({ ok: true });
+    expect(mockClientQuery.mock.calls.at(-1)![0]).toContain("SET user_id = $1");
+  });
+
   it("updatePosition fills a seat and clears the occupant's explicit scope", async () => {
     mockSchemaReady();
-    mockQuery.mockResolvedValueOnce([{ id: 44, centre_id: 8, role: "physics" }]); // position
+    mockQuery.mockResolvedValueOnce([
+      { id: 44, centre_id: 8, role: "physics", user_id: null },
+    ]); // position
     mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user lookup
+    mockQuery.mockResolvedValueOnce([{ level: 1 }]); // region-level guard (not level 2)
     mockQuery.mockResolvedValueOnce([]); // duplicate check (none)
     expect(await updatePosition({ id: 44, body: { user_id: 70 } })).toEqual({
       ok: true,
@@ -534,11 +609,29 @@ describe("positions", () => {
     expect(clearCall[1]).toEqual([70]);
   });
 
-  it("deletePosition soft-deletes", async () => {
+  it("deletePosition soft-deletes a vacant seat", async () => {
     mockSchemaReady();
-    mockQuery.mockResolvedValueOnce([{ id: 44 }]);
-    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockResolvedValueOnce([{ id: 44, user_id: null }]); // vacant seat
+    mockQuery.mockResolvedValueOnce([]); // UPDATE
     expect(await deletePosition({ id: 44 })).toEqual({ ok: true });
+    expect(mockQuery.mock.calls.at(-1)![0]).toContain("SET deleted_at = now()");
+  });
+
+  it("deletePosition refuses to delete an occupant's only seat unless forced", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 44, user_id: 70 }]); // occupied seat
+    mockQuery.mockResolvedValueOnce([]); // isLastActiveSeat → last
+    expect(await deletePosition({ id: 44 })).toMatchObject({
+      ok: false,
+      status: 409,
+      code: "last_seat",
+    });
+
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([{ id: 44, user_id: 70 }]); // occupied seat
+    mockQuery.mockResolvedValueOnce([]); // UPDATE (force skips the last-seat check)
+    expect(await deletePosition({ id: 44, force: true })).toEqual({ ok: true });
     expect(mockQuery.mock.calls.at(-1)![0]).toContain("SET deleted_at = now()");
   });
 });

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -1,0 +1,503 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockQuery, mockWithTransaction, mockClientQuery, mockGetUserPermission } =
+  vi.hoisted(() => {
+    const mockClientQuery = vi.fn();
+    return {
+      mockQuery: vi.fn(),
+      mockClientQuery,
+      mockWithTransaction: vi.fn(
+        async (fn: (client: { query: typeof mockClientQuery }) => Promise<unknown>) =>
+          fn({ query: mockClientQuery })
+      ),
+      mockGetUserPermission: vi.fn(),
+    };
+  });
+
+vi.mock("./db", () => ({
+  query: mockQuery,
+  withTransaction: mockWithTransaction,
+}));
+vi.mock("./permissions", () => ({
+  getUserPermission: mockGetUserPermission,
+}));
+
+import {
+  STAFF_REQUIRED_COLUMNS,
+  createPosition,
+  createStaffMember,
+  deletePosition,
+  getStaffRoster,
+  isSeatRole,
+  normalizeEmployeeCode,
+  normalizeStaffRosterParams,
+  requireStaffAdmin,
+  resetStaffSchemaCheckForTests,
+  updatePosition,
+  updateStaffMember,
+  updateTeacherRecord,
+  validateTeacherUpdateBody,
+} from "./staff-admin";
+
+const SCHEMA_ROWS = STAFF_REQUIRED_COLUMNS.map((c) => ({
+  table_name: c.table,
+  column_name: c.column,
+}));
+
+function mockSchemaReady() {
+  mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  resetStaffSchemaCheckForTests();
+  mockWithTransaction.mockImplementation(
+    async (fn: (client: { query: typeof mockClientQuery }) => Promise<unknown>) =>
+      fn({ query: mockClientQuery })
+  );
+  mockClientQuery.mockResolvedValue({ rows: [] });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("requireStaffAdmin", () => {
+  it("rejects missing sessions, passcode users, and non-admins", async () => {
+    expect(await requireStaffAdmin(null)).toMatchObject({ ok: false, status: 401 });
+    expect(
+      await requireStaffAdmin({
+        user: { email: "x@avantifellows.org" },
+        isPasscodeUser: true,
+      })
+    ).toMatchObject({ ok: false, status: 403 });
+    mockGetUserPermission.mockResolvedValueOnce({ role: "program_manager" });
+    expect(
+      await requireStaffAdmin({ user: { email: "pm@avantifellows.org" } })
+    ).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it("accepts admins", async () => {
+    mockGetUserPermission.mockResolvedValueOnce({ role: "admin" });
+    expect(
+      await requireStaffAdmin({ user: { email: "admin@avantifellows.org" } })
+    ).toMatchObject({ ok: true, email: "admin@avantifellows.org" });
+  });
+});
+
+describe("normalizeEmployeeCode / isSeatRole", () => {
+  it("normalizes codes and rejects junk", () => {
+    expect(normalizeEmployeeCode(" af55 ")).toBe("AF55");
+    expect(normalizeEmployeeCode("MT005")).toBeNull();
+    expect(normalizeEmployeeCode(42)).toBeNull();
+  });
+
+  it("knows the seat roles", () => {
+    expect(isSeatRole("pm")).toBe(true);
+    expect(isSeatRole("apc")).toBe(true);
+    expect(isSeatRole("principal")).toBe(false);
+  });
+});
+
+describe("normalizeStaffRosterParams", () => {
+  it("defaults and validates filter params", () => {
+    expect(normalizeStaffRosterParams({})).toEqual({
+      search: "",
+      kind: "all",
+      code: "all",
+      exited: "exclude",
+      centreId: null,
+    });
+    expect(
+      normalizeStaffRosterParams({
+        search: " asha ",
+        kind: "pending_pm",
+        code: "missing",
+        exited: "include",
+        centre: "8",
+      })
+    ).toEqual({
+      search: "asha",
+      kind: "pending_pm",
+      code: "missing",
+      exited: "include",
+      centreId: 8,
+    });
+    expect(
+      normalizeStaffRosterParams({ kind: "bogus", code: "bogus", centre: "abc" })
+    ).toMatchObject({
+      kind: "all",
+      code: "all",
+      centreId: null,
+    });
+  });
+});
+
+describe("validateTeacherUpdateBody", () => {
+  it("collects payload and field errors", () => {
+    expect(validateTeacherUpdateBody({ teacher_id: "af9" })).toEqual({
+      payload: { teacher_id: "AF9" },
+      fields: {},
+    });
+    expect(validateTeacherUpdateBody({ teacher_id: "nope" }).fields).toHaveProperty(
+      "teacher_id"
+    );
+    expect(validateTeacherUpdateBody({ exit_date: "12-06-2026" }).fields).toHaveProperty(
+      "exit_date"
+    );
+    expect(validateTeacherUpdateBody({ exit_date: "2026-06-12" }).payload).toEqual({
+      exit_date: "2026-06-12",
+    });
+  });
+});
+
+describe("getStaffRoster", () => {
+  it("returns 503 when the schema is missing", async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    const result = await getStaffRoster({ searchParams: {} });
+    expect(result).toMatchObject({ ok: false, status: 503 });
+  });
+
+  it("maps roster rows, summary, and seats", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      {
+        kind: "teacher",
+        record_id: "10",
+        user_id: "70",
+        name: "Asha Teacher",
+        email: "asha@avantifellows.org",
+        employee_code: "AF101",
+        subject_name: "Physics",
+        staff_type: null,
+        designation: "Senior",
+        exit_date: null,
+      },
+      {
+        kind: "pending_pm",
+        record_id: "5",
+        user_id: null,
+        name: "Pending Pm",
+        email: "pm@avantifellows.org",
+        employee_code: null,
+        subject_name: null,
+        staff_type: "program_manager",
+        designation: null,
+        exit_date: null,
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([
+      {
+        total: "2",
+        teachers: "1",
+        staff: "0",
+        pending: "1",
+        missing_code: "1",
+        exited: "0",
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([{ vacant: "3" }]);
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: "44",
+        centre_id: "8",
+        centre_name: "JNV Adilabad - CoE",
+        role: "physics",
+        user_id: "70",
+      },
+    ]);
+
+    const result = await getStaffRoster({
+      searchParams: { code: "all" },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toMatchObject({
+      kind: "teacher",
+      recordId: 10,
+      userId: 70,
+      employeeCode: "AF101",
+      seats: [
+        { id: 44, centreId: 8, centreName: "JNV Adilabad - CoE", role: "physics" },
+      ],
+    });
+    expect(result.rows[1]).toMatchObject({
+      kind: "pending_pm",
+      userId: null,
+      seats: [],
+    });
+    expect(result.summary).toEqual({
+      total: 2,
+      teachers: 1,
+      staff: 0,
+      pending: 1,
+      missingCode: 1,
+      exited: 0,
+      vacantSeats: 3,
+    });
+  });
+
+  it("applies search/kind/code filters in the WHERE clause", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockResolvedValueOnce([]);
+
+    await getStaffRoster({
+      searchParams: { search: "asha", kind: "teacher", code: "missing" },
+    });
+
+    const [sql, values] = mockQuery.mock.calls[1];
+    expect(sql).toContain("ILIKE $1");
+    expect(sql).toContain("roster.kind = $2");
+    expect(sql).toContain("employee_code IS NULL");
+    expect(sql).toContain("exit_date IS NULL");
+    expect(values).toEqual(["%asha%", "teacher"]);
+  });
+
+  it("filters by centre via an EXISTS on seats", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockResolvedValueOnce([]);
+
+    await getStaffRoster({ searchParams: { centre: "8" } });
+
+    const [sql, values] = mockQuery.mock.calls[1];
+    expect(sql).toContain("EXISTS");
+    expect(sql).toContain("cp.centre_id = $1");
+    expect(values).toEqual([8]);
+  });
+});
+
+describe("updateTeacherRecord", () => {
+  it("rejects invalid bodies and unknown teachers", async () => {
+    mockSchemaReady();
+    expect(
+      await updateTeacherRecord({ id: 1, body: { teacher_id: "junk" } })
+    ).toMatchObject({ ok: false, status: 422 });
+
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([]); // teacher lookup
+    expect(
+      await updateTeacherRecord({ id: 1, body: { teacher_id: "AF1" } })
+    ).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it("returns 409 when the code belongs to another teacher", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 1, user_id: 70 }]);
+    mockQuery.mockResolvedValueOnce([{ id: 2 }]); // clash
+    expect(
+      await updateTeacherRecord({ id: 1, body: { teacher_id: "AF1" } })
+    ).toMatchObject({ ok: false, status: 409 });
+  });
+
+  it("PATCHes db-service and vacates seats on exit", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubEnv("DB_SERVICE_URL", "https://db.example/api");
+    vi.stubEnv("DB_SERVICE_TOKEN", "token");
+
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 1, user_id: 70 }]);
+
+    const result = await updateTeacherRecord({
+      id: 1,
+      body: { exit_date: "2026-06-12" },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://db.example/api/teacher/1",
+      expect.objectContaining({ method: "PATCH" })
+    );
+    const clientSql = mockClientQuery.mock.calls.map((call) => call[0]).join("\n");
+    expect(clientSql).toContain("UPDATE centre_positions SET user_id = NULL");
+    expect(clientSql).toContain("UPDATE user_permission SET revoked_at = now()");
+  });
+
+  it("maps db-service failures to 422/502", async () => {
+    vi.stubEnv("DB_SERVICE_URL", "https://db.example/api");
+    vi.stubEnv("DB_SERVICE_TOKEN", "token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("changeset error", { status: 422 }))
+    );
+
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 1, user_id: 70 }]);
+    mockQuery.mockResolvedValueOnce([]); // no clash
+    expect(
+      await updateTeacherRecord({ id: 1, body: { teacher_id: "AF1" } })
+    ).toMatchObject({ ok: false, status: 422 });
+
+    resetStaffSchemaCheckForTests();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([{ id: 1, user_id: 70 }]);
+    mockQuery.mockResolvedValueOnce([]);
+    expect(
+      await updateTeacherRecord({ id: 1, body: { teacher_id: "AF1" } })
+    ).toMatchObject({ ok: false, status: 502 });
+  });
+});
+
+describe("createStaffMember", () => {
+  it("validates the body", async () => {
+    mockSchemaReady();
+    const result = await createStaffMember({ body: {} });
+    expect(result).toMatchObject({ ok: false, status: 422 });
+    if (!result.ok && result.status === 422) {
+      expect(result.fields).toHaveProperty("user_permission_id");
+      expect(result.fields).toHaveProperty("employee_code");
+    }
+  });
+
+  it("404s when the permission row is not a PM", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 5, email: "t@x.org", full_name: "T", role: "teacher", user_id: null },
+    ]);
+    expect(
+      await createStaffMember({
+        body: { user_permission_id: 5, employee_code: "AF7" },
+      })
+    ).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it("creates a user when the PM has none, then the staff row", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: 5,
+        email: "pm@avantifellows.org",
+        full_name: "Pending Pm Person",
+        role: "program_manager",
+        user_id: null,
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([]); // code clash check
+    mockClientQuery.mockResolvedValueOnce({ rows: [{ id: "99" }] }); // user insert
+
+    const result = await createStaffMember({
+      body: { user_permission_id: 5, employee_code: "af7" },
+    });
+    expect(result).toEqual({ ok: true });
+
+    const calls = mockClientQuery.mock.calls;
+    expect(calls[0][0]).toContain(`INSERT INTO "user"`);
+    expect(calls[0][1]).toEqual(["Pending", "Pm Person", "pm@avantifellows.org"]);
+    expect(calls[1][0]).toContain("UPDATE user_permission SET user_id");
+    expect(calls[2][0]).toContain("INSERT INTO staff");
+    expect(calls[2][1]).toEqual([99, "AF7", null]);
+  });
+
+  it("409s when the code or person already exists", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: 5,
+        email: "pm@avantifellows.org",
+        full_name: "P",
+        role: "program_manager",
+        user_id: 70,
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([{ id: 1 }]); // code clash
+    expect(
+      await createStaffMember({
+        body: { user_permission_id: 5, employee_code: "AF7" },
+      })
+    ).toMatchObject({ ok: false, status: 409 });
+  });
+});
+
+describe("updateStaffMember", () => {
+  it("updates fields and vacates on exit", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 3, user_id: 70 }]);
+    const result = await updateStaffMember({
+      id: 3,
+      body: { exit_date: "2026-06-30" },
+    });
+    expect(result).toEqual({ ok: true });
+    const clientSql = mockClientQuery.mock.calls.map((call) => call[0]).join("\n");
+    expect(clientSql).toContain("UPDATE staff SET exit_date = $1");
+    expect(clientSql).toContain("UPDATE centre_positions SET user_id = NULL");
+  });
+
+  it("404s for unknown staff and 409s on code clash", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([]);
+    expect(
+      await updateStaffMember({ id: 3, body: { employee_code: "AF7" } })
+    ).toMatchObject({ ok: false, status: 404 });
+
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([{ id: 3, user_id: 70 }]);
+    mockQuery.mockResolvedValueOnce([{ id: 9 }]); // clash
+    expect(
+      await updateStaffMember({ id: 3, body: { employee_code: "AF7" } })
+    ).toMatchObject({ ok: false, status: 409 });
+  });
+});
+
+describe("positions", () => {
+  it("createPosition validates role and centre", async () => {
+    mockSchemaReady();
+    expect(
+      await createPosition({ body: { centre_id: 1, role: "principal" } })
+    ).toMatchObject({ ok: false, status: 422 });
+
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    mockQuery.mockResolvedValueOnce([]); // centre lookup
+    expect(
+      await createPosition({ body: { centre_id: 1, role: "pm" } })
+    ).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it("createPosition inserts a vacant seat", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([]); // insert
+    expect(
+      await createPosition({ body: { centre_id: 8, role: "physics" } })
+    ).toEqual({ ok: true });
+    const insertCall = mockQuery.mock.calls.at(-1)!;
+    expect(insertCall[0]).toContain("INSERT INTO centre_positions");
+    expect(insertCall[1]).toEqual([8, "physics", null]);
+  });
+
+  it("createPosition rejects duplicate occupied seats", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user
+    mockQuery.mockResolvedValueOnce([{ id: 44 }]); // duplicate
+    expect(
+      await createPosition({ body: { centre_id: 8, role: "physics", user_id: 70 } })
+    ).toMatchObject({ ok: false, status: 409 });
+  });
+
+  it("updatePosition fills and vacates seats", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 44, centre_id: 8, role: "physics" }]);
+    mockQuery.mockResolvedValueOnce([]); // update
+    expect(await updatePosition({ id: 44, body: { user_id: null } })).toEqual({
+      ok: true,
+    });
+    const updateCall = mockQuery.mock.calls.at(-1)!;
+    expect(updateCall[0]).toContain("SET user_id = $1");
+    expect(updateCall[1]).toEqual([null, 44]);
+  });
+
+  it("deletePosition soft-deletes", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 44 }]);
+    mockQuery.mockResolvedValueOnce([]);
+    expect(await deletePosition({ id: 44 })).toEqual({ ok: true });
+    expect(mockQuery.mock.calls.at(-1)![0]).toContain("SET deleted_at = now()");
+  });
+});

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -459,16 +459,37 @@ describe("positions", () => {
     ).toMatchObject({ ok: false, status: 404 });
   });
 
-  it("createPosition inserts a vacant seat", async () => {
+  it("createPosition inserts a vacant seat (no scope clear)", async () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
-    mockQuery.mockResolvedValueOnce([]); // insert
     expect(
       await createPosition({ body: { centre_id: 8, role: "physics" } })
     ).toEqual({ ok: true });
-    const insertCall = mockQuery.mock.calls.at(-1)!;
+    // A vacant seat goes through the transaction client; no occupant → no clear.
+    const insertCall = mockClientQuery.mock.calls.at(-1)!;
     expect(insertCall[0]).toContain("INSERT INTO centre_positions");
     expect(insertCall[1]).toEqual([8, "physics", null]);
+    expect(
+      mockClientQuery.mock.calls.some(([sql]) =>
+        String(sql).includes("SET school_codes = NULL")
+      )
+    ).toBe(false);
+  });
+
+  it("createPosition clears the occupant's explicit school scope (strict per-user)", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user
+    mockQuery.mockResolvedValueOnce([]); // duplicate check (none)
+    expect(
+      await createPosition({ body: { centre_id: 8, role: "physics", user_id: 70 } })
+    ).toEqual({ ok: true });
+    const insertCall = mockClientQuery.mock.calls[0];
+    expect(insertCall[0]).toContain("INSERT INTO centre_positions");
+    expect(insertCall[1]).toEqual([8, "physics", 70]);
+    const clearCall = mockClientQuery.mock.calls[1];
+    expect(clearCall[0]).toContain("SET school_codes = NULL, regions = NULL");
+    expect(clearCall[1]).toEqual([70]);
   });
 
   it("createPosition rejects duplicate occupied seats", async () => {
@@ -481,16 +502,36 @@ describe("positions", () => {
     ).toMatchObject({ ok: false, status: 409 });
   });
 
-  it("updatePosition fills and vacates seats", async () => {
+  it("updatePosition vacates a seat without clearing scope", async () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 44, centre_id: 8, role: "physics" }]);
-    mockQuery.mockResolvedValueOnce([]); // update
     expect(await updatePosition({ id: 44, body: { user_id: null } })).toEqual({
       ok: true,
     });
-    const updateCall = mockQuery.mock.calls.at(-1)!;
+    const updateCall = mockClientQuery.mock.calls.at(-1)!;
     expect(updateCall[0]).toContain("SET user_id = $1");
     expect(updateCall[1]).toEqual([null, 44]);
+    expect(
+      mockClientQuery.mock.calls.some(([sql]) =>
+        String(sql).includes("SET school_codes = NULL")
+      )
+    ).toBe(false);
+  });
+
+  it("updatePosition fills a seat and clears the occupant's explicit scope", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 44, centre_id: 8, role: "physics" }]); // position
+    mockQuery.mockResolvedValueOnce([{ id: 70 }]); // user lookup
+    mockQuery.mockResolvedValueOnce([]); // duplicate check (none)
+    expect(await updatePosition({ id: 44, body: { user_id: 70 } })).toEqual({
+      ok: true,
+    });
+    const updateCall = mockClientQuery.mock.calls[0];
+    expect(updateCall[0]).toContain("SET user_id = $1");
+    expect(updateCall[1]).toEqual([70, 44]);
+    const clearCall = mockClientQuery.mock.calls[1];
+    expect(clearCall[0]).toContain("SET school_codes = NULL, regions = NULL");
+    expect(clearCall[1]).toEqual([70]);
   });
 
   it("deletePosition soft-deletes", async () => {

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -1,0 +1,942 @@
+/**
+ * Staff Management domain logic (admin-only surface at /admin/staff).
+ *
+ * Roster = AF teachers (`teacher.is_af_teacher`) UNION non-teaching `staff`
+ * UNION user_permission rows not yet backfilled into either table
+ * ("pending"). Teachers/PMs without an employee code are a loud state the
+ * UI must surface (badge + filter) — a code-less teacher cannot log into
+ * Gurukul.
+ *
+ * Ownership rule: `teacher` is a db-service core entity, so teacher writes
+ * go through the db-service REST API (PATCH /teacher/:id). `staff` and
+ * `centre_positions` are LMS-owned operational tables written with direct
+ * SQL. `user_permission` stays LMS-direct as before.
+ */
+
+import type { PoolClient } from "pg";
+import { query, withTransaction } from "./db";
+import { getUserPermission } from "./permissions";
+
+// --- Sessions / guard (same shape as requireCentreAdmin) ---
+
+export type StaffAdminSession = {
+  user?: { email?: string | null } | null;
+  isPasscodeUser?: boolean;
+} | null;
+
+export type StaffAdminResult =
+  | {
+      ok: true;
+      email: string;
+      permission: NonNullable<Awaited<ReturnType<typeof getUserPermission>>>;
+    }
+  | { ok: false; status: 401 | 403; error: string };
+
+export async function requireStaffAdmin(
+  session: StaffAdminSession
+): Promise<StaffAdminResult> {
+  const email = session?.user?.email;
+  if (!email) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+
+  if (session.isPasscodeUser) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  const permission = await getUserPermission(email);
+  if (permission?.role !== "admin") {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, email, permission };
+}
+
+// --- Schema readiness ---
+
+export interface StaffSchemaReady {
+  ok: true;
+}
+
+export interface StaffSchemaUnavailable {
+  ok: false;
+  status: 503;
+  error: "Staff management schema unavailable";
+  details: string[];
+}
+
+export type StaffSchemaStatus = StaffSchemaReady | StaffSchemaUnavailable;
+
+export const STAFF_REQUIRED_COLUMNS: Array<{ table: string; column: string }> = [
+  { table: "staff", column: "id" },
+  { table: "staff", column: "user_id" },
+  { table: "staff", column: "employee_code" },
+  { table: "staff", column: "staff_type" },
+  { table: "staff", column: "designation" },
+  { table: "staff", column: "exit_date" },
+  { table: "centre_positions", column: "id" },
+  { table: "centre_positions", column: "centre_id" },
+  { table: "centre_positions", column: "role" },
+  { table: "centre_positions", column: "user_id" },
+  { table: "centre_positions", column: "hr_code" },
+  { table: "centre_positions", column: "notes" },
+  { table: "centre_positions", column: "deleted_at" },
+  { table: "teacher", column: "teacher_id" },
+  { table: "teacher", column: "is_af_teacher" },
+  { table: "teacher", column: "exit_date" },
+  { table: "user_permission", column: "user_id" },
+  { table: "user_permission", column: "revoked_at" },
+  { table: "centres", column: "id" },
+  { table: "centres", column: "name" },
+];
+
+let cachedStaffSchemaStatus: Promise<StaffSchemaStatus> | null = null;
+
+async function loadStaffSchemaStatus(): Promise<StaffSchemaStatus> {
+  const rows = await query<{ table_name: string; column_name: string }>(
+    `SELECT table_name, column_name
+     FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND (table_name, column_name) IN (
+         ${STAFF_REQUIRED_COLUMNS.map((_, i) => `($${i * 2 + 1}, $${i * 2 + 2})`).join(", ")}
+       )`,
+    STAFF_REQUIRED_COLUMNS.flatMap((c) => [c.table, c.column])
+  );
+
+  const present = new Set(rows.map((r) => `${r.table_name}.${r.column_name}`));
+  const missing = STAFF_REQUIRED_COLUMNS.filter(
+    (c) => !present.has(`${c.table}.${c.column}`)
+  ).map((c) => `${c.table}.${c.column}`);
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      status: 503,
+      error: "Staff management schema unavailable",
+      details: missing,
+    };
+  }
+  return { ok: true };
+}
+
+export async function checkStaffManagementSchema(): Promise<StaffSchemaStatus> {
+  cachedStaffSchemaStatus ??= loadStaffSchemaStatus().then(
+    (status) => {
+      if (!status.ok) {
+        cachedStaffSchemaStatus = null;
+      }
+      return status;
+    },
+    (error) => {
+      cachedStaffSchemaStatus = null;
+      throw error;
+    }
+  );
+  return cachedStaffSchemaStatus;
+}
+
+export function resetStaffSchemaCheckForTests() {
+  cachedStaffSchemaStatus = null;
+}
+
+// --- Shared shapes (client-safe values/types live in staff-shared) ---
+
+import {
+  SEAT_ROLES,
+  isSeatRole,
+  normalizeEmployeeCode,
+  type RosterKind,
+  type RosterSeat,
+  type SeatRole,
+  type StaffRosterFilters,
+  type StaffRosterRow,
+  type StaffRosterSummary,
+} from "./staff-shared";
+
+export * from "./staff-shared";
+
+export interface StaffValidationFailure {
+  ok: false;
+  status: 404 | 409 | 422 | 502;
+  error: string;
+  fields?: Record<string, string>;
+}
+
+export function safeStaffApiError(result: {
+  status: number;
+  error: string;
+  fields?: Record<string, string>;
+}): { error: string; fields?: Record<string, string> } {
+  return result.fields
+    ? { error: result.error, fields: result.fields }
+    : { error: result.error };
+}
+
+// --- Roster ---
+
+export type StaffRosterResult =
+  | {
+      ok: true;
+      filters: StaffRosterFilters;
+      rows: StaffRosterRow[];
+      summary: StaffRosterSummary;
+    }
+  | StaffSchemaUnavailable;
+
+function stringParam(value: string | string[] | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function normalizeStaffRosterParams(searchParams: {
+  [key: string]: string | string[] | undefined;
+}): StaffRosterFilters {
+  const kindRaw = stringParam(searchParams.kind);
+  const codeRaw = stringParam(searchParams.code);
+  const centreRaw = Number.parseInt(stringParam(searchParams.centre), 10);
+  return {
+    search: stringParam(searchParams.search),
+    kind: (
+      ["teacher", "staff", "pending_teacher", "pending_pm"] as const
+    ).includes(kindRaw as RosterKind)
+      ? (kindRaw as RosterKind)
+      : "all",
+    code: codeRaw === "missing" || codeRaw === "present" ? codeRaw : "all",
+    exited: stringParam(searchParams.exited) === "include" ? "include" : "exclude",
+    centreId: Number.isInteger(centreRaw) && centreRaw > 0 ? centreRaw : null,
+  };
+}
+
+interface RosterQueryRow {
+  kind: RosterKind;
+  record_id: number;
+  user_id: number | null;
+  name: string;
+  email: string | null;
+  employee_code: string | null;
+  subject_name: string | null;
+  staff_type: string | null;
+  designation: string | null;
+  exit_date: string | null;
+}
+
+const ROSTER_CTE = `
+  WITH roster AS (
+    SELECT
+      'teacher'::text AS kind,
+      t.id AS record_id,
+      u.id AS user_id,
+      trim(coalesce(u.first_name, '') || ' ' || coalesce(u.last_name, '')) AS name,
+      u.email,
+      t.teacher_id AS employee_code,
+      sub.name->0->>'subject' AS subject_name,
+      NULL::varchar AS staff_type,
+      t.designation,
+      t.exit_date::text AS exit_date
+    FROM teacher t
+    JOIN "user" u ON u.id = t.user_id
+    LEFT JOIN subject sub ON sub.id = t.subject_id
+    WHERE t.is_af_teacher = true
+    UNION ALL
+    SELECT
+      'staff', s.id, u.id,
+      trim(coalesce(u.first_name, '') || ' ' || coalesce(u.last_name, '')),
+      u.email, s.employee_code, NULL, s.staff_type, s.designation,
+      s.exit_date::text
+    FROM staff s
+    JOIN "user" u ON u.id = s.user_id
+    UNION ALL
+    SELECT
+      CASE WHEN up.role = 'teacher' THEN 'pending_teacher' ELSE 'pending_pm' END,
+      up.id, up.user_id, coalesce(up.full_name, ''), lower(up.email),
+      NULL, NULL,
+      CASE WHEN up.role = 'program_manager' THEN 'program_manager' ELSE NULL END,
+      NULL, NULL
+    FROM user_permission up
+    WHERE up.role IN ('teacher', 'program_manager')
+      AND up.revoked_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM teacher t WHERE t.user_id = up.user_id AND t.is_af_teacher = true
+      )
+      AND NOT EXISTS (SELECT 1 FROM staff s WHERE s.user_id = up.user_id)
+  )
+`;
+
+export async function getStaffRoster(params: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}): Promise<StaffRosterResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) {
+    return schema;
+  }
+
+  const filters = normalizeStaffRosterParams(params.searchParams);
+
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+  if (filters.search) {
+    values.push(`%${filters.search}%`);
+    conditions.push(
+      `(roster.name ILIKE $${values.length} OR roster.email ILIKE $${values.length} OR roster.employee_code ILIKE $${values.length})`
+    );
+  }
+  if (filters.kind !== "all") {
+    values.push(filters.kind);
+    conditions.push(`roster.kind = $${values.length}`);
+  }
+  if (filters.code === "missing") {
+    conditions.push(`roster.employee_code IS NULL`);
+  } else if (filters.code === "present") {
+    conditions.push(`roster.employee_code IS NOT NULL`);
+  }
+  if (filters.exited === "exclude") {
+    conditions.push(`roster.exit_date IS NULL`);
+  }
+  if (filters.centreId !== null) {
+    values.push(filters.centreId);
+    conditions.push(
+      `EXISTS (
+         SELECT 1 FROM centre_positions cp
+         WHERE cp.user_id = roster.user_id
+           AND cp.centre_id = $${values.length}
+           AND cp.deleted_at IS NULL
+       )`
+    );
+  }
+  const whereSql =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const rows = await query<RosterQueryRow>(
+    `${ROSTER_CTE}
+     SELECT * FROM roster
+     ${whereSql}
+     ORDER BY (roster.name = '') ASC, roster.name ASC, roster.record_id ASC`,
+    values
+  );
+
+  const summaryRows = await query<{
+    total: string;
+    teachers: string;
+    staff: string;
+    pending: string;
+    missing_code: string;
+    exited: string;
+  }>(
+    `${ROSTER_CTE}
+     SELECT
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE kind = 'teacher') AS teachers,
+       COUNT(*) FILTER (WHERE kind = 'staff') AS staff,
+       COUNT(*) FILTER (WHERE kind IN ('pending_teacher', 'pending_pm')) AS pending,
+       COUNT(*) FILTER (WHERE employee_code IS NULL AND exit_date IS NULL) AS missing_code,
+       COUNT(*) FILTER (WHERE exit_date IS NOT NULL) AS exited
+     FROM roster`
+  );
+
+  const vacantRows = await query<{ vacant: string }>(
+    `SELECT COUNT(*) AS vacant
+     FROM centre_positions
+     WHERE deleted_at IS NULL AND user_id IS NULL`
+  );
+
+  const userIds = [
+    ...new Set(
+      rows
+        .map((r) => (r.user_id === null ? null : Number(r.user_id)))
+        .filter((id): id is number => id !== null)
+    ),
+  ];
+  const seatRows =
+    userIds.length > 0
+      ? await query<{
+          id: number;
+          centre_id: number;
+          centre_name: string;
+          role: SeatRole;
+          user_id: number;
+        }>(
+          `SELECT cp.id, cp.centre_id, c.name AS centre_name, cp.role, cp.user_id
+           FROM centre_positions cp
+           JOIN centres c ON c.id = cp.centre_id
+           WHERE cp.deleted_at IS NULL AND cp.user_id = ANY($1)
+           ORDER BY c.name ASC, cp.role ASC`,
+          [userIds]
+        )
+      : [];
+
+  const seatsByUserId = new Map<number, RosterSeat[]>();
+  for (const seat of seatRows) {
+    const userId = Number(seat.user_id);
+    const list = seatsByUserId.get(userId) ?? [];
+    list.push({
+      id: Number(seat.id),
+      centreId: Number(seat.centre_id),
+      centreName: seat.centre_name,
+      role: seat.role,
+    });
+    seatsByUserId.set(userId, list);
+  }
+
+  const summary = summaryRows[0];
+  return {
+    ok: true,
+    filters,
+    rows: rows.map((row) => ({
+      kind: row.kind,
+      recordId: Number(row.record_id),
+      userId: row.user_id === null ? null : Number(row.user_id),
+      name: row.name,
+      email: row.email,
+      employeeCode: row.employee_code,
+      subjectName: row.subject_name,
+      staffType: row.staff_type,
+      designation: row.designation,
+      exitDate: row.exit_date,
+      seats:
+        row.user_id === null
+          ? []
+          : (seatsByUserId.get(Number(row.user_id)) ?? []),
+    })),
+    summary: {
+      total: Number(summary?.total ?? 0),
+      teachers: Number(summary?.teachers ?? 0),
+      staff: Number(summary?.staff ?? 0),
+      pending: Number(summary?.pending ?? 0),
+      missingCode: Number(summary?.missing_code ?? 0),
+      exited: Number(summary?.exited ?? 0),
+      vacantSeats: Number(vacantRows[0]?.vacant ?? 0),
+    },
+  };
+}
+
+// --- Teacher updates (proxied to db-service: core entity) ---
+
+export interface TeacherUpdateBody {
+  teacher_id?: unknown;
+  designation?: unknown;
+  exit_date?: unknown;
+}
+
+export type TeacherUpdateResult =
+  | { ok: true }
+  | StaffSchemaUnavailable
+  | StaffValidationFailure;
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export function validateTeacherUpdateBody(body: TeacherUpdateBody): {
+  payload: Record<string, string>;
+  fields: Record<string, string>;
+} {
+  const payload: Record<string, string> = {};
+  const fields: Record<string, string> = {};
+
+  if (body.teacher_id !== undefined) {
+    const code = normalizeEmployeeCode(body.teacher_id);
+    if (!code) {
+      fields.teacher_id = "Employee code must look like AF123";
+    } else {
+      payload.teacher_id = code;
+    }
+  }
+  if (body.designation !== undefined) {
+    if (typeof body.designation !== "string" || !body.designation.trim()) {
+      fields.designation = "Designation must be a non-empty string";
+    } else {
+      payload.designation = body.designation.trim();
+    }
+  }
+  if (body.exit_date !== undefined) {
+    if (!isIsoDate(body.exit_date)) {
+      fields.exit_date = "Exit date must be YYYY-MM-DD";
+    } else {
+      payload.exit_date = body.exit_date;
+    }
+  }
+
+  return { payload, fields };
+}
+
+async function dbServiceTeacherPatch(
+  teacherDbId: number,
+  payload: Record<string, string>
+): Promise<{ ok: true } | StaffValidationFailure> {
+  const baseUrl = process.env.DB_SERVICE_URL?.trim();
+  const token = process.env.DB_SERVICE_TOKEN?.trim();
+  if (!baseUrl || !token) {
+    return {
+      ok: false,
+      status: 502,
+      error: "DB service is not configured (DB_SERVICE_URL / DB_SERVICE_TOKEN)",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/teacher/${teacherDbId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    return { ok: false, status: 502, error: "DB service is unreachable" };
+  }
+
+  if (response.ok) {
+    return { ok: true };
+  }
+
+  const detail = await response.text();
+  if (response.status === 404) {
+    return { ok: false, status: 404, error: "Teacher not found" };
+  }
+  return {
+    ok: false,
+    status: 422,
+    error: `DB service rejected the teacher update: ${detail.slice(0, 300)}`,
+  };
+}
+
+export async function updateTeacherRecord(params: {
+  id: number;
+  body: TeacherUpdateBody;
+}): Promise<TeacherUpdateResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const { payload, fields } = validateTeacherUpdateBody(params.body);
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+  if (Object.keys(payload).length === 0) {
+    return { ok: false, status: 422, error: "Nothing to update" };
+  }
+
+  const existing = await query<{ id: number; user_id: number | null }>(
+    `SELECT id, user_id FROM teacher WHERE id = $1 AND is_af_teacher = true`,
+    [params.id]
+  );
+  if (existing.length === 0) {
+    return { ok: false, status: 404, error: "Teacher not found" };
+  }
+
+  if (payload.teacher_id) {
+    const clash = await query<{ id: number }>(
+      `SELECT id FROM teacher WHERE teacher_id = $1 AND id <> $2`,
+      [payload.teacher_id, params.id]
+    );
+    if (clash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: `Employee code ${payload.teacher_id} is already used by another teacher`,
+      };
+    }
+  }
+
+  const patched = await dbServiceTeacherPatch(params.id, payload);
+  if (!patched.ok) return patched;
+
+  // Exits also vacate seats + revoke LMS access (LMS-owned tables).
+  if (payload.exit_date && existing[0].user_id !== null) {
+    await withTransaction(async (client) => {
+      await vacateSeatsAndRevoke(client, Number(existing[0].user_id));
+    });
+  }
+
+  return { ok: true };
+}
+
+async function vacateSeatsAndRevoke(
+  client: PoolClient,
+  userId: number
+): Promise<void> {
+  await client.query(
+    `UPDATE centre_positions SET user_id = NULL, updated_at = now()
+     WHERE user_id = $1 AND deleted_at IS NULL`,
+    [userId]
+  );
+  await client.query(
+    `UPDATE user_permission SET revoked_at = now(), updated_at = now()
+     WHERE user_id = $1 AND revoked_at IS NULL`,
+    [userId]
+  );
+}
+
+// --- Staff (non-teaching) members: LMS-direct ---
+
+export interface CreateStaffMemberBody {
+  user_permission_id?: unknown;
+  employee_code?: unknown;
+  designation?: unknown;
+}
+
+export type StaffMutationResult =
+  | { ok: true }
+  | StaffSchemaUnavailable
+  | StaffValidationFailure;
+
+export async function createStaffMember(params: {
+  body: CreateStaffMemberBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const permissionId = Number(params.body.user_permission_id);
+  if (!Number.isInteger(permissionId) || permissionId <= 0) {
+    fields.user_permission_id = "user_permission_id is required";
+  }
+  const code = normalizeEmployeeCode(params.body.employee_code);
+  if (!code) {
+    fields.employee_code = "Employee code must look like AF123";
+  }
+  let designation: string | null = null;
+  if (params.body.designation !== undefined && params.body.designation !== null) {
+    if (typeof params.body.designation !== "string") {
+      fields.designation = "Designation must be a string";
+    } else {
+      designation = params.body.designation.trim() || null;
+    }
+  }
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+
+  const permissions = await query<{
+    id: number;
+    email: string;
+    full_name: string | null;
+    role: string;
+    user_id: number | null;
+  }>(
+    `SELECT id, lower(email) AS email, full_name, role, user_id
+     FROM user_permission WHERE id = $1`,
+    [permissionId]
+  );
+  if (permissions.length === 0 || permissions[0].role !== "program_manager") {
+    return {
+      ok: false,
+      status: 404,
+      error: "Program manager permission row not found",
+    };
+  }
+  const permission = permissions[0];
+
+  const codeClash = await query<{ id: number }>(
+    `SELECT id FROM staff WHERE employee_code = $1`,
+    [code]
+  );
+  if (codeClash.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Employee code ${code} is already used by another staff member`,
+    };
+  }
+  if (permission.user_id !== null) {
+    const staffClash = await query<{ id: number }>(
+      `SELECT id FROM staff WHERE user_id = $1`,
+      [permission.user_id]
+    );
+    if (staffClash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: "This person already has a staff record",
+      };
+    }
+  }
+
+  await withTransaction(async (client) => {
+    let userId = permission.user_id === null ? null : Number(permission.user_id);
+    if (userId === null) {
+      const name = (permission.full_name ?? "").trim();
+      const tokens = name.split(/\s+/).filter(Boolean);
+      const inserted = await client.query(
+        `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at)
+         VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+        [
+          tokens[0] ?? null,
+          tokens.length > 1 ? tokens.slice(1).join(" ") : null,
+          permission.email,
+        ]
+      );
+      userId = Number(inserted.rows[0].id);
+      await client.query(
+        `UPDATE user_permission SET user_id = $1, updated_at = now() WHERE id = $2`,
+        [userId, permission.id]
+      );
+    }
+    await client.query(
+      `INSERT INTO staff (user_id, employee_code, staff_type, designation, inserted_at, updated_at)
+       VALUES ($1, $2, 'program_manager', $3, now(), now())`,
+      [userId, code, designation]
+    );
+  });
+
+  return { ok: true };
+}
+
+export interface UpdateStaffMemberBody {
+  employee_code?: unknown;
+  designation?: unknown;
+  exit_date?: unknown;
+}
+
+export async function updateStaffMember(params: {
+  id: number;
+  body: UpdateStaffMemberBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (params.body.employee_code !== undefined) {
+    const code = normalizeEmployeeCode(params.body.employee_code);
+    if (!code) {
+      fields.employee_code = "Employee code must look like AF123";
+    } else {
+      values.push(code);
+      updates.push(`employee_code = $${values.length}`);
+    }
+  }
+  if (params.body.designation !== undefined) {
+    if (typeof params.body.designation !== "string") {
+      fields.designation = "Designation must be a string";
+    } else {
+      values.push(params.body.designation.trim() || null);
+      updates.push(`designation = $${values.length}`);
+    }
+  }
+  if (params.body.exit_date !== undefined) {
+    if (!isIsoDate(params.body.exit_date)) {
+      fields.exit_date = "Exit date must be YYYY-MM-DD";
+    } else {
+      values.push(params.body.exit_date);
+      updates.push(`exit_date = $${values.length}`);
+    }
+  }
+
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+  if (updates.length === 0) {
+    return { ok: false, status: 422, error: "Nothing to update" };
+  }
+
+  const existing = await query<{ id: number; user_id: number }>(
+    `SELECT id, user_id FROM staff WHERE id = $1`,
+    [params.id]
+  );
+  if (existing.length === 0) {
+    return { ok: false, status: 404, error: "Staff member not found" };
+  }
+
+  if (params.body.employee_code !== undefined) {
+    const code = normalizeEmployeeCode(params.body.employee_code);
+    const clash = await query<{ id: number }>(
+      `SELECT id FROM staff WHERE employee_code = $1 AND id <> $2`,
+      [code, params.id]
+    );
+    if (clash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: `Employee code ${code} is already used by another staff member`,
+      };
+    }
+  }
+
+  await withTransaction(async (client) => {
+    values.push(params.id);
+    await client.query(
+      `UPDATE staff SET ${updates.join(", ")}, updated_at = now() WHERE id = $${values.length}`,
+      values
+    );
+    if (
+      params.body.exit_date !== undefined &&
+      isIsoDate(params.body.exit_date)
+    ) {
+      await vacateSeatsAndRevoke(client, Number(existing[0].user_id));
+    }
+  });
+
+  return { ok: true };
+}
+
+// --- Centre positions (seats): LMS-direct ---
+
+export interface CreatePositionBody {
+  centre_id?: unknown;
+  role?: unknown;
+  user_id?: unknown;
+}
+
+export async function createPosition(params: {
+  body: CreatePositionBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const centreId = Number(params.body.centre_id);
+  if (!Number.isInteger(centreId) || centreId <= 0) {
+    fields.centre_id = "centre_id is required";
+  }
+  if (!isSeatRole(params.body.role)) {
+    fields.role = `Role must be one of: ${SEAT_ROLES.join(", ")}`;
+  }
+  let userId: number | null = null;
+  if (params.body.user_id !== undefined && params.body.user_id !== null) {
+    userId = Number(params.body.user_id);
+    if (!Number.isInteger(userId) || userId <= 0) {
+      fields.user_id = "user_id must be a positive integer";
+    }
+  }
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+  const role = params.body.role as SeatRole;
+
+  const centres = await query<{ id: number }>(
+    `SELECT id FROM centres WHERE id = $1`,
+    [centreId]
+  );
+  if (centres.length === 0) {
+    return { ok: false, status: 404, error: "Centre not found" };
+  }
+
+  if (userId !== null) {
+    const users = await query<{ id: number }>(
+      `SELECT id FROM "user" WHERE id = $1`,
+      [userId]
+    );
+    if (users.length === 0) {
+      return { ok: false, status: 404, error: "User not found" };
+    }
+    const duplicate = await query<{ id: number }>(
+      `SELECT id FROM centre_positions
+       WHERE centre_id = $1 AND role = $2 AND user_id = $3 AND deleted_at IS NULL`,
+      [centreId, role, userId]
+    );
+    if (duplicate.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: "This person already holds this seat",
+      };
+    }
+  }
+
+  await query(
+    `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+     VALUES ($1, $2, $3, now(), now())`,
+    [centreId, role, userId]
+  );
+
+  return { ok: true };
+}
+
+export interface UpdatePositionBody {
+  user_id?: unknown;
+}
+
+export async function updatePosition(params: {
+  id: number;
+  body: UpdatePositionBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  if (!("user_id" in params.body)) {
+    return {
+      ok: false,
+      status: 422,
+      error: "Provide user_id (a user to fill the seat, or null to vacate)",
+    };
+  }
+
+  const positions = await query<{
+    id: number;
+    centre_id: number;
+    role: SeatRole;
+  }>(
+    `SELECT id, centre_id, role FROM centre_positions
+     WHERE id = $1 AND deleted_at IS NULL`,
+    [params.id]
+  );
+  if (positions.length === 0) {
+    return { ok: false, status: 404, error: "Position not found" };
+  }
+  const position = positions[0];
+
+  let userId: number | null = null;
+  if (params.body.user_id !== null) {
+    userId = Number(params.body.user_id);
+    if (!Number.isInteger(userId) || userId <= 0) {
+      return {
+        ok: false,
+        status: 422,
+        error: "Validation failed",
+        fields: { user_id: "user_id must be a positive integer or null" },
+      };
+    }
+    const users = await query<{ id: number }>(
+      `SELECT id FROM "user" WHERE id = $1`,
+      [userId]
+    );
+    if (users.length === 0) {
+      return { ok: false, status: 404, error: "User not found" };
+    }
+    const duplicate = await query<{ id: number }>(
+      `SELECT id FROM centre_positions
+       WHERE centre_id = $1 AND role = $2 AND user_id = $3
+         AND deleted_at IS NULL AND id <> $4`,
+      [position.centre_id, position.role, userId, params.id]
+    );
+    if (duplicate.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: "This person already holds this seat",
+      };
+    }
+  }
+
+  await query(
+    `UPDATE centre_positions SET user_id = $1, updated_at = now() WHERE id = $2`,
+    [userId, params.id]
+  );
+
+  return { ok: true };
+}
+
+export async function deletePosition(params: {
+  id: number;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const positions = await query<{ id: number }>(
+    `SELECT id FROM centre_positions WHERE id = $1 AND deleted_at IS NULL`,
+    [params.id]
+  );
+  if (positions.length === 0) {
+    return { ok: false, status: 404, error: "Position not found" };
+  }
+
+  await query(
+    `UPDATE centre_positions SET deleted_at = now(), updated_at = now() WHERE id = $1`,
+    [params.id]
+  );
+
+  return { ok: true };
+}

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -567,6 +567,27 @@ async function vacateSeatsAndRevoke(
   );
 }
 
+// Strict per-user exclusivity: when a person is assigned a centre seat their
+// school scope becomes purely seat-derived, so clear any explicit
+// school_codes/regions on their user_permission row. This is what makes
+// centre_positions the source of truth and prevents the move-doesn't-revoke
+// staleness bug — a seated person's home schools must live in exactly one place
+// (the seats). A seated person must therefore have ALL their schools
+// represented as seats; ops backfills any seat gaps (the one-time migration
+// script reports them). The NOT NULL guard keeps this a no-op when nothing is
+// set, so re-saving an already-seated person doesn't churn the row.
+async function clearExplicitSchoolScope(
+  client: PoolClient,
+  userId: number
+): Promise<void> {
+  await client.query(
+    `UPDATE user_permission
+     SET school_codes = NULL, regions = NULL, updated_at = now()
+     WHERE user_id = $1 AND (school_codes IS NOT NULL OR regions IS NOT NULL)`,
+    [userId]
+  );
+}
+
 // --- Staff (non-teaching) members: LMS-direct ---
 
 export interface CreateStaffMemberBody {
@@ -836,11 +857,16 @@ export async function createPosition(params: {
     }
   }
 
-  await query(
-    `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
-     VALUES ($1, $2, $3, now(), now())`,
-    [centreId, role, userId]
-  );
+  await withTransaction(async (client) => {
+    await client.query(
+      `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+       VALUES ($1, $2, $3, now(), now())`,
+      [centreId, role, userId]
+    );
+    if (userId !== null) {
+      await clearExplicitSchoolScope(client, userId);
+    }
+  });
 
   return { ok: true };
 }
@@ -911,10 +937,15 @@ export async function updatePosition(params: {
     }
   }
 
-  await query(
-    `UPDATE centre_positions SET user_id = $1, updated_at = now() WHERE id = $2`,
-    [userId, params.id]
-  );
+  await withTransaction(async (client) => {
+    await client.query(
+      `UPDATE centre_positions SET user_id = $1, updated_at = now() WHERE id = $2`,
+      [userId, params.id]
+    );
+    if (userId !== null) {
+      await clearExplicitSchoolScope(client, userId);
+    }
+  });
 
   return { ok: true };
 }

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -15,41 +15,22 @@
 
 import type { PoolClient } from "pg";
 import { query, withTransaction } from "./db";
-import { getUserPermission } from "./permissions";
+import {
+  type AdminGuardResult,
+  type AdminSession,
+  makeSchemaChecker,
+  requireAdmin,
+} from "./admin-guard";
 
-// --- Sessions / guard (same shape as requireCentreAdmin) ---
+// --- Sessions / guard (shared with the Centre management surface) ---
 
-export type StaffAdminSession = {
-  user?: { email?: string | null } | null;
-  isPasscodeUser?: boolean;
-} | null;
-
-export type StaffAdminResult =
-  | {
-      ok: true;
-      email: string;
-      permission: NonNullable<Awaited<ReturnType<typeof getUserPermission>>>;
-    }
-  | { ok: false; status: 401 | 403; error: string };
+export type StaffAdminSession = AdminSession;
+export type StaffAdminResult = AdminGuardResult;
 
 export async function requireStaffAdmin(
   session: StaffAdminSession
 ): Promise<StaffAdminResult> {
-  const email = session?.user?.email;
-  if (!email) {
-    return { ok: false, status: 401, error: "Unauthorized" };
-  }
-
-  if (session.isPasscodeUser) {
-    return { ok: false, status: 403, error: "Forbidden" };
-  }
-
-  const permission = await getUserPermission(email);
-  if (permission?.role !== "admin") {
-    return { ok: false, status: 403, error: "Forbidden" };
-  }
-
-  return { ok: true, email, permission };
+  return requireAdmin(session);
 }
 
 // --- Schema readiness ---
@@ -90,8 +71,6 @@ export const STAFF_REQUIRED_COLUMNS: Array<{ table: string; column: string }> = 
   { table: "centres", column: "name" },
 ];
 
-let cachedStaffSchemaStatus: Promise<StaffSchemaStatus> | null = null;
-
 async function loadStaffSchemaStatus(): Promise<StaffSchemaStatus> {
   const rows = await query<{ table_name: string; column_name: string }>(
     `SELECT table_name, column_name
@@ -119,24 +98,14 @@ async function loadStaffSchemaStatus(): Promise<StaffSchemaStatus> {
   return { ok: true };
 }
 
-export async function checkStaffManagementSchema(): Promise<StaffSchemaStatus> {
-  cachedStaffSchemaStatus ??= loadStaffSchemaStatus().then(
-    (status) => {
-      if (!status.ok) {
-        cachedStaffSchemaStatus = null;
-      }
-      return status;
-    },
-    (error) => {
-      cachedStaffSchemaStatus = null;
-      throw error;
-    }
-  );
-  return cachedStaffSchemaStatus;
+const staffSchemaChecker = makeSchemaChecker(loadStaffSchemaStatus);
+
+export function checkStaffManagementSchema(): Promise<StaffSchemaStatus> {
+  return staffSchemaChecker.check();
 }
 
 export function resetStaffSchemaCheckForTests() {
-  cachedStaffSchemaStatus = null;
+  staffSchemaChecker.reset();
 }
 
 // --- Shared shapes (client-safe values/types live in staff-shared) ---
@@ -160,16 +129,22 @@ export interface StaffValidationFailure {
   status: 404 | 409 | 422 | 502;
   error: string;
   fields?: Record<string, string>;
+  // Machine-readable discriminator for failures the client handles specially
+  // (e.g. "last_seat" → offer a force-confirm). Absent for ordinary failures.
+  code?: string;
 }
 
 export function safeStaffApiError(result: {
   status: number;
   error: string;
   fields?: Record<string, string>;
-}): { error: string; fields?: Record<string, string> } {
-  return result.fields
-    ? { error: result.error, fields: result.fields }
-    : { error: result.error };
+  code?: string;
+}): { error: string; fields?: Record<string, string>; code?: string } {
+  return {
+    error: result.error,
+    ...(result.fields ? { fields: result.fields } : {}),
+    ...(result.code ? { code: result.code } : {}),
+  };
 }
 
 // --- Roster ---
@@ -588,6 +563,54 @@ async function clearExplicitSchoolScope(
   );
 }
 
+// Strict region/seat exclusivity (#1): a region-level (level-2) user's scope is
+// their regions, which seat assignment would wipe with no way to reconstitute.
+// Reject seating such a user up front rather than silently collapsing their
+// access to a single school. Returns a failure to surface, or null if allowed.
+async function rejectIfRegionLevelUser(
+  userId: number
+): Promise<StaffValidationFailure | null> {
+  const rows = await query<{ level: number }>(
+    `SELECT level FROM user_permission WHERE user_id = $1 AND revoked_at IS NULL`,
+    [userId]
+  );
+  if (rows.some((r) => r.level === 2)) {
+    return {
+      ok: false,
+      status: 422,
+      error:
+        "Region-level users can't hold centre seats — their access is scoped by region, not by seat.",
+      fields: { user_id: "This user has region-level access" },
+    };
+  }
+  return null;
+}
+
+// Whether `userId`'s only remaining active seat is `excludePositionId` — i.e.
+// removing/vacating that seat would leave them with no seat-derived scope.
+// Strict exclusivity already cleared their explicit school_codes, so this is a
+// total access loss (#2): callers block it unless `force` is set.
+async function isLastActiveSeat(
+  userId: number,
+  excludePositionId: number
+): Promise<boolean> {
+  const others = await query<{ id: number }>(
+    `SELECT id FROM centre_positions
+     WHERE user_id = $1 AND deleted_at IS NULL AND id <> $2
+     LIMIT 1`,
+    [userId, excludePositionId]
+  );
+  return others.length === 0;
+}
+
+const LAST_SEAT_BLOCK: StaffValidationFailure = {
+  ok: false,
+  status: 409,
+  error:
+    "This is the person's only centre seat — removing it leaves them with no access. Re-assign them to another seat first, or confirm to remove anyway.",
+  code: "last_seat",
+};
+
 // --- Staff (non-teaching) members: LMS-direct ---
 
 export interface CreateStaffMemberBody {
@@ -659,10 +682,25 @@ export async function createStaffMember(params: {
       error: `Employee code ${code} is already used by another staff member`,
     };
   }
-  if (permission.user_id !== null) {
+  // Resolve the effective user identity. If user_permission.user_id is unset, a
+  // "user" row may still exist for this email (e.g. a prior backfill linked by
+  // email but never wrote user_permission.user_id). Reuse it rather than
+  // minting a duplicate identity that would orphan their teacher/seat links
+  // (#3). null here means "no user exists yet — create one in the transaction".
+  let existingUserId: number | null =
+    permission.user_id === null ? null : Number(permission.user_id);
+  if (existingUserId === null) {
+    const found = await query<{ id: number | string }>(
+      `SELECT id FROM "user" WHERE LOWER(email) = $1 ORDER BY id LIMIT 1`,
+      [permission.email]
+    );
+    if (found.length > 0) existingUserId = Number(found[0].id);
+  }
+
+  if (existingUserId !== null) {
     const staffClash = await query<{ id: number }>(
       `SELECT id FROM staff WHERE user_id = $1`,
-      [permission.user_id]
+      [existingUserId]
     );
     if (staffClash.length > 0) {
       return {
@@ -674,7 +712,7 @@ export async function createStaffMember(params: {
   }
 
   await withTransaction(async (client) => {
-    let userId = permission.user_id === null ? null : Number(permission.user_id);
+    let userId = existingUserId;
     if (userId === null) {
       const name = (permission.full_name ?? "").trim();
       const tokens = name.split(/\s+/).filter(Boolean);
@@ -688,6 +726,8 @@ export async function createStaffMember(params: {
         ]
       );
       userId = Number(inserted.rows[0].id);
+    }
+    if (userId !== permission.user_id) {
       await client.query(
         `UPDATE user_permission SET user_id = $1, updated_at = now() WHERE id = $2`,
         [userId, permission.id]
@@ -843,6 +883,8 @@ export async function createPosition(params: {
     if (users.length === 0) {
       return { ok: false, status: 404, error: "User not found" };
     }
+    const regionBlock = await rejectIfRegionLevelUser(userId);
+    if (regionBlock) return regionBlock;
     const duplicate = await query<{ id: number }>(
       `SELECT id FROM centre_positions
        WHERE centre_id = $1 AND role = $2 AND user_id = $3 AND deleted_at IS NULL`,
@@ -878,6 +920,7 @@ export interface UpdatePositionBody {
 export async function updatePosition(params: {
   id: number;
   body: UpdatePositionBody;
+  force?: boolean;
 }): Promise<StaffMutationResult> {
   const schema = await checkStaffManagementSchema();
   if (!schema.ok) return schema;
@@ -894,8 +937,9 @@ export async function updatePosition(params: {
     id: number;
     centre_id: number;
     role: SeatRole;
+    user_id: number | null;
   }>(
-    `SELECT id, centre_id, role FROM centre_positions
+    `SELECT id, centre_id, role, user_id FROM centre_positions
      WHERE id = $1 AND deleted_at IS NULL`,
     [params.id]
   );
@@ -922,6 +966,8 @@ export async function updatePosition(params: {
     if (users.length === 0) {
       return { ok: false, status: 404, error: "User not found" };
     }
+    const regionBlock = await rejectIfRegionLevelUser(userId);
+    if (regionBlock) return regionBlock;
     const duplicate = await query<{ id: number }>(
       `SELECT id FROM centre_positions
        WHERE centre_id = $1 AND role = $2 AND user_id = $3
@@ -935,6 +981,17 @@ export async function updatePosition(params: {
         error: "This person already holds this seat",
       };
     }
+  }
+
+  // Vacating the seat: refuse if it's the occupant's only seat (would strand
+  // them with no scope), unless the caller explicitly forces it (#2).
+  if (
+    userId === null &&
+    position.user_id !== null &&
+    !params.force &&
+    (await isLastActiveSeat(position.user_id, params.id))
+  ) {
+    return LAST_SEAT_BLOCK;
   }
 
   await withTransaction(async (client) => {
@@ -952,16 +1009,28 @@ export async function updatePosition(params: {
 
 export async function deletePosition(params: {
   id: number;
+  force?: boolean;
 }): Promise<StaffMutationResult> {
   const schema = await checkStaffManagementSchema();
   if (!schema.ok) return schema;
 
-  const positions = await query<{ id: number }>(
-    `SELECT id FROM centre_positions WHERE id = $1 AND deleted_at IS NULL`,
+  const positions = await query<{ id: number; user_id: number | null }>(
+    `SELECT id, user_id FROM centre_positions WHERE id = $1 AND deleted_at IS NULL`,
     [params.id]
   );
   if (positions.length === 0) {
     return { ok: false, status: 404, error: "Position not found" };
+  }
+  const position = positions[0];
+
+  // Deleting an occupied seat that is the occupant's last one strands them
+  // (#2) — block unless forced. Empty seats delete freely.
+  if (
+    position.user_id !== null &&
+    !params.force &&
+    (await isLastActiveSeat(position.user_id, params.id))
+  ) {
+    return LAST_SEAT_BLOCK;
   }
 
   await query(

--- a/src/lib/staff-backfill.test.ts
+++ b/src/lib/staff-backfill.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeName,
+  splitFullName,
+  normalizeAfCode,
+  resolveAfCode,
+  hrSubjectToSeatRole,
+  hrSubjectToSubjectId,
+  mapSchoolCodesToCentres,
+  parseSheetTsv,
+  buildPersonPlan,
+  type SheetRow,
+  type HrEmployee,
+  type CentreRef,
+} from "./staff-backfill";
+
+function sheetRow(overrides: Partial<SheetRow> = {}): SheetRow {
+  return {
+    status: "AUTO_MATCHED",
+    email: "t@avantifellows.org",
+    role: "teacher",
+    lmsName: "Test Teacher",
+    proposedAfId: "AF100",
+    teamDecision: "",
+    correctAfId: "",
+    ...overrides,
+  };
+}
+
+describe("normalizeName", () => {
+  it("lowercases, strips punctuation and collapses whitespace", () => {
+    expect(normalizeName("  R. Nivetha ")).toBe("r nivetha");
+    expect(normalizeName("Sivaranjani.S")).toBe("sivaranjani s");
+    expect(normalizeName("Anand   Joshi")).toBe("anand joshi");
+  });
+});
+
+describe("splitFullName", () => {
+  it("splits first token from the rest", () => {
+    expect(splitFullName("Anjali B O")).toEqual({
+      firstName: "Anjali",
+      lastName: "B O",
+    });
+  });
+
+  it("handles single-token and empty names", () => {
+    expect(splitFullName("Aryaman")).toEqual({
+      firstName: "Aryaman",
+      lastName: null,
+    });
+    expect(splitFullName("  ")).toEqual({ firstName: "", lastName: null });
+  });
+});
+
+describe("normalizeAfCode", () => {
+  it("uppercases valid AF codes", () => {
+    expect(normalizeAfCode(" af123 ")).toBe("AF123");
+  });
+
+  it("rejects placeholder and malformed codes", () => {
+    expect(normalizeAfCode("MT005")).toBeNull();
+    expect(normalizeAfCode("TBH123")).toBeNull();
+    expect(normalizeAfCode("AF12X")).toBeNull();
+    expect(normalizeAfCode("")).toBeNull();
+  });
+});
+
+describe("resolveAfCode", () => {
+  it("includes people missing from the sheet with no code", () => {
+    expect(resolveAfCode(undefined)).toEqual({
+      include: true,
+      code: null,
+      source: "not_in_sheet",
+    });
+  });
+
+  it("excludes on a team exclude decision", () => {
+    const result = resolveAfCode(sheetRow({ teamDecision: "exclude" }));
+    expect(result.include).toBe(false);
+    expect(result.source).toBe("excluded_by_team");
+  });
+
+  it("prefers a filled correct_af_id over everything else", () => {
+    const result = resolveAfCode(
+      sheetRow({ teamDecision: "use correct_af_id", correctAfId: "af200" })
+    );
+    expect(result).toMatchObject({
+      include: true,
+      code: "AF200",
+      source: "team_correct_af_id",
+    });
+  });
+
+  it("warns when correct_af_id is not a valid code", () => {
+    const result = resolveAfCode(sheetRow({ correctAfId: "MT005" }));
+    expect(result.code).toBeNull();
+    expect(result.warning).toContain("MT005");
+  });
+
+  it("uses the proposed code on an OK decision, even for test accounts", () => {
+    const result = resolveAfCode(
+      sheetRow({ status: "TEST_ACCOUNT", teamDecision: "OK" })
+    );
+    expect(result).toMatchObject({
+      include: true,
+      code: "AF100",
+      source: "team_ok_proposed",
+    });
+  });
+
+  it("trusts AUTO_MATCHED without a decision", () => {
+    expect(resolveAfCode(sheetRow())).toMatchObject({
+      include: true,
+      code: "AF100",
+      source: "auto_matched",
+    });
+  });
+
+  it("rejects an AUTO_MATCHED placeholder code with a warning", () => {
+    const result = resolveAfCode(sheetRow({ proposedAfId: "MT005" }));
+    expect(result.include).toBe(true);
+    expect(result.code).toBeNull();
+    expect(result.warning).toContain("MT005");
+  });
+
+  it("skips undecided test accounts", () => {
+    const result = resolveAfCode(sheetRow({ status: "TEST_ACCOUNT" }));
+    expect(result.include).toBe(false);
+    expect(result.source).toBe("test_account");
+  });
+
+  it("includes CANDIDATE_VERIFY and NEEDS_AF_ID without a code", () => {
+    for (const status of ["CANDIDATE_VERIFY", "NEEDS_AF_ID"]) {
+      const result = resolveAfCode(sheetRow({ status }));
+      expect(result).toMatchObject({
+        include: true,
+        code: null,
+        source: "unconfirmed",
+      });
+    }
+  });
+});
+
+describe("hr subject mapping", () => {
+  it("maps HR subjects to seat roles", () => {
+    expect(hrSubjectToSeatRole("Mathematics")).toBe("maths");
+    expect(hrSubjectToSeatRole("Physics")).toBe("physics");
+    expect(hrSubjectToSeatRole("APC")).toBe("apc");
+    expect(hrSubjectToSeatRole("")).toBeNull();
+    expect(hrSubjectToSeatRole(null)).toBeNull();
+    expect(hrSubjectToSeatRole("Economics")).toBeNull();
+  });
+
+  it("maps HR subjects to db-service subject ids", () => {
+    expect(hrSubjectToSubjectId("Mathematics")).toBe(1);
+    expect(hrSubjectToSubjectId("Chemistry")).toBe(2);
+    expect(hrSubjectToSubjectId("Biology")).toBe(3);
+    expect(hrSubjectToSubjectId("Physics")).toBe(4);
+    expect(hrSubjectToSubjectId("APC")).toBeNull();
+  });
+});
+
+const COE: CentreRef = {
+  id: 8,
+  name: "JNV Adilabad - CoE",
+  typeCode: "coe",
+  schoolCode: "59525",
+};
+const NODAL: CentreRef = {
+  id: 11,
+  name: "JNV Adilabad - Nodal",
+  typeCode: "nodal",
+  schoolCode: "59525",
+};
+const SINGLE: CentreRef = {
+  id: 3,
+  name: "JNV Bengaluru",
+  typeCode: "coe",
+  schoolCode: "29139",
+};
+
+function centreMap(): Map<string, CentreRef[]> {
+  return new Map([
+    ["59525", [COE, NODAL]],
+    ["29139", [SINGLE]],
+  ]);
+}
+
+describe("mapSchoolCodesToCentres", () => {
+  it("maps a single-centre school directly", () => {
+    const result = mapSchoolCodesToCentres(["29139"], [], centreMap());
+    expect(result.centres).toEqual([SINGLE]);
+    expect(result.ambiguous).toEqual([]);
+  });
+
+  it("breaks multi-centre ties using program ids", () => {
+    expect(
+      mapSchoolCodesToCentres(["59525"], [1], centreMap()).centres
+    ).toEqual([COE]);
+    expect(
+      mapSchoolCodesToCentres(["59525"], [2], centreMap()).centres
+    ).toEqual([NODAL]);
+  });
+
+  it("reports ambiguity when programs cannot break the tie", () => {
+    const result = mapSchoolCodesToCentres(["59525"], [], centreMap());
+    expect(result.centres).toEqual([]);
+    expect(result.ambiguous).toEqual([[COE, NODAL]]);
+  });
+
+  it("dedupes centres across school codes and skips unknown schools", () => {
+    const result = mapSchoolCodesToCentres(
+      ["29139", "29139", "99999"],
+      [],
+      centreMap()
+    );
+    expect(result.centres).toEqual([SINGLE]);
+  });
+});
+
+describe("parseSheetTsv", () => {
+  const header =
+    "status\temail\trole\tlms_name\tlms_centre\tproposed_af_id\thr_name\thr_centre\tmatch_rule\tother_candidates\tteam_decision (OK / use correct_af_id / exclude)\tcorrect_af_id\tnotes";
+
+  it("parses rows keyed by header prefixes", () => {
+    const rows = parseSheetTsv(
+      `${header}\nAUTO_MATCHED\tA@avantifellows.org\tteacher\tA Person\t\tAF1\tA Person\t\texact name\t\tOK\t\tfine`
+    );
+    expect(rows).toEqual([
+      {
+        status: "AUTO_MATCHED",
+        email: "a@avantifellows.org",
+        role: "teacher",
+        lmsName: "A Person",
+        proposedAfId: "AF1",
+        teamDecision: "OK",
+        correctAfId: "",
+      },
+    ]);
+  });
+
+  it("throws when a required column is missing", () => {
+    expect(() => parseSheetTsv("status\temail\n")).toThrow(
+      /missing column/i
+    );
+  });
+});
+
+// --- buildPersonPlan ---
+
+interface TestTeacherRow {
+  id: number;
+  teacher_id: string | null;
+  user_id: number;
+  user_email: string | null;
+  user_name: string;
+}
+
+function context(overrides: {
+  teachers?: TestTeacherRow[];
+  userIdByEmail?: Array<[string, number]>;
+  staffUserIds?: number[];
+  staffCodes?: string[];
+  activeSeats?: string[];
+  centres?: Array<[string, CentreRef[]]>;
+}) {
+  const teachers = overrides.teachers ?? [];
+  const byName = new Map<string, TestTeacherRow[]>();
+  for (const t of teachers) {
+    const key = normalizeName(t.user_name);
+    byName.set(key, [...(byName.get(key) ?? []), t]);
+  }
+  return {
+    teacherByCode: new Map(
+      teachers.filter((t) => t.teacher_id).map((t) => [t.teacher_id!, t])
+    ),
+    afTeacherByName: byName,
+    teacherByUserId: new Map(teachers.map((t) => [t.user_id, t])),
+    userIdByEmail: new Map(overrides.userIdByEmail ?? []),
+    staffUserIds: new Set(overrides.staffUserIds ?? []),
+    staffCodes: new Set(overrides.staffCodes ?? []),
+    activeSeats: new Set(overrides.activeSeats ?? []),
+    centresBySchoolCode: new Map(overrides.centres ?? []),
+  };
+}
+
+function person(overrides: Partial<Parameters<typeof buildPersonPlan>[0]> = {}) {
+  return {
+    id: 1,
+    email: "t@avantifellows.org",
+    full_name: "Test Teacher",
+    role: "teacher" as const,
+    school_codes: ["29139"],
+    program_ids: [1],
+    user_id: null,
+    ...overrides,
+  };
+}
+
+const HR_PHYSICS: HrEmployee = {
+  employee_code: "AF100",
+  name: "Test Teacher",
+  subject: "Physics",
+  staff_type: "Teaching Staff",
+  designation: "Senior Teacher",
+  centre: "JNV Bengaluru",
+  is_vacant: 0,
+};
+
+describe("buildPersonPlan", () => {
+  it("creates user + coded teacher + subject seat for a clean auto-match", () => {
+    const plan = buildPersonPlan(
+      person(),
+      sheetRow(),
+      new Map([["AF100", HR_PHYSICS]]),
+      context({ centres: [["29139", [SINGLE]]] }),
+      new Map()
+    );
+    expect(plan).toMatchObject({
+      skipped: false,
+      code: "AF100",
+      userAction: "create",
+      teacherAction: "create",
+      subjectId: 4,
+      designation: "Senior Teacher",
+      seats: [{ centreId: 3, role: "physics" }],
+    });
+  });
+
+  it("links by AF code to an existing email-less teacher row", () => {
+    const plan = buildPersonPlan(
+      person(),
+      sheetRow(),
+      new Map(),
+      context({
+        teachers: [
+          {
+            id: 9,
+            teacher_id: "AF100",
+            user_id: 77,
+            user_email: null,
+            user_name: "Test Teacher",
+          },
+        ],
+        centres: [["29139", [SINGLE]]],
+      }),
+      new Map()
+    );
+    expect(plan).toMatchObject({
+      userAction: "link_by_af_code",
+      existingUserId: 77,
+      setEmailOnUser: true,
+      teacherAction: "update_existing",
+      existingTeacherId: 9,
+    });
+  });
+
+  it("defers when two emails claim the same AF code", () => {
+    const usedCodes = new Map([["AF100", "first@avantifellows.org"]]);
+    const plan = buildPersonPlan(
+      person(),
+      sheetRow(),
+      new Map(),
+      context({}),
+      usedCodes
+    );
+    expect(plan.skipped).toBe(true);
+    expect(plan.skipReason).toBe("needs_review_duplicate_code");
+  });
+
+  it("defers a code-less person whose name matches an AF-coded row", () => {
+    const plan = buildPersonPlan(
+      person({ full_name: "Kanhaiya" }),
+      sheetRow({ status: "NEEDS_AF_ID", proposedAfId: "" }),
+      new Map(),
+      context({
+        teachers: [
+          {
+            id: 7,
+            teacher_id: "AF448",
+            user_id: 43,
+            user_email: null,
+            user_name: "Kanhaiya",
+          },
+        ],
+      }),
+      new Map()
+    );
+    expect(plan.skipped).toBe(true);
+    expect(plan.skipReason).toBe("needs_review_name_collision");
+  });
+
+  it("links by name to a code-less existing AF teacher row", () => {
+    const plan = buildPersonPlan(
+      person({ full_name: "Not Permanent Person" }),
+      sheetRow({ status: "NEEDS_AF_ID", proposedAfId: "" }),
+      new Map(),
+      context({
+        teachers: [
+          {
+            id: 12,
+            teacher_id: null,
+            user_id: 55,
+            user_email: null,
+            user_name: "Not Permanent Person",
+          },
+        ],
+      }),
+      new Map()
+    );
+    expect(plan).toMatchObject({
+      skipped: false,
+      userAction: "link_by_name",
+      existingUserId: 55,
+      teacherAction: "update_existing",
+    });
+  });
+
+  it("creates a new row when a confirmed code differs from the name match", () => {
+    const plan = buildPersonPlan(
+      person({ full_name: "Kanhaiya" }),
+      sheetRow({ proposedAfId: "AF900" }),
+      new Map(),
+      context({
+        teachers: [
+          {
+            id: 7,
+            teacher_id: "AF448",
+            user_id: 43,
+            user_email: null,
+            user_name: "Kanhaiya",
+          },
+        ],
+      }),
+      new Map()
+    );
+    expect(plan.skipped).toBe(false);
+    expect(plan.userAction).toBe("create");
+    expect(plan.code).toBe("AF900");
+    expect(plan.warnings.join(" ")).toContain("AF448");
+  });
+
+  it("keeps an existing teacher code when the sheet disagrees", () => {
+    const plan = buildPersonPlan(
+      person({ user_id: 77 }),
+      sheetRow({ proposedAfId: "AF999" }),
+      new Map(),
+      context({
+        teachers: [
+          {
+            id: 9,
+            teacher_id: "AF100",
+            user_id: 77,
+            user_email: "t@avantifellows.org",
+            user_name: "Test Teacher",
+          },
+        ],
+      }),
+      new Map()
+    );
+    expect(plan.code).toBe("AF100");
+    expect(plan.warnings.join(" ")).toContain("AF999");
+  });
+
+  it("creates staff + pm seats per mapped centre for a coded PM", () => {
+    const plan = buildPersonPlan(
+      person({
+        role: "program_manager",
+        full_name: "Pm Person",
+        school_codes: ["29139", "59525"],
+        program_ids: [1],
+      }),
+      sheetRow({ role: "program_manager" }),
+      new Map(),
+      context({ centres: [["29139", [SINGLE]], ["59525", [COE, NODAL]]] }),
+      new Map()
+    );
+    expect(plan.staffAction).toBe("create");
+    expect(plan.seats).toEqual([
+      { centreId: 3, centreName: "JNV Bengaluru", role: "pm" },
+      { centreId: 8, centreName: "JNV Adilabad - CoE", role: "pm" },
+    ]);
+  });
+
+  it("marks a code-less PM as pending instead of creating staff", () => {
+    const plan = buildPersonPlan(
+      person({ role: "program_manager", full_name: "Pm Person" }),
+      sheetRow({ status: "NEEDS_AF_ID", proposedAfId: "" }),
+      new Map(),
+      context({}),
+      new Map()
+    );
+    expect(plan.skipped).toBe(false);
+    expect(plan.staffAction).toBe("pending_no_code");
+    expect(plan.seatGaps.length).toBeGreaterThan(0);
+  });
+
+  it("records a seat gap instead of a seat when the subject is unknown", () => {
+    const plan = buildPersonPlan(
+      person(),
+      sheetRow({ status: "CANDIDATE_VERIFY" }),
+      new Map(),
+      context({ centres: [["29139", [SINGLE]]] }),
+      new Map()
+    );
+    expect(plan.code).toBeNull();
+    expect(plan.seats).toEqual([]);
+    expect(plan.seatGaps.join(" ")).toContain("no confirmed AF code");
+  });
+
+  it("records ambiguity when programs cannot pick the Adilabad centre", () => {
+    const plan = buildPersonPlan(
+      person({ school_codes: ["59525"], program_ids: [] }),
+      sheetRow(),
+      new Map([["AF100", HR_PHYSICS]]),
+      context({ centres: [["59525", [COE, NODAL]]] }),
+      new Map()
+    );
+    expect(plan.seats).toEqual([]);
+    expect(plan.seatGaps.join(" ")).toContain("ambiguous");
+  });
+});

--- a/src/lib/staff-backfill.ts
+++ b/src/lib/staff-backfill.ts
@@ -29,6 +29,7 @@
 import * as fs from "fs";
 import type { PoolClient } from "pg";
 import { query, withTransaction } from "./db";
+import { normalizeEmployeeCode, type SeatRole } from "./staff-shared";
 
 export type BackfillMode = "dry-run" | "apply";
 
@@ -73,13 +74,7 @@ export interface CentreRef {
   schoolCode: string;
 }
 
-export type SeatRole =
-  | "physics"
-  | "chemistry"
-  | "maths"
-  | "biology"
-  | "apc"
-  | "pm";
+export type { SeatRole };
 
 export interface PlannedSeat {
   centreId: number;
@@ -160,12 +155,9 @@ export function splitFullName(fullName: string): {
   return { firstName: tokens[0], lastName: tokens.slice(1).join(" ") };
 }
 
-const AF_CODE_PATTERN = /^AF\d+$/i;
-
-export function normalizeAfCode(raw: string): string | null {
-  const code = raw.trim().toUpperCase();
-  return AF_CODE_PATTERN.test(code) ? code : null;
-}
+// Canonical AF-code normalization lives in staff-shared (used by the live admin
+// surface too); keep this name as the backfill's entry point so they can't drift.
+export const normalizeAfCode = normalizeEmployeeCode;
 
 export function resolveAfCode(row: SheetRow | undefined): CodeResolution {
   if (!row) {
@@ -744,7 +736,7 @@ export async function runStaffBackfill(
     try {
       await withTransaction(async (client) => {
         for (const plan of report.plans) {
-          if (!plan.skipped) await applyPlan(client, plan, people);
+          if (!plan.skipped) await applyPlan(client, plan, people, existing);
         }
       });
     } catch (error) {
@@ -796,7 +788,8 @@ function tallyPlan(
 async function applyPlan(
   client: PoolClient,
   plan: PersonPlan,
-  people: PermissionRow[]
+  people: PermissionRow[],
+  existing: ExistingContext
 ): Promise<void> {
   const person = people.find(
     (p) => p.email === plan.email && p.role === plan.role
@@ -854,19 +847,19 @@ async function applyPlan(
     [userId, person.id]
   );
 
-  // 4. Seats (skip ones that already exist for this user)
+  // 4. Seats (skip ones that already exist for this user). Reuse the
+  // pre-loaded activeSeats set instead of a per-seat SELECT (the same set
+  // tallyPlan counts against), and add freshly-inserted keys so a later plan
+  // for the same user can't double-insert within this transaction.
   for (const seat of plan.seats) {
-    const existsResult = await client.query(
-      `SELECT 1 FROM centre_positions
-       WHERE centre_id = $1 AND role = $2 AND user_id = $3 AND deleted_at IS NULL`,
-      [seat.centreId, seat.role, userId]
-    );
-    if (existsResult.rows.length === 0) {
+    const seatKey = `${seat.centreId}:${seat.role}:${userId}`;
+    if (!existing.activeSeats.has(seatKey)) {
       await client.query(
         `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
          VALUES ($1, $2, $3, now(), now())`,
         [seat.centreId, seat.role, userId]
       );
+      existing.activeSeats.add(seatKey);
     }
   }
 }

--- a/src/lib/staff-backfill.ts
+++ b/src/lib/staff-backfill.ts
@@ -1,0 +1,872 @@
+/**
+ * Teacher/PM backfill: turns `user_permission` rows (the freshest assignment
+ * source) into real `user` + `teacher` / `staff` rows and filled
+ * `centre_positions` seats.
+ *
+ * Inputs:
+ * - user_permission (role = teacher | program_manager, not revoked)
+ * - the AF-ID review sheet (TSV export) for employee codes
+ * - an HR employees dump (JSON) for subjects/designations
+ *
+ * Rules (agreed 2026-06-12):
+ * - Every teacher is backfilled; AF code where known, NULL otherwise
+ *   (admins fill missing codes in the Staff Management UI).
+ * - Dedupe against existing teacher rows by AF code first, exact
+ *   normalized name second (most existing AF-teacher user rows have no
+ *   email, so an email join cannot prove absence). On collision LINK the
+ *   existing row instead of creating a second identity for the same code.
+ * - `staff` (non-teaching) requires employee_code at the DB level, so PMs
+ *   without a confirmed code get a user row + user_permission link only,
+ *   and are reported as pending.
+ * - Sheet TEST_ACCOUNT rows are skipped unless the team overrides via
+ *   team_decision; they are listed in the report.
+ *
+ * Writes are direct SQL (not the db-service REST API): this is a one-time,
+ * idempotent migration script run with --apply after a reviewed dry-run.
+ * Interactive teacher creation in the UI should still go through db-service.
+ */
+
+import * as fs from "fs";
+import type { PoolClient } from "pg";
+import { query, withTransaction } from "./db";
+
+export type BackfillMode = "dry-run" | "apply";
+
+export interface SheetRow {
+  status: string;
+  email: string;
+  role: string;
+  lmsName: string;
+  proposedAfId: string;
+  teamDecision: string;
+  correctAfId: string;
+}
+
+export interface HrEmployee {
+  employee_code: string;
+  name: string;
+  subject: string | null;
+  staff_type: string | null;
+  designation: string | null;
+  centre: string | null;
+  is_vacant: number | boolean;
+}
+
+export interface CodeResolution {
+  include: boolean;
+  code: string | null;
+  source:
+    | "team_correct_af_id"
+    | "team_ok_proposed"
+    | "auto_matched"
+    | "unconfirmed"
+    | "not_in_sheet"
+    | "excluded_by_team"
+    | "test_account";
+  warning?: string;
+}
+
+export interface CentreRef {
+  id: number;
+  name: string;
+  typeCode: string | null;
+  schoolCode: string;
+}
+
+export type SeatRole =
+  | "physics"
+  | "chemistry"
+  | "maths"
+  | "biology"
+  | "apc"
+  | "pm";
+
+export interface PlannedSeat {
+  centreId: number;
+  centreName: string;
+  role: SeatRole;
+}
+
+export interface PersonPlan {
+  email: string;
+  role: "teacher" | "program_manager";
+  fullName: string;
+  code: string | null;
+  codeSource: CodeResolution["source"];
+  skipped: boolean;
+  skipReason?:
+    | "excluded_by_team"
+    | "test_account"
+    | "needs_review_duplicate_code"
+    | "needs_review_name_collision";
+  userAction:
+    | "already_linked"
+    | "link_by_af_code"
+    | "link_by_email"
+    | "link_by_name"
+    | "create";
+  existingUserId: number | null;
+  setEmailOnUser: boolean;
+  teacherAction: "create" | "update_existing" | "none";
+  existingTeacherId: number | null;
+  subjectId: number | null;
+  designation: string | null;
+  staffAction: "create" | "exists" | "pending_no_code" | "none";
+  seats: PlannedSeat[];
+  seatGaps: string[];
+  warnings: string[];
+}
+
+export interface BackfillReport {
+  mode: BackfillMode;
+  ok: boolean;
+  error?: string;
+  counts: {
+    sourceTeachers: number;
+    sourcePms: number;
+    skipped: number;
+    usersToCreate: number;
+    usersLinked: number;
+    teachersToCreate: number;
+    teachersLinkedExisting: number;
+    teachersWithCode: number;
+    teachersWithoutCode: number;
+    staffToCreate: number;
+    staffPendingNoCode: number;
+    seatsToCreate: number;
+    seatsExisting: number;
+  };
+  plans: PersonPlan[];
+  warnings: string[];
+}
+
+// --- Pure helpers (exported for tests) ---
+
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function splitFullName(fullName: string): {
+  firstName: string;
+  lastName: string | null;
+} {
+  const tokens = fullName.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return { firstName: "", lastName: null };
+  if (tokens.length === 1) return { firstName: tokens[0], lastName: null };
+  return { firstName: tokens[0], lastName: tokens.slice(1).join(" ") };
+}
+
+const AF_CODE_PATTERN = /^AF\d+$/i;
+
+export function normalizeAfCode(raw: string): string | null {
+  const code = raw.trim().toUpperCase();
+  return AF_CODE_PATTERN.test(code) ? code : null;
+}
+
+export function resolveAfCode(row: SheetRow | undefined): CodeResolution {
+  if (!row) {
+    return { include: true, code: null, source: "not_in_sheet" };
+  }
+
+  const decision = row.teamDecision.trim().toLowerCase();
+  const correct = row.correctAfId.trim();
+  const proposed = row.proposedAfId.trim();
+
+  if (decision.includes("exclude")) {
+    return { include: false, code: null, source: "excluded_by_team" };
+  }
+
+  if (correct) {
+    const code = normalizeAfCode(correct);
+    return {
+      include: true,
+      code,
+      source: "team_correct_af_id",
+      warning: code
+        ? undefined
+        : `correct_af_id "${correct}" is not a valid AF code; treating as missing`,
+    };
+  }
+
+  if (decision.startsWith("ok")) {
+    const code = normalizeAfCode(proposed);
+    return {
+      include: true,
+      code,
+      source: "team_ok_proposed",
+      warning: code
+        ? undefined
+        : `team said OK but proposed_af_id "${proposed}" is not a valid AF code`,
+    };
+  }
+
+  // No team decision yet: trust only AUTO_MATCHED; skip test accounts.
+  if (row.status === "TEST_ACCOUNT") {
+    return { include: false, code: null, source: "test_account" };
+  }
+  if (row.status === "AUTO_MATCHED") {
+    const code = normalizeAfCode(proposed);
+    return {
+      include: true,
+      code,
+      source: "auto_matched",
+      warning: code
+        ? undefined
+        : `AUTO_MATCHED but proposed_af_id "${proposed}" is not a valid AF code`,
+    };
+  }
+  return { include: true, code: null, source: "unconfirmed" };
+}
+
+const HR_SUBJECT_TO_SEAT_ROLE: Record<string, SeatRole> = {
+  mathematics: "maths",
+  maths: "maths",
+  physics: "physics",
+  chemistry: "chemistry",
+  biology: "biology",
+  apc: "apc",
+};
+
+// db-service `subject` table ids (en names): 1=Maths, 2=Chemistry, 3=Biology, 4=Physics
+const HR_SUBJECT_TO_SUBJECT_ID: Record<string, number> = {
+  mathematics: 1,
+  maths: 1,
+  chemistry: 2,
+  biology: 3,
+  physics: 4,
+};
+
+export function hrSubjectToSeatRole(subject: string | null): SeatRole | null {
+  if (!subject) return null;
+  return HR_SUBJECT_TO_SEAT_ROLE[subject.trim().toLowerCase()] ?? null;
+}
+
+export function hrSubjectToSubjectId(subject: string | null): number | null {
+  if (!subject) return null;
+  return HR_SUBJECT_TO_SUBJECT_ID[subject.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Map a person's school_codes to centres. When one school has multiple
+ * centres (only JNV Adilabad today), program_ids break the tie:
+ * program 1 = "JNV CoE" -> type_code coe, program 2 = "JNV Nodal" -> nodal.
+ */
+export function mapSchoolCodesToCentres(
+  schoolCodes: string[],
+  programIds: number[],
+  centresBySchoolCode: Map<string, CentreRef[]>
+): { centres: CentreRef[]; ambiguous: CentreRef[][] } {
+  const centres: CentreRef[] = [];
+  const ambiguous: CentreRef[][] = [];
+  const seen = new Set<number>();
+
+  for (const schoolCode of schoolCodes) {
+    const candidates = centresBySchoolCode.get(schoolCode) ?? [];
+    let resolved: CentreRef[] = candidates;
+    if (candidates.length > 1) {
+      const wantedType = programIds.includes(1)
+        ? "coe"
+        : programIds.includes(2)
+          ? "nodal"
+          : null;
+      const tieBroken = candidates.filter((c) => c.typeCode === wantedType);
+      if (tieBroken.length === 1) {
+        resolved = tieBroken;
+      } else {
+        ambiguous.push(candidates);
+        resolved = [];
+      }
+    }
+    for (const centre of resolved) {
+      if (!seen.has(centre.id)) {
+        seen.add(centre.id);
+        centres.push(centre);
+      }
+    }
+  }
+
+  return { centres, ambiguous };
+}
+
+export function parseSheetTsv(content: string): SheetRow[] {
+  const lines = content.split("\n").filter((line) => line.trim() !== "");
+  if (lines.length === 0) return [];
+
+  const header = lines[0].split("\t").map((h) => h.trim().toLowerCase());
+  const col = (prefix: string) =>
+    header.findIndex((h) => h.startsWith(prefix));
+  const idx = {
+    status: col("status"),
+    email: col("email"),
+    role: col("role"),
+    lmsName: col("lms_name"),
+    proposedAfId: col("proposed_af_id"),
+    teamDecision: col("team_decision"),
+    correctAfId: col("correct_af_id"),
+  };
+  for (const [name, i] of Object.entries(idx)) {
+    if (i === -1) throw new Error(`Sheet TSV is missing column: ${name}`);
+  }
+
+  return lines.slice(1).map((line) => {
+    const cells = line.split("\t");
+    const cell = (i: number) => (cells[i] ?? "").trim();
+    return {
+      status: cell(idx.status),
+      email: cell(idx.email).toLowerCase(),
+      role: cell(idx.role),
+      lmsName: cell(idx.lmsName),
+      proposedAfId: cell(idx.proposedAfId),
+      teamDecision: cell(idx.teamDecision),
+      correctAfId: cell(idx.correctAfId),
+    };
+  });
+}
+
+// --- Planning ---
+
+interface PermissionRow {
+  id: number;
+  email: string;
+  full_name: string | null;
+  role: "teacher" | "program_manager";
+  school_codes: string[] | null;
+  program_ids: number[] | null;
+  user_id: number | null;
+}
+
+interface ExistingTeacherRow {
+  id: number;
+  teacher_id: string | null;
+  user_id: number;
+  user_email: string | null;
+  user_name: string;
+}
+
+interface ExistingContext {
+  teacherByCode: Map<string, ExistingTeacherRow>;
+  afTeacherByName: Map<string, ExistingTeacherRow[]>;
+  teacherByUserId: Map<number, ExistingTeacherRow>;
+  userIdByEmail: Map<string, number>;
+  staffUserIds: Set<number>;
+  staffCodes: Set<string>;
+  activeSeats: Set<string>; // `${centreId}:${role}:${userId}`
+  centresBySchoolCode: Map<string, CentreRef[]>;
+}
+
+export function buildPersonPlan(
+  person: PermissionRow,
+  sheetRow: SheetRow | undefined,
+  hrByCode: Map<string, HrEmployee>,
+  existing: ExistingContext,
+  usedCodes: Map<string, string>
+): PersonPlan {
+  const fullName = (person.full_name ?? "").trim();
+  const warnings: string[] = [];
+  const resolution = resolveAfCode(sheetRow);
+  if (resolution.warning) warnings.push(resolution.warning);
+
+  const plan: PersonPlan = {
+    email: person.email,
+    role: person.role,
+    fullName,
+    code: resolution.code,
+    codeSource: resolution.source,
+    skipped: false,
+    userAction: "create",
+    existingUserId: null,
+    setEmailOnUser: false,
+    teacherAction: "none",
+    existingTeacherId: null,
+    subjectId: null,
+    designation: null,
+    staffAction: "none",
+    seats: [],
+    seatGaps: [],
+    warnings,
+  };
+
+  if (!resolution.include) {
+    plan.skipped = true;
+    plan.skipReason = resolution.source as
+      | "excluded_by_team"
+      | "test_account";
+    return plan;
+  }
+
+  if (plan.code) {
+    const priorEmail = usedCodes.get(plan.code);
+    if (priorEmail && priorEmail !== person.email) {
+      // Two emails claiming one code is a duplicate-person signal (e.g. a
+      // typo'd email row in user_permission) — defer, don't create a dupe.
+      warnings.push(
+        `AF code ${plan.code} already claimed by ${priorEmail} — likely the same person twice in user_permission; skipping until resolved`
+      );
+      plan.skipped = true;
+      plan.skipReason = "needs_review_duplicate_code";
+      return plan;
+    }
+    usedCodes.set(plan.code, person.email);
+  }
+
+  // HR enrichment (subject/designation) only makes sense with a code.
+  const hr = plan.code ? hrByCode.get(plan.code) : undefined;
+  if (plan.code && !hr) {
+    warnings.push(`AF code ${plan.code} not found in the HR employees dump`);
+  }
+  plan.designation = hr?.designation?.trim() || null;
+
+  // --- Resolve the person to a user row ---
+  const existingByCode = plan.code
+    ? existing.teacherByCode.get(plan.code)
+    : undefined;
+
+  if (person.user_id !== null) {
+    plan.userAction = "already_linked";
+    plan.existingUserId = person.user_id;
+    if (existingByCode && existingByCode.user_id !== person.user_id) {
+      warnings.push(
+        `user_permission.user_id (${person.user_id}) differs from the user owning teacher code ${plan.code} (user ${existingByCode.user_id})`
+      );
+    }
+  } else if (existingByCode) {
+    plan.userAction = "link_by_af_code";
+    plan.existingUserId = existingByCode.user_id;
+    plan.setEmailOnUser = !existingByCode.user_email;
+    if (
+      existingByCode.user_email &&
+      existingByCode.user_email.toLowerCase() !== person.email
+    ) {
+      warnings.push(
+        `existing teacher ${plan.code} has email ${existingByCode.user_email}, LMS has ${person.email}; keeping the existing email`
+      );
+    }
+  } else if (existing.userIdByEmail.has(person.email)) {
+    plan.userAction = "link_by_email";
+    plan.existingUserId = existing.userIdByEmail.get(person.email)!;
+  } else {
+    const nameMatches = fullName
+      ? (existing.afTeacherByName.get(normalizeName(fullName)) ?? [])
+      : [];
+    // Only link by name when it cannot contradict a known code.
+    const linkable = nameMatches.filter(
+      (t) => !t.teacher_id || t.teacher_id === plan.code
+    );
+    if (linkable.length === 1) {
+      plan.userAction = "link_by_name";
+      plan.existingUserId = linkable[0].user_id;
+      plan.setEmailOnUser = !linkable[0].user_email;
+      warnings.push(
+        `linked to existing AF teacher row id=${linkable[0].id} by exact name match ("${fullName}") — verify`
+      );
+    } else if (nameMatches.length > 0 && !plan.code) {
+      // Same name as an AF-coded row, and we have no code to prove they are
+      // a different person. Creating would risk a duplicate identity (and a
+      // unique-index conflict if the sheet later assigns that code) — defer.
+      warnings.push(
+        `name "${fullName}" matches existing AF teacher row(s) [${nameMatches
+          .map((t) => `id=${t.id} code=${t.teacher_id}`)
+          .join(
+            ", "
+          )}] and no AF code is confirmed; skipping until the sheet decides`
+      );
+      plan.skipped = true;
+      plan.skipReason = "needs_review_name_collision";
+      return plan;
+    } else {
+      if (nameMatches.length > 0) {
+        warnings.push(
+          `name "${fullName}" matches existing AF teacher row(s) [${nameMatches
+            .map((t) => `id=${t.id} code=${t.teacher_id}`)
+            .join(", ")}] with a different confirmed code; creating a new row`
+        );
+      }
+      plan.userAction = "create";
+    }
+  }
+
+  // --- Teacher / staff row ---
+  if (person.role === "teacher") {
+    plan.subjectId = hrSubjectToSubjectId(hr?.subject ?? null);
+    const existingTeacher =
+      plan.existingUserId !== null
+        ? existing.teacherByUserId.get(plan.existingUserId)
+        : undefined;
+    if (existingTeacher) {
+      plan.teacherAction = "update_existing";
+      plan.existingTeacherId = existingTeacher.id;
+      if (
+        existingTeacher.teacher_id &&
+        plan.code &&
+        existingTeacher.teacher_id !== plan.code
+      ) {
+        warnings.push(
+          `existing teacher row has code ${existingTeacher.teacher_id}, sheet says ${plan.code}; keeping the existing code`
+        );
+        plan.code = existingTeacher.teacher_id;
+      }
+    } else {
+      plan.teacherAction = "create";
+    }
+  } else {
+    // program_manager -> staff row (requires employee_code at DB level)
+    const alreadyStaff =
+      (plan.existingUserId !== null &&
+        existing.staffUserIds.has(plan.existingUserId)) ||
+      (plan.code !== null && existing.staffCodes.has(plan.code));
+    if (alreadyStaff) {
+      plan.staffAction = "exists";
+    } else if (plan.code) {
+      plan.staffAction = "create";
+    } else {
+      plan.staffAction = "pending_no_code";
+    }
+  }
+
+  // --- Seats ---
+  const { centres, ambiguous } = mapSchoolCodesToCentres(
+    person.school_codes ?? [],
+    person.program_ids ?? [],
+    existing.centresBySchoolCode
+  );
+  for (const group of ambiguous) {
+    plan.seatGaps.push(
+      `ambiguous centre for school (candidates: ${group.map((c) => c.name).join(" / ")}) — program_ids do not break the tie`
+    );
+  }
+
+  if (person.role === "program_manager") {
+    for (const centre of centres) {
+      plan.seats.push({ centreId: centre.id, centreName: centre.name, role: "pm" });
+    }
+    if (centres.length === 0 && ambiguous.length === 0) {
+      plan.seatGaps.push("no school_codes map to a centre; no pm seat created");
+    }
+  } else {
+    const seatRole = hrSubjectToSeatRole(hr?.subject ?? null);
+    if (seatRole === "apc") {
+      warnings.push(
+        `HR lists ${plan.code} as APC but LMS role is teacher; creating an apc seat`
+      );
+    }
+    if (centres.length === 0) {
+      if (ambiguous.length === 0) {
+        plan.seatGaps.push("school has no linked centre; no seat created");
+      }
+    } else if (centres.length > 1) {
+      plan.seatGaps.push(
+        `school_codes map to ${centres.length} centres (${centres.map((c) => c.name).join(", ")}); teachers get one seat — none created`
+      );
+    } else if (!seatRole) {
+      plan.seatGaps.push(
+        hr
+          ? `HR subject "${hr.subject ?? ""}" does not map to a seat role; no seat created`
+          : plan.code
+            ? `AF code ${plan.code} has no HR row to take a subject from; no seat created`
+            : "no confirmed AF code, so no HR subject; no seat created"
+      );
+    } else {
+      plan.seats.push({
+        centreId: centres[0].id,
+        centreName: centres[0].name,
+        role: seatRole,
+      });
+    }
+  }
+
+  return plan;
+}
+
+// --- Runner ---
+
+export interface BackfillOptions {
+  mode: BackfillMode;
+  sheetPath: string;
+  hrPath: string;
+}
+
+export async function runStaffBackfill(
+  options: BackfillOptions
+): Promise<BackfillReport> {
+  const report: BackfillReport = {
+    mode: options.mode,
+    ok: true,
+    counts: {
+      sourceTeachers: 0,
+      sourcePms: 0,
+      skipped: 0,
+      usersToCreate: 0,
+      usersLinked: 0,
+      teachersToCreate: 0,
+      teachersLinkedExisting: 0,
+      teachersWithCode: 0,
+      teachersWithoutCode: 0,
+      staffToCreate: 0,
+      staffPendingNoCode: 0,
+      seatsToCreate: 0,
+      seatsExisting: 0,
+    },
+    plans: [],
+    warnings: [],
+  };
+
+  let sheetRows: SheetRow[];
+  let hrEmployees: HrEmployee[];
+  try {
+    sheetRows = parseSheetTsv(fs.readFileSync(options.sheetPath, "utf8"));
+    hrEmployees = JSON.parse(fs.readFileSync(options.hrPath, "utf8"));
+  } catch (error) {
+    report.ok = false;
+    report.error = `Failed to read inputs: ${error instanceof Error ? error.message : error}`;
+    return report;
+  }
+
+  const sheetByEmail = new Map(sheetRows.map((r) => [r.email, r]));
+  const hrByCode = new Map(
+    hrEmployees
+      .filter((e) => !e.is_vacant)
+      .map((e) => [e.employee_code.trim().toUpperCase(), e])
+  );
+
+  const people = await query<PermissionRow>(
+    `SELECT id, lower(email) AS email, full_name, role, school_codes, program_ids, user_id
+     FROM user_permission
+     WHERE role IN ('teacher', 'program_manager') AND revoked_at IS NULL
+     ORDER BY role, email`
+  );
+
+  // AF-relevant rows only: name-dedupe against the 3k school teachers with
+  // phone-style codes would be pure noise.
+  const existingTeachers = await query<ExistingTeacherRow>(
+    `SELECT t.id, t.teacher_id, t.user_id, u.email AS user_email,
+            trim(coalesce(u.first_name, '') || ' ' || coalesce(u.last_name, '')) AS user_name
+     FROM teacher t
+     JOIN "user" u ON u.id = t.user_id
+     WHERE t.is_af_teacher = true OR t.teacher_id ~ '^AF[0-9]+$'`
+  );
+
+  const emails = people.map((p) => p.email);
+  const usersByEmail = await query<{ id: number; email: string }>(
+    `SELECT id, lower(email) AS email FROM "user" WHERE lower(email) = ANY($1)`,
+    [emails]
+  );
+  const teacherRowsForUsers = await query<ExistingTeacherRow>(
+    `SELECT t.id, t.teacher_id, t.user_id, u.email AS user_email,
+            trim(coalesce(u.first_name, '') || ' ' || coalesce(u.last_name, '')) AS user_name
+     FROM teacher t JOIN "user" u ON u.id = t.user_id
+     WHERE t.user_id = ANY($2) OR lower(u.email) = ANY($1)`,
+    [emails, people.map((p) => p.user_id).filter((id) => id !== null)]
+  );
+
+  const staffRows = await query<{ user_id: number; employee_code: string }>(
+    `SELECT user_id, employee_code FROM staff`
+  );
+  const seatRows = await query<{
+    centre_id: number;
+    role: string;
+    user_id: number | null;
+  }>(
+    `SELECT centre_id, role, user_id FROM centre_positions WHERE deleted_at IS NULL`
+  );
+  const centreRows = await query<{
+    id: number;
+    name: string;
+    type_code: string | null;
+    school_code: string;
+  }>(
+    `SELECT c.id, c.name, c.type_code, s.code AS school_code
+     FROM centres c JOIN school s ON s.id = c.school_id
+     WHERE c.is_active = true`
+  );
+
+  const existing: ExistingContext = {
+    teacherByCode: new Map(),
+    afTeacherByName: new Map(),
+    teacherByUserId: new Map(),
+    userIdByEmail: new Map(usersByEmail.map((u) => [u.email, Number(u.id)])),
+    staffUserIds: new Set(staffRows.map((s) => Number(s.user_id))),
+    staffCodes: new Set(staffRows.map((s) => s.employee_code)),
+    activeSeats: new Set(
+      seatRows
+        .filter((s) => s.user_id !== null)
+        .map((s) => `${s.centre_id}:${s.role}:${s.user_id}`)
+    ),
+    centresBySchoolCode: new Map(),
+  };
+  for (const t of existingTeachers) {
+    const row = { ...t, id: Number(t.id), user_id: Number(t.user_id) };
+    if (t.teacher_id) existing.teacherByCode.set(t.teacher_id, row);
+    const key = normalizeName(t.user_name);
+    if (key) {
+      const list = existing.afTeacherByName.get(key) ?? [];
+      list.push(row);
+      existing.afTeacherByName.set(key, list);
+    }
+    existing.teacherByUserId.set(row.user_id, row);
+  }
+  for (const t of teacherRowsForUsers) {
+    existing.teacherByUserId.set(Number(t.user_id), {
+      ...t,
+      id: Number(t.id),
+      user_id: Number(t.user_id),
+    });
+  }
+  for (const c of centreRows) {
+    const ref: CentreRef = {
+      id: Number(c.id),
+      name: c.name,
+      typeCode: c.type_code,
+      schoolCode: c.school_code,
+    };
+    const list = existing.centresBySchoolCode.get(c.school_code) ?? [];
+    list.push(ref);
+    existing.centresBySchoolCode.set(c.school_code, list);
+  }
+
+  const usedCodes = new Map<string, string>();
+  for (const person of people) {
+    const plan = buildPersonPlan(
+      { ...person, id: Number(person.id), user_id: person.user_id === null ? null : Number(person.user_id) },
+      sheetByEmail.get(person.email),
+      hrByCode,
+      existing,
+      usedCodes
+    );
+    report.plans.push(plan);
+    tallyPlan(report, plan, existing);
+  }
+
+  if (options.mode === "apply") {
+    try {
+      await withTransaction(async (client) => {
+        for (const plan of report.plans) {
+          if (!plan.skipped) await applyPlan(client, plan, people);
+        }
+      });
+    } catch (error) {
+      report.ok = false;
+      report.error = `Apply failed (rolled back): ${error instanceof Error ? error.message : error}`;
+    }
+  }
+
+  return report;
+}
+
+function tallyPlan(
+  report: BackfillReport,
+  plan: PersonPlan,
+  existing: ExistingContext
+): void {
+  const c = report.counts;
+  if (plan.role === "teacher") c.sourceTeachers++;
+  else c.sourcePms++;
+  if (plan.skipped) {
+    c.skipped++;
+    return;
+  }
+  if (plan.userAction === "create") c.usersToCreate++;
+  else c.usersLinked++;
+  if (plan.role === "teacher") {
+    if (plan.teacherAction === "create") c.teachersToCreate++;
+    else c.teachersLinkedExisting++;
+    if (plan.code) c.teachersWithCode++;
+    else c.teachersWithoutCode++;
+  }
+  if (plan.staffAction === "create") c.staffToCreate++;
+  if (plan.staffAction === "pending_no_code") c.staffPendingNoCode++;
+  for (const seat of plan.seats) {
+    const known =
+      plan.existingUserId !== null &&
+      existing.activeSeats.has(
+        `${seat.centreId}:${seat.role}:${plan.existingUserId}`
+      );
+    if (known) c.seatsExisting++;
+    else c.seatsToCreate++;
+  }
+  report.warnings.push(
+    ...plan.warnings.map((w) => `${plan.email}: ${w}`),
+    ...plan.seatGaps.map((g) => `${plan.email}: ${g}`)
+  );
+}
+
+async function applyPlan(
+  client: PoolClient,
+  plan: PersonPlan,
+  people: PermissionRow[]
+): Promise<void> {
+  const person = people.find(
+    (p) => p.email === plan.email && p.role === plan.role
+  )!;
+
+  // 1. User row
+  let userId = plan.existingUserId;
+  if (userId === null) {
+    const { firstName, lastName } = splitFullName(plan.fullName);
+    const inserted = await client.query(
+      `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at)
+       VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+      [firstName || null, lastName, plan.email]
+    );
+    userId = Number(inserted.rows[0].id);
+  } else if (plan.setEmailOnUser) {
+    await client.query(
+      `UPDATE "user" SET email = $1, updated_at = now()
+       WHERE id = $2 AND (email IS NULL OR email = '')`,
+      [plan.email, userId]
+    );
+  }
+
+  // 2. Teacher / staff row
+  if (plan.teacherAction === "create") {
+    await client.query(
+      `INSERT INTO teacher (user_id, teacher_id, is_af_teacher, subject_id, designation, inserted_at, updated_at)
+       VALUES ($1, $2, true, $3, $4, now(), now())`,
+      [userId, plan.code, plan.subjectId, plan.designation]
+    );
+  } else if (plan.teacherAction === "update_existing") {
+    await client.query(
+      `UPDATE teacher
+       SET teacher_id = COALESCE(teacher_id, $1),
+           is_af_teacher = true,
+           subject_id = COALESCE(subject_id, $2),
+           designation = COALESCE(designation, $3),
+           updated_at = now()
+       WHERE id = $4`,
+      [plan.code, plan.subjectId, plan.designation, plan.existingTeacherId]
+    );
+  }
+  if (plan.staffAction === "create") {
+    await client.query(
+      `INSERT INTO staff (user_id, employee_code, staff_type, designation, inserted_at, updated_at)
+       VALUES ($1, $2, 'program_manager', $3, now(), now())`,
+      [userId, plan.code, plan.designation]
+    );
+  }
+
+  // 3. user_permission link
+  await client.query(
+    `UPDATE user_permission SET user_id = $1, updated_at = now()
+     WHERE id = $2 AND (user_id IS NULL OR user_id = $1)`,
+    [userId, person.id]
+  );
+
+  // 4. Seats (skip ones that already exist for this user)
+  for (const seat of plan.seats) {
+    const existsResult = await client.query(
+      `SELECT 1 FROM centre_positions
+       WHERE centre_id = $1 AND role = $2 AND user_id = $3 AND deleted_at IS NULL`,
+      [seat.centreId, seat.role, userId]
+    );
+    if (existsResult.rows.length === 0) {
+      await client.query(
+        `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+         VALUES ($1, $2, $3, now(), now())`,
+        [seat.centreId, seat.role, userId]
+      );
+    }
+  }
+}

--- a/src/lib/staff-shared.ts
+++ b/src/lib/staff-shared.ts
@@ -1,0 +1,72 @@
+/**
+ * Client-safe staff types and constants. No DB imports — this module is
+ * bundled into client components (StaffGrid); server-only logic lives in
+ * staff-admin.ts, which re-exports these.
+ */
+
+export const SEAT_ROLES = [
+  "physics",
+  "chemistry",
+  "maths",
+  "biology",
+  "apc",
+  "pm",
+] as const;
+
+export type SeatRole = (typeof SEAT_ROLES)[number];
+
+export function isSeatRole(value: unknown): value is SeatRole {
+  return typeof value === "string" && SEAT_ROLES.includes(value as SeatRole);
+}
+
+export const EMPLOYEE_CODE_PATTERN = /^AF\d+$/;
+
+export function normalizeEmployeeCode(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const code = value.trim().toUpperCase();
+  return EMPLOYEE_CODE_PATTERN.test(code) ? code : null;
+}
+
+export type RosterKind = "teacher" | "staff" | "pending_teacher" | "pending_pm";
+export type RosterKindFilter = "all" | RosterKind;
+export type RosterCodeFilter = "all" | "missing" | "present";
+export type RosterExitedFilter = "exclude" | "include";
+
+export interface StaffRosterFilters {
+  search: string;
+  kind: RosterKindFilter;
+  code: RosterCodeFilter;
+  exited: RosterExitedFilter;
+  centreId: number | null;
+}
+
+export interface RosterSeat {
+  id: number;
+  centreId: number;
+  centreName: string;
+  role: SeatRole;
+}
+
+export interface StaffRosterRow {
+  kind: RosterKind;
+  recordId: number;
+  userId: number | null;
+  name: string;
+  email: string | null;
+  employeeCode: string | null;
+  subjectName: string | null;
+  staffType: string | null;
+  designation: string | null;
+  exitDate: string | null;
+  seats: RosterSeat[];
+}
+
+export interface StaffRosterSummary {
+  total: number;
+  teachers: number;
+  staff: number;
+  pending: number;
+  missingCode: number;
+  exited: number;
+  vacantSeats: number;
+}

--- a/src/lib/visits-policy.test.ts
+++ b/src/lib/visits-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { UserPermission } from "@/lib/permissions";
 import {
+  buildVisitScopePredicate,
   buildVisitsActor,
   canAccessVisitSchoolScope,
   canEditCompletedActionData,
@@ -98,5 +99,76 @@ describe("visits-policy", () => {
     expect(lockError?.status).toBe(409);
     expect(canEditCompletedActionData(pm)).toBe(false);
     expect(canEditCompletedActionData(admin)).toBe(true);
+  });
+});
+
+describe("buildVisitScopePredicate (seat-aware list filter)", () => {
+  it("returns no clause for level 3 (all access)", () => {
+    const actor = buildVisitsActor("a@x.org", makePermission({ role: "admin", level: 3 }));
+    expect(buildVisitScopePredicate(actor)).toEqual({ clause: "", params: [] });
+  });
+
+  it("level 1 falls back to raw school_codes when scope is unresolved", () => {
+    const actor = buildVisitsActor("t@x.org", makePermission({ level: 1, school_codes: ["70705"] }));
+    const scope = buildVisitScopePredicate(actor, { startIndex: 1, schoolCodeColumn: "v.school_code" });
+    expect(scope.clause).toBe("v.school_code = ANY($1)");
+    expect(scope.params).toEqual([["70705"]]);
+  });
+
+  it("level 1 uses the resolved scope set (explicit ∪ seats) when present", () => {
+    const actor = buildVisitsActor(
+      "t@x.org",
+      makePermission({
+        level: 1,
+        school_codes: ["70705"],
+        scope: { schools: new Set(["70705", "99999"]), centres: new Set([5]) },
+      })
+    );
+    const scope = buildVisitScopePredicate(actor, { startIndex: 1, schoolCodeColumn: "v.school_code" });
+    expect(scope.clause).toBe("v.school_code = ANY($1)");
+    expect(new Set(scope.params[0] as string[])).toEqual(new Set(["70705", "99999"]));
+  });
+
+  it("level 2 with only regions filters by region", () => {
+    const actor = buildVisitsActor(
+      "a@x.org",
+      makePermission({ role: "admin", level: 2, regions: ["North"], school_codes: null })
+    );
+    const scope = buildVisitScopePredicate(actor, {
+      startIndex: 3,
+      schoolRegionColumn: "s.region",
+    });
+    expect(scope.clause).toBe("COALESCE(s.region, '') = ANY($3)");
+    expect(scope.params).toEqual([["North"]]);
+  });
+
+  it("level 2 with seats ORs region and seat-school membership", () => {
+    const actor = buildVisitsActor(
+      "a@x.org",
+      makePermission({
+        role: "admin",
+        level: 2,
+        regions: ["North"],
+        school_codes: null,
+        scope: { schools: new Set(["55555"]), centres: new Set([9]) },
+      })
+    );
+    const scope = buildVisitScopePredicate(actor, {
+      startIndex: 1,
+      schoolCodeColumn: "v.school_code",
+      schoolRegionColumn: "s.region",
+    });
+    expect(scope.clause).toBe(
+      "(COALESCE(s.region, '') = ANY($1) OR v.school_code = ANY($2))"
+    );
+    expect(scope.params).toEqual([["North"], ["55555"]]);
+  });
+
+  it("returns an always-false clause when a scoped role has no scope at all", () => {
+    const actor = buildVisitsActor(
+      "t@x.org",
+      makePermission({ level: 1, school_codes: [], scope: { schools: new Set(), centres: new Set() } })
+    );
+    expect(buildVisitScopePredicate(actor)).toEqual({ clause: "1 = 0", params: [] });
   });
 });

--- a/src/lib/visits-policy.ts
+++ b/src/lib/visits-policy.ts
@@ -5,7 +5,7 @@ import { query } from "@/lib/db";
 import {
   canAccessSchoolSync,
   getFeatureAccess,
-  getUserPermission,
+  getResolvedPermission,
   type UserPermission,
   type UserRole,
 } from "@/lib/permissions";
@@ -102,7 +102,7 @@ export async function requireVisitsAccess(
     };
   }
 
-  const permission = await getUserPermission(email);
+  const permission = await getResolvedPermission(email);
   if (!permission) {
     return { ok: false, response: apiError(403, "Forbidden") };
   }
@@ -154,18 +154,42 @@ export function buildVisitScopePredicate(
     return { clause: "", params: [] };
   }
 
+  // Seat-derived schools from the resolved scope (B1). For level 1 the scope set
+  // already unions explicit school_codes with seat schools, so it's the complete
+  // school list; for level 2 it carries only seats (regions stay separate). Once
+  // strict-exclusivity clears explicit school_codes for seated staff, this is the
+  // ONLY thing keeping their visits in the list — so the SQL filter must read it.
+  const scope = actor.permission.scope;
+  const seatScopeSchools =
+    scope && scope.schools !== "all" ? [...scope.schools] : null;
+
   if (actor.permission.level === 2) {
     const regions = actor.permission.regions ?? [];
-    if (regions.length === 0) {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (regions.length > 0) {
+      params.push(regions);
+      conditions.push(
+        `COALESCE(${schoolRegionColumn}, '') = ANY($${startIndex + params.length - 1})`
+      );
+    }
+    if (seatScopeSchools && seatScopeSchools.length > 0) {
+      params.push(seatScopeSchools);
+      conditions.push(`${schoolCodeColumn} = ANY($${startIndex + params.length - 1})`);
+    }
+    if (conditions.length === 0) {
       return { clause: "1 = 0", params: [] };
     }
     return {
-      clause: `COALESCE(${schoolRegionColumn}, '') = ANY($${startIndex})`,
-      params: [regions],
+      clause: conditions.length > 1 ? `(${conditions.join(" OR ")})` : conditions[0],
+      params,
     };
   }
 
-  const schoolCodes = actor.permission.school_codes ?? [];
+  // Level 1: prefer the resolved scope set (explicit ∪ seats); fall back to raw
+  // school_codes when scope isn't resolved (e.g. an actor built from a bare
+  // permission), preserving the pre-seat behaviour.
+  const schoolCodes = seatScopeSchools ?? actor.permission.school_codes ?? [];
   if (schoolCodes.length === 0) {
     return { clause: "1 = 0", params: [] };
   }


### PR DESCRIPTION
Relates to #123.

## What

First version of Staff Management plus the centre-seat **access model** that makes centre assignments drive school access. Built on the db-service #545 schema (`staff`, `centre_positions`, optional `teacher.teacher_id`, `user_permission.user_id`/`revoked_at`).

### `/admin/staff` (admin-only)
- Roster **grouped by Centre** (the primary browsing axis), with a "No Centre assigned" section; people assigned to several Centres appear under each
- Flat cards: Email / Role / Subject / Centre fields + one **Edit** button
- Edit modal: AF code (for a pending PM this creates the `staff` record), **Assigned Centres** with add/remove, and a **Mark exited** flow (sets `exit_date`, removes all Centre assignments, revokes LMS access)
- Filters: search, Centre, type, AF code missing/present, exited; stat tiles with a loud **Missing AF ID** counter
- Roster = `teacher (is_af_teacher)` ∪ `staff` ∪ not-yet-backfilled `user_permission` rows — pending people stay visible with a warning badge
- Ownership rule respected: teacher writes proxy through the db-service REST API; `staff`/`centre_positions` are LMS-direct

### Backfill script
`npm run staff:backfill` (dry-run default / `--apply` / `--env-file=`): materializes `user_permission` teachers + PMs into `user`/`teacher`/`staff` rows and filled `centre_positions`, with AF codes from the review sheet and subjects from the HR dump. Idempotent; dedupes against existing teacher rows by AF code then exact name; ambiguous cases deferred with loud warnings. **Already applied on staging.** Prod apply waits on the #545 prod release.

## Access model (added on this branch after v1)

Wires centre seats into access and makes seats the source of truth for centre staff. **Additive and regression-safe until the one-time clear migration is run** (seated staff still hold their old `school_codes` in the meantime, so access is a superset).

- **`resolveScope`** (`permissions.ts`): effective school scope = explicit `school_codes`/`regions` **∪ centre-seat-derived schools** (`centre_positions → centres.school_id`). `getResolvedPermission` resolves seats and fails safe to explicit-only if the centre tables are absent; `canAccessSchoolSync` gains an *additive* seat check (signature unchanged). ~13 loaders read the resolved permission. `school_codes` is seeded into scope only for level 1; level 2 stays region-based.
- **Strict per-user exclusivity**: assigning a centre seat (`createPosition`/`updatePosition`) clears the occupant's explicit `school_codes`/`regions` in a transaction, so moving a seat can't leave stale access behind. One-time migration `npm run staff:clear-seated-scope` (dry-run default, `--apply`, loud "stranded" worklist for anyone whose codes aren't fully seat-covered).
- **Seat-aware list filters**: the visit-list and curriculum-summary SQL filters read the resolved scope set, so seated staff stay listed once their explicit codes are cleared.
- **Editable centre ↔ program** field in `/admin/centres` (the #543 follow-up; lets ops correct the name-matched program tags).
- **`/admin/users`** Scope column shows read-only **centre-assignment chips** (edits stay in `/admin/staff`).

### Verified on staging (e2e, both directions)
Assigning a centre to a real teacher cleared their explicit `school_codes` to null **and** moved their effective access — `canAccessSchool` then granted the new centre's school and revoked the old explicit school — then the test restored the original state.

### Held / follow-ups (separate, gated)
- Run the clear-migration (after ops links the one centre the dry-run flagged as stranded).
- **Separate centre-staff vs non-centre add/edit flows** (design doc on the branch): centre staff managed in `/admin/staff` (seat scope, no `school_codes`), non-centre users in `/admin/users`. Fixes the current "delete + re-add on centre change" habit, which now orphans seats because a re-added `user_permission` row has no `user_id`.

## Testing
- Full unit suite **2345 green**; production build green
- Backfill planning rules, staff-admin lib + routes, StaffGrid, resolveScope/exclusivity, seat-aware filters, users-page centres all covered
- Manually verified against staging via the browser + a real authenticated API round-trip (assignment → scope clear → access resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
