### PR TITLE
PM + teacher centre assignments; seats as source of truth for scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ stop-discord-bot.sh
 centres-for-crud-ui/
 centre_name_table.csv
 centre_name_mapping_template.csv
+
+# Roster data (PII) — regenerated locally from the sheet/DB, never committed
+scripts/data/pm/

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "pm:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-pm-centres.ts",
-    "pm:check": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/check-teacher-centre-vs-prod.ts"
+    "pm:check": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/check-teacher-centre-vs-prod.ts",
+    "pm:promodiff": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/check-promotion-school-diff.ts",
+    "pm:mirror": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/mirror-seats-staging-to-prod.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1025.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e": "NODE_V8_COVERAGE=.v8-coverage playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "pm:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-pm-centres.ts"
+    "pm:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-pm-centres.ts",
+    "pm:check": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/check-teacher-centre-vs-prod.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1025.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "NODE_V8_COVERAGE=.v8-coverage playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "pm:import": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/import-pm-centres.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1025.0",

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -1,0 +1,237 @@
+/**
+ * Read-only PRE-PROMOTION diff: for teachers & staff in JNV CoE (program 1) and
+ * JNV Nodal (program 2), how will the set of schools each person can access
+ * CHANGE when we promote the staging centre-seat model to prod?
+ *
+ * Prod today (old model): access = user_permission.school_codes (level 1) or
+ * "all" (level 3+). Staging (target model): access = explicit school_codes (L1)
+ * ∪ centre-seat-derived schools (resolveScope semantics). Promotion replaces
+ * prod's state with staging's, so diff(prod_now, staging) = exactly what changes.
+ *
+ * Scope of the comparison = the "migration domain": school codes linked to an
+ * active centre in program 1 or 2 (staging). Seats only govern access to these
+ * schools, so access to any other school is untouched and out of scope here.
+ *
+ * 100% read-only. Connects to BOTH dbs (staging .env.local, prod .env.production).
+ *
+ * Usage (from worktree root):
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/check-promotion-school-diff.ts
+ *   npm run pm:promodiff           (if aliased)
+ *   options: --staging-env= --prod-env= --out= --verbose
+ */
+import * as path from "path";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import * as dotenv from "dotenv";
+import { Pool } from "pg";
+
+const COE_NODAL = [1, 2];
+
+interface Cli { stagingEnv: string; prodEnv: string; out: string; verbose: boolean; }
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = { stagingEnv: ".env.local", prodEnv: ".env.production", out: "scripts/data/pm/promotion-school-diff.csv", verbose: false };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--staging-env=")) o.stagingEnv = a.slice(14);
+    else if (a.startsWith("--prod-env=")) o.prodEnv = a.slice(11);
+    else if (a.startsWith("--out=")) o.out = a.slice(6);
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+function poolFromEnvFile(envFile: string, label: string): Pool {
+  if (!existsSync(envFile)) throw new Error(`${label} env file not found: ${envFile}`);
+  const env = dotenv.parse(readFileSync(envFile));
+  return new Pool({
+    host: env.DATABASE_HOST, port: parseInt(env.DATABASE_PORT || "5432"),
+    user: env.DATABASE_USER, password: env.DATABASE_PASSWORD, database: env.DATABASE_NAME,
+    ssl: env.DATABASE_SSL === "false" ? false : { rejectUnauthorized: false },
+    max: 4, connectionTimeoutMillis: 8000, statement_timeout: 30000,
+  });
+}
+const setsEqual = (a: Set<string>, b: Set<string>) => a.size === b.size && [...a].every((x) => b.has(x));
+const sortedList = (s: Iterable<string>) => [...s].sort();
+
+type PersonAgg = {
+  email: string;
+  prodLevel: number | null;       // max (broadest) level across prod CoE/Nodal rows
+  prodRoles: Set<string>;
+  prodSchools: Set<string>;       // school_codes ∩ domain (level-1 contribution)
+  prodBroad: boolean;             // level>=3 → all schools
+  stagingLevel: number | null;
+  stagingRoles: Set<string>;      // seat roles ∪ user_permission role
+  stagingSchools: Set<string>;    // (L1 school_codes ∩ D) ∪ seat schools(prog1/2)
+  stagingBroad: boolean;
+  seated: boolean;
+};
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const staging = poolFromEnvFile(cli.stagingEnv, "STAGING");
+  const prod = poolFromEnvFile(cli.prodEnv, "PROD");
+  try {
+    const sName = (await staging.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+    const pName = (await prod.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+
+    // --- DOMAIN: centre-linked schools in program 1/2 (staging = target model) ---
+    const domRows = (await staging.query<{ code: string; name: string }>(
+      `SELECT DISTINCT s.code, s.name FROM centres c JOIN school s ON s.id = c.school_id
+       WHERE c.is_active = true AND c.program_id = ANY($1::int[]) AND c.school_id IS NOT NULL`,
+      [COE_NODAL]
+    )).rows;
+    const DOMAIN = new Set(domRows.map((r) => r.code));
+    const schoolName = new Map(domRows.map((r) => [r.code, r.name]));
+    const inDom = (codes: string[] | null) => new Set((codes || []).filter((c) => DOMAIN.has(c)));
+
+    const people = new Map<string, PersonAgg>();
+    const get = (email: string): PersonAgg => {
+      const e = email.toLowerCase();
+      if (!people.has(e)) people.set(e, {
+        email: e, prodLevel: null, prodRoles: new Set(), prodSchools: new Set(), prodBroad: false,
+        stagingLevel: null, stagingRoles: new Set(), stagingSchools: new Set(), stagingBroad: false, seated: false,
+      });
+      return people.get(e)!;
+    };
+
+    // --- PROD: every active user_permission touching CoE/Nodal ---
+    const prodRows = (await prod.query<{ email: string; level: number; role: string; school_codes: string[] | null }>(
+      `SELECT lower(email) email, level, role, school_codes
+       FROM user_permission WHERE revoked_at IS NULL AND program_ids && $1::int[]`,
+      [COE_NODAL]
+    )).rows;
+    for (const r of prodRows) {
+      const p = get(r.email);
+      p.prodLevel = Math.max(p.prodLevel ?? 0, r.level);
+      p.prodRoles.add(r.role);
+      if (r.level >= 3) p.prodBroad = true;
+      if (r.level === 1) for (const c of inDom(r.school_codes)) p.prodSchools.add(c);
+    }
+
+    // --- STAGING: seats at prog 1/2 centres ---
+    const seatRows = (await staging.query<{ email: string; code: string; role: string }>(
+      `SELECT lower(u.email) email, s.code, cp.role
+       FROM centre_positions cp
+       JOIN centres c ON c.id = cp.centre_id
+       JOIN school  s ON s.id = c.school_id
+       JOIN "user"  u ON u.id = cp.user_id
+       WHERE cp.deleted_at IS NULL AND c.program_id = ANY($1::int[]) AND c.school_id IS NOT NULL`,
+      [COE_NODAL]
+    )).rows;
+    for (const r of seatRows) {
+      const p = get(r.email);
+      p.seated = true;
+      p.stagingRoles.add(r.role);
+      if (DOMAIN.has(r.code)) p.stagingSchools.add(r.code);
+    }
+    // --- STAGING: user_permission (L1 explicit school_codes contribute; L3 broad) ---
+    const stgPerm = (await staging.query<{ email: string; level: number; role: string; school_codes: string[] | null }>(
+      `SELECT lower(email) email, level, role, school_codes
+       FROM user_permission WHERE revoked_at IS NULL AND program_ids && $1::int[]`,
+      [COE_NODAL]
+    )).rows;
+    for (const r of stgPerm) {
+      const p = get(r.email);
+      p.stagingLevel = Math.max(p.stagingLevel ?? 0, r.level);
+      p.stagingRoles.add(r.role);
+      if (r.level >= 3) p.stagingBroad = true;
+      if (r.level === 1) for (const c of inDom(r.school_codes)) p.stagingSchools.add(c);
+    }
+
+    // --- CLASSIFY ---
+    type Out = {
+      email: string; bucket: string;
+      prod_access: string; staging_access: string;
+      schools_added: string; schools_removed: string;
+      prod_role: string; staging_role: string; note: string;
+    };
+    const out: Out[] = [];
+    const buckets: Record<string, number> = {};
+    let totalAdded = 0, totalRemoved = 0;
+
+    for (const p of people.values()) {
+      // effective school sets within domain (broad = all of domain)
+      const prodEff = p.prodBroad ? new Set(DOMAIN) : p.prodSchools;
+      const stgEff = p.stagingBroad ? new Set(DOMAIN) : p.stagingSchools;
+      const added = sortedList([...stgEff].filter((c) => !prodEff.has(c)));
+      const removed = sortedList([...prodEff].filter((c) => !stgEff.has(c)));
+
+      // The promotion importers are UPSERT-ONLY — they create/update seats and
+      // mirror teacher rows, but never DELETE/revoke a prod row absent from their
+      // input. So a person's prod access only CHANGES if they get SEATED in
+      // staging (seating clears their explicit school_codes -> scope derives from
+      // the seat). Everyone NOT seated is left exactly as prod has them today —
+      // including prod L3 admins that staging (a partial env) simply doesn't
+      // mirror. Counting those as "losses" would be a false alarm.
+      let bucket: string;
+      const inProd = p.prodLevel != null;
+      if (!p.seated) {
+        bucket = "UNTOUCHED"; // upsert-only importers don't revoke; prod access preserved
+      } else if (!inProd) bucket = "NEW_IN_STAGING";
+      else if (setsEqual(prodEff, stgEff)) bucket = "UNCHANGED";
+      else if (added.length && !removed.length) bucket = "GAINED_ONLY";
+      else if (removed.length && !added.length) bucket = "LOST_ONLY";
+      else bucket = "CHANGED_BOTH";
+
+      buckets[bucket] = (buckets[bucket] || 0) + 1;
+      // only count access deltas for people the promotion actually touches
+      if (p.seated) { totalAdded += added.length; totalRemoved += removed.length; }
+
+      const showSets = bucket !== "UNCHANGED" && bucket !== "UNTOUCHED";
+      out.push({
+        email: p.email, bucket,
+        prod_access: p.prodBroad ? "ALL(L3+)" : sortedList(prodEff).join("|"),
+        staging_access: p.stagingBroad ? "ALL(L3+)" : sortedList(stgEff).join("|"),
+        schools_added: added.join("|"),
+        schools_removed: removed.join("|"),
+        prod_role: `${p.prodLevel != null ? "L" + p.prodLevel + " " : ""}${[...p.prodRoles].join(",")}`,
+        staging_role: `${p.stagingLevel != null ? "L" + p.stagingLevel + " " : ""}${[...p.stagingRoles].join(",")}${p.seated ? " (seated)" : ""}`,
+        note: showSets ? "" : "no school-access change within domain",
+      });
+    }
+
+    // --- OUTPUT ---
+    const order = ["LOST_ONLY", "CHANGED_BOTH", "GAINED_ONLY", "NEW_IN_STAGING", "UNCHANGED", "UNTOUCHED"];
+    console.log(`\n=== Promotion school-access diff — JNV CoE (1) + JNV Nodal (2), teachers & staff ===`);
+    console.log(`staging(target): ${sName}   prod(current): ${pName}`);
+    console.log(`migration domain: ${DOMAIN.size} centre-linked schools in prog 1/2`);
+    console.log(`people in scope: ${people.size}`);
+    console.log(`(promotion is UPSERT-ONLY: only SEATED people have their scope rewritten; UNTOUCHED = prod access preserved as-is)\n`);
+    console.log(`change buckets:`);
+    for (const b of order) if (buckets[b]) console.log(`  ${String(buckets[b]).padStart(3)}  ${b}`);
+    const changed = (buckets.LOST_ONLY||0)+(buckets.CHANGED_BOTH||0)+(buckets.GAINED_ONLY||0)+(buckets.NEW_IN_STAGING||0);
+    console.log(`\n  → ${changed} seated people have a school-access CHANGE; ${buckets.UNCHANGED||0} seated-unchanged; ${buckets.UNTOUCHED||0} untouched by promotion`);
+    console.log(`  → among changed: (person,school) access GAINED: ${totalAdded}   REMOVED: ${totalRemoved}`);
+
+    // surface the risk buckets (access removed) inline
+    const losers = out.filter((r) => r.bucket === "LOST_ONLY" || r.bucket === "CHANGED_BOTH")
+      .sort((a, b) => a.bucket.localeCompare(b.bucket) || a.email.localeCompare(b.email));
+    if (losers.length) {
+      console.log(`\n--- ACCESS REMOVED (review carefully — these people lose schools) ---`);
+      for (const r of losers) {
+        const rem = r.schools_removed.split("|").filter(Boolean).map((c) => `${schoolName.get(c) || "?"}(${c})`).join(", ");
+        console.log(`  [${r.bucket}] ${r.email} (${r.prod_role} → ${r.staging_role}) loses: ${rem || "(all CoE/Nodal access)"}`);
+      }
+    }
+    if (cli.verbose) {
+      const gainers = out.filter((r) => r.bucket === "GAINED_ONLY" || r.bucket === "NEW_IN_STAGING").sort((a,b)=>a.email.localeCompare(b.email));
+      console.log(`\n--- ACCESS GAINED ---`);
+      for (const r of gainers) {
+        const add = r.schools_added.split("|").filter(Boolean).map((c) => `${schoolName.get(c) || "?"}(${c})`).join(", ");
+        console.log(`  [${r.bucket}] ${r.email} (${r.prod_role} → ${r.staging_role}) gains: ${add}`);
+      }
+    }
+
+    // CSV
+    const header = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"];
+    const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+    const csv = [header.join(",")].concat(
+      out.sort((a,b)=> order.indexOf(a.bucket)-order.indexOf(b.bucket) || a.email.localeCompare(b.email))
+        .map((r)=>header.map((h)=>esc(String((r as any)[h] ?? ""))).join(","))
+    ).join("\n");
+    const outPath = path.resolve(cli.out);
+    mkdirSync(path.dirname(outPath), { recursive: true });
+    writeFileSync(outPath, csv + "\n");
+    console.log(`\nCSV: ${outPath}  (${out.length} rows; contains emails — gitignored dir)`);
+  } finally { await staging.end(); await prod.end(); }
+}
+main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/scripts/check-teacher-centre-vs-prod.ts
+++ b/scripts/check-teacher-centre-vs-prod.ts
@@ -1,0 +1,390 @@
+/**
+ * Read-only consistency check: do STAGING centre<->teacher seat mappings line
+ * up with PRODUCTION user<->school mappings, for every teacher whose school is
+ * linked to a centre?
+ *
+ * Why this exists: staging is the new model (teachers seated at centres; scope
+ * derives from the seat, so staging's own user_permission.school_codes are
+ * CLEARED for seated teachers). Prod is still the old model (everyone in
+ * user_permission with school_codes, no seats). So prod is the only reference
+ * for "which school does this teacher actually belong to" — this script joins
+ * the two by email and reports every divergence.
+ *
+ * Connects to BOTH databases at once (staging from .env.local, prod from
+ * .env.production), so it needs no MCP and can run live on a call. 100% read-only
+ * — no BEGIN/COMMIT, no writes.
+ *
+ * Identifier note: prod user_permission.school_codes stores school.code (the AF
+ * short code, e.g. "49057"), the SAME value a centre's linked school carries via
+ * centres.school_id -> school.code. So the comparison is code-to-code.
+ *
+ * Usage (from the worktree root):
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/check-teacher-centre-vs-prod.ts
+ *   # options:
+ *   #   --staging-env=.env.local        (default)
+ *   #   --prod-env=.env.production      (default; must exist, gitignored)
+ *   #   --out=scripts/data/pm/teacher-centre-vs-prod.csv   (default; gitignored dir)
+ *   #   --verbose                       (print every exception inline)
+ *
+ * Or: npm run pm:check
+ */
+import * as path from "path";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import * as dotenv from "dotenv";
+import { Pool } from "pg";
+import { SEAT_ROLES, PM_SEAT_ROLES } from "../src/lib/staff-shared";
+
+// Subject-teaching seat roles = all seat roles that aren't PM-family tiers.
+const TEACHER_SEAT_ROLES = SEAT_ROLES.filter(
+  (r) => !(PM_SEAT_ROLES as readonly string[]).includes(r)
+);
+
+interface Cli {
+  stagingEnv: string;
+  prodEnv: string;
+  out: string;
+  verbose: boolean;
+}
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = {
+    stagingEnv: ".env.local",
+    prodEnv: ".env.production",
+    out: "scripts/data/pm/teacher-centre-vs-prod.csv",
+    verbose: false,
+  };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--staging-env=")) o.stagingEnv = a.slice(14);
+    else if (a.startsWith("--prod-env=")) o.prodEnv = a.slice(11);
+    else if (a.startsWith("--out=")) o.out = a.slice(6);
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+
+function poolFromEnvFile(envFile: string, label: string): Pool {
+  if (!existsSync(envFile)) {
+    throw new Error(
+      `${label} env file not found: ${envFile}\n` +
+        (envFile.includes("production")
+          ? `  -> copy it from the main clone: cp ~/af/af_lms/.env.production .env.production (it's gitignored)`
+          : "")
+    );
+  }
+  const env = dotenv.parse(readFileSync(envFile));
+  return new Pool({
+    host: env.DATABASE_HOST,
+    port: parseInt(env.DATABASE_PORT || "5432"),
+    user: env.DATABASE_USER,
+    password: env.DATABASE_PASSWORD,
+    database: env.DATABASE_NAME,
+    ssl: env.DATABASE_SSL === "false" ? false : { rejectUnauthorized: false },
+    max: 4,
+    connectionTimeoutMillis: 8000,
+    statement_timeout: 30000,
+  });
+}
+
+// gmail ignores dots in the local part; flag "same person, email typed
+// differently" rather than silently treating them as equal.
+function dotKey(email: string): string {
+  const [local, domain] = email.toLowerCase().split("@");
+  if (!domain) return email.toLowerCase();
+  return `${local.replace(/\./g, "")}@${domain}`;
+}
+
+type SeatRow = {
+  email: string;
+  school_code: string;
+  school_name: string;
+  centre_id: string;
+  centre_name: string;
+  centre_program_id: number | null;
+  role: string;
+};
+type ProdRow = {
+  email: string;
+  school_codes: string[];
+  program_ids: number[] | null;
+  read_only: boolean;
+};
+type CentreSchool = {
+  code: string;
+  centres: { id: string; name: string; program_id: number | null }[];
+};
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const staging = poolFromEnvFile(cli.stagingEnv, "STAGING");
+  const prod = poolFromEnvFile(cli.prodEnv, "PROD");
+
+  try {
+    // --- sanity: confirm we're pointed where we think ---
+    const sName = (await staging.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+    const pName = (await prod.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+
+    // --- STAGING: teacher seats at centres WITH a linked school ---
+    const seats = (
+      await staging.query<SeatRow>(
+        `SELECT lower(u.email)   AS email,
+                s.code           AS school_code,
+                s.name           AS school_name,
+                c.id::text       AS centre_id,
+                c.name           AS centre_name,
+                c.program_id     AS centre_program_id,
+                cp.role          AS role
+         FROM centre_positions cp
+         JOIN centres c ON c.id = cp.centre_id
+         JOIN school  s ON s.id = c.school_id
+         JOIN "user"  u ON u.id = cp.user_id
+         WHERE cp.deleted_at IS NULL
+           AND cp.role = ANY($1::text[])
+           AND c.school_id IS NOT NULL
+         ORDER BY 1, 2`,
+        [TEACHER_SEAT_ROLES]
+      )
+    ).rows;
+
+    // --- STAGING: every email holding ANY active seat (incl PM-family) ---
+    // Lets us distinguish "not seated at all" from "seated, but as a PM/etc.".
+    const anySeatEmails = new Set(
+      (
+        await staging.query<{ email: string }>(
+          `SELECT DISTINCT lower(u.email) AS email
+           FROM centre_positions cp JOIN "user" u ON u.id = cp.user_id
+           WHERE cp.deleted_at IS NULL AND cp.user_id IS NOT NULL`
+        )
+      ).rows.map((r) => r.email)
+    );
+
+    // --- STAGING: active centres with a linked school -> code + its centres ---
+    const centreSchoolRows = (
+      await staging.query<{ code: string; centre_id: string; centre_name: string; program_id: number | null }>(
+        `SELECT s.code AS code, c.id::text AS centre_id, c.name AS centre_name, c.program_id AS program_id
+         FROM centres c JOIN school s ON s.id = c.school_id
+         WHERE c.is_active = true AND c.school_id IS NOT NULL`
+      )
+    ).rows;
+    const centreSchools = new Map<string, CentreSchool>();
+    for (const r of centreSchoolRows) {
+      if (!centreSchools.has(r.code)) centreSchools.set(r.code, { code: r.code, centres: [] });
+      centreSchools.get(r.code)!.centres.push({ id: r.centre_id, name: r.centre_name, program_id: r.program_id });
+    }
+
+    // --- PROD: level-1 teachers (the population that maps to a single school) ---
+    const prodTeachers = (
+      await prod.query<ProdRow>(
+        `SELECT lower(email) AS email, school_codes, program_ids, read_only
+         FROM user_permission
+         WHERE level = 1 AND role = 'teacher' AND revoked_at IS NULL`
+      )
+    ).rows;
+    const prodByEmail = new Map<string, ProdRow>();
+    const prodByDotKey = new Map<string, ProdRow>();
+    for (const p of prodTeachers) {
+      prodByEmail.set(p.email, p);
+      prodByDotKey.set(dotKey(p.email), p);
+    }
+
+    // --- school code -> name, for display of prod-only codes ---
+    const allCodes = new Set<string>();
+    for (const s of seats) allCodes.add(s.school_code);
+    for (const c of centreSchools.keys()) allCodes.add(c);
+    for (const p of prodTeachers) for (const c of p.school_codes || []) allCodes.add(c);
+    const nameRows = (
+      await staging.query<{ code: string; name: string }>(
+        `SELECT code, name FROM school WHERE code = ANY($1::text[])`,
+        [[...allCodes]]
+      )
+    ).rows;
+    const schoolName = new Map(nameRows.map((r) => [r.code, r.name]));
+    const nm = (code: string) => schoolName.get(code) || "?";
+
+    // staging teacher-seat schools per email
+    const seatSchoolsByEmail = new Map<string, Set<string>>();
+    for (const s of seats) {
+      if (!seatSchoolsByEmail.has(s.email)) seatSchoolsByEmail.set(s.email, new Set());
+      seatSchoolsByEmail.get(s.email)!.add(s.school_code);
+    }
+
+    type Csv = {
+      issue: string;
+      email: string;
+      prod_school_code: string;
+      prod_school_name: string;
+      seat_school_code: string;
+      seat_school_name: string;
+      seat_centre: string;
+      seat_role: string;
+      note: string;
+    };
+    const rows: Csv[] = [];
+
+    // ===== FORWARD: is each staging teacher-seat backed by prod? =====
+    let fwdMatch = 0;
+    const fwdMismatch: SeatRow[] = [];
+    const fwdNoProd: SeatRow[] = [];
+    for (const s of seats) {
+      const p = prodByEmail.get(s.email);
+      if (!p) {
+        const fuzzy = prodByDotKey.get(dotKey(s.email));
+        fwdNoProd.push(s);
+        rows.push({
+          issue: "SEAT_NO_PROD_ROW",
+          email: s.email,
+          prod_school_code: fuzzy ? fuzzy.school_codes.join("|") : "",
+          prod_school_name: fuzzy ? fuzzy.school_codes.map(nm).join("|") : "",
+          seat_school_code: s.school_code,
+          seat_school_name: s.school_name,
+          seat_centre: s.centre_name,
+          seat_role: s.role,
+          note: fuzzy
+            ? `no exact prod match; email dot-variant exists in prod: ${fuzzy.email} (likely same person)`
+            : "teacher seated in staging but has no prod level-1 teacher grant",
+        });
+        continue;
+      }
+      if ((p.school_codes || []).includes(s.school_code)) {
+        fwdMatch++;
+        continue;
+      }
+      fwdMismatch.push(s);
+      const otherSeatMatches = [...(seatSchoolsByEmail.get(s.email) || [])].some((c) =>
+        (p.school_codes || []).includes(c)
+      );
+      rows.push({
+        issue: otherSeatMatches ? "SEAT_EXTRA_SCHOOL" : "SEAT_SCHOOL_MISMATCH",
+        email: s.email,
+        prod_school_code: (p.school_codes || []).join("|"),
+        prod_school_name: (p.school_codes || []).map(nm).join("|"),
+        seat_school_code: s.school_code,
+        seat_school_name: s.school_name,
+        seat_centre: s.centre_name,
+        seat_role: s.role,
+        note: otherSeatMatches
+          ? "second/extra seat; teacher's primary seat DOES match prod"
+          : "staging seats this teacher at a school prod does not assign them",
+      });
+    }
+
+    // ===== REVERSE: is every prod centre-linked teacher seated in staging? =====
+    let revOk = 0;
+    const revElsewhere: { email: string; code: string }[] = [];
+    const revNotSeated: { email: string; code: string; note: string }[] = [];
+    for (const p of prodTeachers) {
+      for (const code of p.school_codes || []) {
+        if (!centreSchools.has(code)) continue; // school isn't linked to a centre -> out of scope
+        const seatCodes = seatSchoolsByEmail.get(p.email);
+        if (seatCodes && seatCodes.has(code)) {
+          revOk++;
+          continue;
+        }
+        const centreList = centreSchools
+          .get(code)!
+          .centres.map((c) => `${c.name}(prog${c.program_id ?? "?"})`)
+          .join("; ");
+        if (seatCodes && seatCodes.size > 0) {
+          revElsewhere.push({ email: p.email, code });
+          rows.push({
+            issue: "PROD_SEATED_DIFFERENT_SCHOOL",
+            email: p.email,
+            prod_school_code: code,
+            prod_school_name: nm(code),
+            seat_school_code: [...seatCodes].join("|"),
+            seat_school_name: [...seatCodes].map(nm).join("|"),
+            seat_centre: centreList,
+            seat_role: "",
+            note: "prod says this school; staging seats them at a different school",
+          });
+        } else {
+          let note: string;
+          if (anySeatEmails.has(p.email)) note = "has a staging seat but NOT a teacher seat (likely seated as PM/other)";
+          else {
+            const fuzzyEmail = [...seatSchoolsByEmail.keys()].find((e) => dotKey(e) === dotKey(p.email) && e !== p.email);
+            note = fuzzyEmail
+              ? `no seat under this email; email dot-variant IS seated: ${fuzzyEmail} (likely same person)`
+              : "no staging seat at all";
+          }
+          revNotSeated.push({ email: p.email, code, note });
+          rows.push({
+            issue: "PROD_NOT_SEATED",
+            email: p.email,
+            prod_school_code: code,
+            prod_school_name: nm(code),
+            seat_school_code: "",
+            seat_school_name: "",
+            seat_centre: centreList,
+            seat_role: "",
+            note,
+          });
+        }
+      }
+    }
+
+    // ===== OUTPUT =====
+    console.log(`\n=== Teacher centre<->prod consistency check ===`);
+    console.log(`staging: ${sName} (${cli.stagingEnv})   prod: ${pName} (${cli.prodEnv})`);
+    console.log(`teacher seat roles: ${TEACHER_SEAT_ROLES.join(", ")}`);
+    console.log(`centre-linked schools (staging, active): ${centreSchools.size}`);
+    console.log();
+    console.log(`FORWARD — staging teacher seats vs prod school_codes (${seats.length} seats):`);
+    console.log(`  ${fwdMatch}  match prod`);
+    console.log(`  ${fwdMismatch.length}  seated at a school prod doesn't assign (incl. extra second seats)`);
+    console.log(`  ${fwdNoProd.length}  teacher has no prod level-1 teacher grant`);
+    console.log();
+    const pop = revOk + revElsewhere.length + revNotSeated.length;
+    console.log(`REVERSE — prod teachers whose school is centre-linked (${pop} teacher-school pairs):`);
+    console.log(`  ${revOk}  seated at the centre for their prod school`);
+    console.log(`  ${revElsewhere.length}  seated, but at a different school`);
+    console.log(`  ${revNotSeated.length}  not seated as a teacher in staging`);
+    console.log();
+    console.log(`Total exception rows written: ${rows.length}`);
+
+    if (cli.verbose) {
+      console.log(`\n--- all exceptions ---`);
+      for (const r of rows) console.log(`  [${r.issue}] ${r.email}  prod=${r.prod_school_code} seat=${r.seat_school_code} ${r.seat_centre}  :: ${r.note}`);
+    } else {
+      // always surface the sharpest bucket inline — useful live. Forward
+      // (seat-based) and reverse (prod-based) catch the same divergence from
+      // both ends, so dedupe by person+schools for a clean read.
+      const sharp = rows.filter((r) => r.issue === "SEAT_SCHOOL_MISMATCH" || r.issue === "PROD_SEATED_DIFFERENT_SCHOOL");
+      const seen = new Set<string>();
+      const lines: string[] = [];
+      for (const r of sharp) {
+        const key = `${r.email}|${r.seat_school_code}|${r.prod_school_code}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        lines.push(`  ${r.email}: staging "${r.seat_school_name || r.seat_centre}" (${r.seat_school_code}) vs prod "${r.prod_school_name}" (${r.prod_school_code})`);
+      }
+      if (lines.length) {
+        console.log(`\n--- wrong-school divergences (staging seat != prod school), ${lines.length} distinct ---`);
+        for (const l of lines) console.log(l);
+      }
+    }
+
+    // CSV
+    const header = ["issue", "email", "prod_school_code", "prod_school_name", "seat_school_code", "seat_school_name", "seat_centre", "seat_role", "note"];
+    const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+    const csv = [header.join(",")]
+      .concat(
+        rows
+          .sort((a, b) => a.issue.localeCompare(b.issue) || a.email.localeCompare(b.email))
+          .map((r) => header.map((h) => esc(String((r as unknown as Record<string, unknown>)[h] ?? ""))).join(","))
+      )
+      .join("\n");
+    const outPath = path.resolve(cli.out);
+    mkdirSync(path.dirname(outPath), { recursive: true });
+    writeFileSync(outPath, csv + "\n");
+    console.log(`\nCSV: ${outPath}`);
+    console.log(`(${rows.length} rows. Contains emails — path is under a gitignored dir.)`);
+  } finally {
+    await staging.end();
+    await prod.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.stack || e.message : e);
+  process.exitCode = 1;
+});

--- a/scripts/clear-seated-school-codes.ts
+++ b/scripts/clear-seated-school-codes.ts
@@ -52,6 +52,20 @@ function printReport(report: ClearSeatedScopeReport): void {
     `${report.mode === "apply" ? "Cleared" : "Would clear"}: ${report.usersCleared}`
   );
 
+  if (report.skippedWouldBeEmpty.length > 0) {
+    console.log(
+      `\n⏭️  SKIPPED (${report.skippedWouldBeEmpty.length}) — seated at school-less (unlinked) centres only.`
+    );
+    console.log(
+      `   Clearing would empty their scope (lockout), so they keep their school_codes. Ops: link the centre, then re-run.`
+    );
+    for (const u of report.skippedWouldBeEmpty) {
+      console.log(
+        `   - ${u.email} (user_id=${u.userId}) keeps: ${u.schoolCodes.join(", ") || u.regions.join(", ")}`
+      );
+    }
+  }
+
   if (report.strandedUsers.length > 0) {
     console.log(
       `\n⚠️  STRANDED (${report.strandedUsers.length}) — seated people whose school_codes are NOT all seat-covered.`

--- a/scripts/import-pm-centres.ts
+++ b/scripts/import-pm-centres.ts
@@ -1,0 +1,221 @@
+/**
+ * Import PM-family centre assignments (apm/pm/spm/ph seats) from the ops
+ * spreadsheet, plus the people + centre lifecycle they imply. Full replacement
+ * of PM-family seats on the in-sheet centres; subject-teacher seats are left
+ * untouched.
+ *
+ * Env-portable: resolves people by email/AF code and centres by name+type, so
+ * the SAME inputs drive staging now and prod later. Inputs are the business-key
+ * CSVs in scripts/data/pm/ (people.csv, centres.csv, seats.csv), produced by
+ * the Python exporter from the sheet + budget DB.
+ *
+ * Dry-run executes every read/write inside a transaction then ROLLBACKs, so the
+ * printed plan is exact (real ids, real diff) but nothing persists.
+ *
+ * Usage:
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/import-pm-centres.ts            # dry-run vs .env.local (staging)
+ *   npx ts-node ... scripts/import-pm-centres.ts -- --apply
+ *   npx ts-node ... scripts/import-pm-centres.ts -- --env=production --apply
+ */
+import * as path from "path";
+import { readFileSync } from "fs";
+import * as dotenv from "dotenv";
+import { parse } from "csv-parse/sync";
+import type { PoolClient } from "pg";
+import { PM_SEAT_ROLES } from "../src/lib/staff-shared";
+
+interface Cli { mode: "dry-run" | "apply"; envFile: string; dataDir: string; verbose: boolean; }
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = { mode: "dry-run", envFile: ".env.local", dataDir: "scripts/data/pm", verbose: false };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--apply") o.mode = "apply";
+    else if (a === "--dry-run") o.mode = "dry-run";
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--env=")) o.envFile = `.env.${a.slice(6)}`;
+    else if (a.startsWith("--env-file=")) o.envFile = a.slice(11);
+    else if (a.startsWith("--data=")) o.dataDir = a.slice(7);
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+
+type PersonRow = { af_code: string; email: string; first_name: string; last_name: string; designation: string; staff_type: string; up_role: string };
+type CentreRow = { action: string; name: string; type_code: string; category_code: string; sub_category_code: string };
+type SeatRow = { centre_name: string; centre_type: string; seat_role: string; af_code: string; email: string };
+
+function loadCsv<T>(file: string): T[] {
+  return parse(readFileSync(file), { columns: true, skip_empty_lines: true, trim: true }) as T[];
+}
+
+const PROGRAM_FOR_TYPE: Record<string, number> = { coe: 1, nodal: 2 };
+
+async function run(client: PoolClient, cli: Cli) {
+  const dir = path.resolve(cli.dataDir);
+  const people = loadCsv<PersonRow>(path.join(dir, "people.csv"));
+  const centresInput = loadCsv<CentreRow>(path.join(dir, "centres.csv"));
+  const seats = loadCsv<SeatRow>(path.join(dir, "seats.csv"));
+
+  const log: string[] = [];
+  const counts = { centresCreated: 0, centresClosed: 0, usersCreated: 0, staffCreated: 0,
+    permsUpserted: 0, seatsAdded: 0, seatsSoftDeleted: 0, seatsKept: 0 };
+
+  // ---- 1. Centre lifecycle ----
+  for (const c of centresInput) {
+    if (c.action === "create") {
+      const found = await client.query<{ id: number }>(
+        `SELECT id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=$2`,
+        [c.name, c.type_code]);
+      if (found.rows.length > 0) { log.push(`centre exists, skip create: ${c.name} (${c.type_code}) id=${found.rows[0].id}`); continue; }
+      const programId = PROGRAM_FOR_TYPE[c.type_code] ?? null;
+      const ins = await client.query<{ id: number }>(
+        `INSERT INTO centres (name, type_code, category_code, sub_category_code, program_id, is_physical, is_active, inserted_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,true,true,now(),now()) RETURNING id`,
+        [c.name, c.type_code, c.category_code || null, c.sub_category_code || null, programId]);
+      counts.centresCreated++; log.push(`CREATE centre ${c.name} (${c.type_code}/${c.category_code}/${c.sub_category_code}) -> id=${ins.rows[0].id}`);
+    } else if (c.action === "close") {
+      const upd = await client.query(
+        `UPDATE centres SET is_active=false, updated_at=now()
+         WHERE lower(name)=lower($1) AND coalesce(type_code,'')=$2 AND is_active=true`, [c.name, c.type_code]);
+      if (upd.rowCount && upd.rowCount > 0) { counts.centresClosed++; log.push(`CLOSE centre ${c.name} (set is_active=false)`); }
+      else log.push(`close no-op (already inactive/not found): ${c.name}`);
+    }
+  }
+
+  // ---- 2. People: user + staff + user_permission ----
+  // program_ids per person = distinct program_id over the centres they're seated on (admins get full set)
+  const seatsByAf = new Map<string, SeatRow[]>();
+  for (const s of seats) { (seatsByAf.get(s.af_code) ?? seatsByAf.set(s.af_code, []).get(s.af_code)!).push(s); }
+
+  const userIdByEmail = new Map<string, number>();
+  for (const p of people) {
+    const email = p.email.toLowerCase();
+    // resolve / create user
+    let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+    let userId: number;
+    if (u.rows.length === 0) {
+      const ins = await client.query<{ id: number }>(
+        `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at) VALUES ($1,$2,$3,now(),now()) RETURNING id`,
+        [p.first_name, p.last_name || null, p.email]);
+      userId = ins.rows[0].id; counts.usersCreated++; log.push(`CREATE user ${p.email} (${p.first_name} ${p.last_name}) -> id=${userId}`);
+    } else if (u.rows.length === 1) { userId = u.rows[0].id; }
+    else { throw new Error(`Ambiguous user email ${p.email} (${u.rows.length} rows)`); }
+    userIdByEmail.set(p.af_code, userId);
+
+    // ensure staff by employee_code
+    const st = await client.query<{ id: number }>(`SELECT id FROM staff WHERE upper(employee_code)=upper($1)`, [p.af_code]);
+    if (st.rows.length === 0) {
+      await client.query(
+        `INSERT INTO staff (user_id, employee_code, staff_type, designation, inserted_at, updated_at) VALUES ($1,$2,$3,$4,now(),now())`,
+        [userId, p.af_code, p.staff_type, p.designation || null]);
+      counts.staffCreated++; log.push(`CREATE staff ${p.af_code} (${p.designation}) user=${userId}`);
+    }
+
+    // program_ids
+    let programIds: number[];
+    if (p.up_role === "admin") programIds = [1, 2, 64];
+    else {
+      const pids = new Set<number>();
+      for (const s of seatsByAf.get(p.af_code) ?? []) {
+        const row = await client.query<{ program_id: number | null }>(
+          `SELECT program_id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=$2`, [s.centre_name, s.centre_type]);
+        if (row.rows[0]?.program_id != null) pids.add(row.rows[0].program_id);
+      }
+      programIds = [...pids].sort((a, b) => a - b);
+    }
+    const level = p.up_role === "admin" ? 3 : 1;
+    // upsert user_permission by email; seat-derived scope -> clear school_codes/regions
+    await client.query(
+      `INSERT INTO user_permission (email, role, level, program_ids, user_id, school_codes, regions, read_only, inserted_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,NULL,NULL,false,now(),now())
+       ON CONFLICT (email) DO UPDATE SET role=EXCLUDED.role, level=EXCLUDED.level, program_ids=EXCLUDED.program_ids,
+         user_id=EXCLUDED.user_id, school_codes=NULL, regions=NULL, updated_at=now(), revoked_at=NULL`,
+      [p.email, p.up_role, level, programIds, userId]);
+    counts.permsUpserted++;
+    if (cli.verbose) log.push(`perm ${p.email} role=${p.up_role} level=${level} programs=[${programIds}] user=${userId}`);
+  }
+
+  // ---- 3. Seats: full replacement of PM-family roles on in-sheet centres ----
+  // resolve desired (centre_id, role, user_id)
+  const centreIdCache = new Map<string, number | null>();
+  async function centreId(name: string, type: string): Promise<number | null> {
+    const key = `${name.toLowerCase()}|${type}`;
+    if (centreIdCache.has(key)) return centreIdCache.get(key)!;
+    const r = await client.query<{ id: number }>(
+      `SELECT id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=$2`, [name, type]);
+    const id = r.rows[0]?.id ?? null; centreIdCache.set(key, id); return id;
+  }
+  const desired = new Set<string>();           // `${centreId}|${role}|${userId}`
+  const inScopeCentres = new Set<number>();
+  const unresolvedSeats: string[] = [];
+  for (const s of seats) {
+    const cid = await centreId(s.centre_name, s.centre_type);
+    const uid = userIdByEmail.get(s.af_code);
+    if (cid == null) { unresolvedSeats.push(`centre ${s.centre_name} (${s.centre_type})`); continue; }
+    if (uid == null) { unresolvedSeats.push(`person ${s.af_code}`); continue; }
+    desired.add(`${cid}|${s.seat_role}|${uid}`);
+    inScopeCentres.add(cid);
+  }
+
+  const centreIds = [...inScopeCentres];
+  const existing = await client.query<{ id: number; centre_id: number; role: string; user_id: number | null }>(
+    `SELECT id, centre_id, role, user_id FROM centre_positions
+     WHERE centre_id = ANY($1::bigint[]) AND role = ANY($2::varchar[]) AND deleted_at IS NULL`,
+    [centreIds, [...PM_SEAT_ROLES]]);
+  const existingActive = new Set<string>();
+  for (const e of existing.rows) {
+    const key = `${e.centre_id}|${e.role}|${e.user_id}`;
+    if (e.user_id != null && desired.has(key)) { existingActive.add(key); counts.seatsKept++; }
+    else {
+      await client.query(`UPDATE centre_positions SET deleted_at=now(), updated_at=now() WHERE id=$1`, [e.id]);
+      counts.seatsSoftDeleted++;
+      if (cli.verbose) log.push(`soft-delete seat id=${e.id} centre=${e.centre_id} role=${e.role} user=${e.user_id}`);
+    }
+  }
+  for (const key of desired) {
+    if (existingActive.has(key)) continue;
+    const [cid, role, uid] = key.split("|");
+    await client.query(
+      `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at) VALUES ($1,$2,$3,now(),now())`,
+      [Number(cid), role, Number(uid)]);
+    counts.seatsAdded++;
+  }
+
+  return { counts, log, unresolvedSeats, inScope: centreIds.length };
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  dotenv.config({ path: cli.envFile, quiet: true });
+  const dbModule = await import("../src/lib/db");
+  const pool = dbModule.default;
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const r = await run(client, cli);
+    if (cli.mode === "apply") { await client.query("COMMIT"); }
+    else { await client.query("ROLLBACK"); }
+
+    console.log(`\nPM centre-assignment import (${cli.mode}) :: env=${cli.envFile}`);
+    console.log(`In-scope centres (PM-family seats managed): ${r.inScope}`);
+    const c = r.counts;
+    console.log(`Centres:   ${c.centresCreated} created, ${c.centresClosed} closed`);
+    console.log(`People:    ${c.usersCreated} users created, ${c.staffCreated} staff created, ${c.permsUpserted} permissions upserted`);
+    console.log(`Seats:     ${c.seatsAdded} added, ${c.seatsSoftDeleted} soft-deleted, ${c.seatsKept} unchanged`);
+    if (r.unresolvedSeats.length) {
+      console.log(`\nUNRESOLVED (${r.unresolvedSeats.length}) — these seats were skipped:`);
+      for (const u of [...new Set(r.unresolvedSeats)]) console.log(`  - ${u}`);
+    }
+    if (cli.verbose) { console.log(`\nDetail:`); for (const l of r.log) console.log(`  ${l}`); }
+    else { console.log(`\n(run with --verbose for per-row detail)`); }
+    if (cli.mode === "dry-run") console.log(`\nDRY-RUN: transaction rolled back, nothing written. Re-run with --apply to persist.`);
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/scripts/import-teacher-perms.ts
+++ b/scripts/import-teacher-perms.ts
@@ -1,0 +1,166 @@
+/**
+ * Mirror teacher user_permission rows from prod into staging, keyed by email.
+ *
+ * Prod is the source of truth for teacher (school/region) access; staging is
+ * moving to the centre-seat model for PMs but teachers stay as user_permission
+ * access grants. This upserts the prod teacher rows (exported to
+ * scripts/data/pm/teacher-permissions.csv via the avanti-db MCP) into the target
+ * DB by email — additive/update only. It does NOT delete staging teacher rows
+ * that are absent from prod; those are reported as "extras" for a human to judge.
+ *
+ * The PM people are excluded at export time (notably shahnwaj@, a teacher in
+ * prod but an APM on staging) so this never clobbers the PM import.
+ *
+ * Dry-run executes inside a transaction then ROLLBACKs (exact plan, no writes).
+ *
+ * Usage:
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/import-teacher-perms.ts            # dry-run vs .env.local
+ *   npx ts-node ... scripts/import-teacher-perms.ts --apply
+ *   npx ts-node ... scripts/import-teacher-perms.ts --env=production --apply   # (later, gated)
+ */
+import * as path from "path";
+import { readFileSync } from "fs";
+import * as dotenv from "dotenv";
+import type { PoolClient } from "pg";
+
+interface Cli { mode: "dry-run" | "apply"; envFile: string; file: string; verbose: boolean; }
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = { mode: "dry-run", envFile: ".env.local", file: "scripts/data/pm/teacher-permissions.csv", verbose: false };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--apply") o.mode = "apply";
+    else if (a === "--dry-run") o.mode = "dry-run";
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--env=")) o.envFile = `.env.${a.slice(6)}`;
+    else if (a.startsWith("--env-file=")) o.envFile = a.slice(11);
+    else if (a.startsWith("--file=")) o.file = a.slice(7);
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+
+interface TeacherRow {
+  email: string;
+  level: number;
+  schoolCodes: string[] | null;
+  regions: string[] | null;
+  programIds: number[] | null;
+  readOnly: boolean;
+  fullName: string | null;
+}
+
+function splitArr(v: string): string[] | null {
+  const t = v.trim();
+  if (!t) return null;
+  return t.split(";").map((x) => x.trim()).filter(Boolean);
+}
+
+function parseCsv(file: string): TeacherRow[] {
+  const lines = readFileSync(file, "utf8").split("\n").filter((l) => l.trim().length > 0);
+  const rows: TeacherRow[] = [];
+  for (const line of lines.slice(1)) {
+    // pipe-delimited; full_name is the last field and may contain spaces but no pipe
+    const f = line.split("|");
+    if (f.length < 7) throw new Error(`Malformed row: ${line}`);
+    const programs = splitArr(f[4]);
+    rows.push({
+      email: f[0].trim().toLowerCase(),
+      level: Number(f[1]),
+      schoolCodes: splitArr(f[2]),
+      regions: splitArr(f[3]),
+      programIds: programs ? programs.map(Number) : null,
+      readOnly: f[5].trim() === "true",
+      fullName: f[6].trim() || null,
+    });
+  }
+  return rows;
+}
+
+async function run(client: PoolClient, cli: Cli) {
+  const rows = parseCsv(path.resolve(cli.file));
+  const counts = { inserted: 0, updated: 0, matchedUser: 0, noUser: 0 };
+  const noUser: string[] = [];
+
+  for (const r of rows) {
+    const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [r.email]);
+    const userId = u.rows[0]?.id ?? null;
+    if (userId != null) counts.matchedUser++;
+    else { counts.noUser++; noUser.push(r.email); }
+
+    // Match case-INSENSITIVELY (getUserPermission looks up by LOWER(email)), but
+    // the unique constraint on email is case-SENSITIVE — so an ON CONFLICT(email)
+    // upsert with a normalized email would create a second row when the stored
+    // email differs only in case (e.g. "Abhishekpachauri@…"). Look up by
+    // lower(email), update that row in place (normalizing its email to lower), and
+    // only insert when truly absent. This keeps it dup-safe on prod too.
+    const existing = await client.query<{ id: number }>(
+      `SELECT id FROM user_permission WHERE lower(email)=$1 ORDER BY id`, [r.email]
+    );
+    if (existing.rows.length > 1) {
+      throw new Error(`Case-variant duplicate rows for ${r.email}: ids ${existing.rows.map((x) => x.id).join(", ")} — dedupe first`);
+    }
+    if (existing.rows.length === 1) {
+      await client.query(
+        `UPDATE user_permission SET email=$1, role='teacher', level=$2, school_codes=$3, regions=$4,
+           program_ids=$5, read_only=$6, full_name=$7, user_id=$8, revoked_at=NULL, updated_at=now() WHERE id=$9`,
+        [r.email, r.level, r.schoolCodes, r.regions, r.programIds, r.readOnly, r.fullName, userId, existing.rows[0].id]
+      );
+      counts.updated++;
+    } else {
+      await client.query(
+        `INSERT INTO user_permission
+           (email, role, level, school_codes, regions, program_ids, read_only, full_name, user_id, inserted_at, updated_at)
+         VALUES ($1,'teacher',$2,$3,$4,$5,$6,$7,$8,now(),now())`,
+        [r.email, r.level, r.schoolCodes, r.regions, r.programIds, r.readOnly, r.fullName, userId]
+      );
+      counts.inserted++;
+    }
+    if (cli.verbose) console.log(`  upsert ${r.email} level=${r.level} schools=[${r.schoolCodes ?? ""}] regions=[${r.regions ?? ""}] programs=[${r.programIds ?? ""}] user=${userId ?? "—"}`);
+  }
+
+  // Staging teacher rows NOT in the prod set — reported, never deleted.
+  const csvEmails = rows.map((r) => r.email);
+  const extras = await client.query<{ email: string }>(
+    `SELECT lower(email) AS email FROM user_permission
+     WHERE role='teacher' AND lower(email) <> ALL($1::text[]) ORDER BY email`,
+    [csvEmails]
+  );
+
+  return { counts, noUser, extras: extras.rows.map((e) => e.email) };
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  dotenv.config({ path: cli.envFile, quiet: true });
+  const dbModule = await import("../src/lib/db");
+  const pool = dbModule.default;
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const r = await run(client, cli);
+    if (cli.mode === "apply") await client.query("COMMIT");
+    else await client.query("ROLLBACK");
+
+    console.log(`\nTeacher user_permission mirror (${cli.mode}) :: env=${cli.envFile}`);
+    console.log(`Rows: ${r.counts.inserted} inserted, ${r.counts.updated} updated`);
+    console.log(`User link: ${r.counts.matchedUser} matched a staging user, ${r.counts.noUser} keyed by email only (user_id NULL)`);
+    if (r.noUser.length && cli.verbose) {
+      console.log(`\nNo staging user (kept email-only):`);
+      for (const e of r.noUser) console.log(`  - ${e}`);
+    }
+    if (r.extras.length) {
+      console.log(`\nStaging teacher rows NOT in prod (${r.extras.length}) — left untouched, review manually:`);
+      for (const e of r.extras) console.log(`  - ${e}`);
+    }
+    if (cli.mode === "dry-run") console.log(`\nDRY-RUN: transaction rolled back, nothing written. Re-run with --apply to persist.`);
+    else console.log(`\nAPPLIED.`);
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/scripts/mirror-seats-staging-to-prod.ts
+++ b/scripts/mirror-seats-staging-to-prod.ts
@@ -1,0 +1,386 @@
+/**
+ * Faithful MIRROR of staging's centre seating into another environment (prod),
+ * by BUSINESS KEY — the promotion step for the centre-seat model.
+ *
+ * Why this exists (vs seat-pending-teachers): that script RE-DERIVES a teacher's
+ * centre from school_codes ∩ program, so it cannot reproduce a staging seat that
+ * ops hand-placed at a school the person's school_codes don't contain (e.g. the
+ * EMRS Bhopal teachers). This script instead COPIES staging's actual seats, so
+ * "assume staging is correct" holds exactly. Re-derivation is lossy; copy is not.
+ *
+ * What it does, in ONE transaction against the TARGET:
+ *   1. Centres   — resolve each seated centre by (name,type,program); link its
+ *                  school if unlinked; CREATE if truly absent. A name that exists
+ *                  under a DIFFERENT program is NOT auto-created — flagged as
+ *                  NEEDS-DECISION and its seats skipped (the Meritorious case).
+ *   2. Users     — resolve by email; reuse a dot-variant if present (flagged);
+ *                  CREATE only if genuinely absent (flagged).
+ *   3. Teacher/  — ensure the teacher/staff row each seated person has in staging
+ *      staff       (so the seat renders + is editable). subject_id is copied only
+ *                  if that id exists in the target subject table, else NULL+flag.
+ *   4. Seats     — FULL REPLACEMENT within the in-scope programs: insert staging's
+ *                  seats, soft-delete target seats (at prog-P centres) staging no
+ *                  longer has. Keyed by (centre,role,user).
+ *   5. Scope     — clear user_permission.school_codes/regions for every user now
+ *      clear       holding ≥1 seat at a LINKED centre (the seat-as-source-of-truth
+ *                  invariant). Guarded: a person whose seats are all at unlinked
+ *                  centres is SKIPPED (clearing would empty their scope). Mirrors
+ *                  src/lib/clear-seated-scope.ts, run inside this same txn.
+ *
+ * It does NOT set user_permission role/level/program_ids — that is owned by
+ * import-pm-centres.ts (PMs) + import-teacher-perms.ts (teachers), which the
+ * promotion runs first. A seated person with NO target user_permission row is
+ * FLAGGED (a seat without a permission row grants no access), never invented.
+ *
+ * Read-only on SOURCE. TARGET writes are wrapped in a transaction; default is
+ * DRY-RUN (rolled back, exact plan printed). --apply commits. Refuses to run if
+ * source and target point at the same database.
+ *
+ * After --apply, `npm run pm:promodiff` (check-promotion-school-diff.ts) is the
+ * parity check: a faithful mirror should report 0 seated changes vs staging.
+ *
+ * Usage (from worktree root):
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/mirror-seats-staging-to-prod.ts            # dry-run: staging -> prod
+ *   npx ts-node ... scripts/mirror-seats-staging-to-prod.ts -- --apply                                        # commit
+ *   options: --source-env=.env.local  --target-env=.env.production  --programs=1,2  --verbose
+ */
+import { readFileSync, existsSync } from "fs";
+import * as dotenv from "dotenv";
+import { Pool, PoolClient } from "pg";
+
+interface Cli { mode: "dry-run" | "apply"; sourceEnv: string; targetEnv: string; programs: number[]; verbose: boolean; }
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = { mode: "dry-run", sourceEnv: ".env.local", targetEnv: ".env.production", programs: [1, 2], verbose: false };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--apply") o.mode = "apply";
+    else if (a === "--dry-run") o.mode = "dry-run";
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--source-env=")) o.sourceEnv = a.slice(13);
+    else if (a.startsWith("--target-env=")) o.targetEnv = a.slice(13);
+    else if (a.startsWith("--programs=")) o.programs = a.slice(11).split(",").map((s) => parseInt(s.trim(), 10)).filter((n) => !Number.isNaN(n));
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+
+function poolFromEnvFile(envFile: string, label: string): Pool {
+  if (!existsSync(envFile)) {
+    throw new Error(`${label} env file not found: ${envFile}` +
+      (envFile.includes("production") ? `\n  -> cp ~/af/af_lms/.env.production .env.production (gitignored)` : ""));
+  }
+  const env = dotenv.parse(readFileSync(envFile));
+  return new Pool({
+    host: env.DATABASE_HOST, port: parseInt(env.DATABASE_PORT || "5432"),
+    user: env.DATABASE_USER, password: env.DATABASE_PASSWORD, database: env.DATABASE_NAME,
+    ssl: env.DATABASE_SSL === "false" ? false : { rejectUnauthorized: false },
+    max: 4, connectionTimeoutMillis: 8000, statement_timeout: 60000,
+  });
+}
+
+const dotKey = (email: string): string => {
+  const [l, d] = email.toLowerCase().split("@");
+  return d ? `${l.replace(/\./g, "")}@${d}` : email.toLowerCase();
+};
+const centreKey = (name: string, type: string | null, program: number | null) =>
+  `${name.toLowerCase().trim()}|${type ?? ""}|${program ?? ""}`;
+
+// ---- source shapes ----
+type SourceSeat = {
+  email: string; first_name: string | null; last_name: string | null;
+  centre_name: string; type_code: string | null; category_code: string | null;
+  sub_category_code: string | null; program_id: number | null;
+  school_code: string | null; school_name: string | null;
+  role: string;
+  is_af_teacher: boolean | null; subject_id: number | null;
+  employee_code: string | null; staff_type: string | null; designation: string | null;
+};
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const source = poolFromEnvFile(cli.sourceEnv, "SOURCE");
+  const target = poolFromEnvFile(cli.targetEnv, "TARGET");
+
+  const flags: Record<string, string[]> = {
+    centresCreated: [], centresLinked: [], centreNeedsDecision: [], centreMissingSchool: [],
+    usersCreated: [], usersDotVariant: [], teacherRows: [], staffRows: [], subjectDropped: [],
+    seatsUnresolved: [], permMissing: [],
+  };
+  const counts = {
+    sourceSeats: 0, desiredSeats: 0, seatsAdded: 0, seatsSoftDeleted: 0, seatsKept: 0,
+    centresCreated: 0, centresLinked: 0, usersCreated: 0, teacherRows: 0, staffRows: 0,
+    permLinked: 0, scopeUsersCleared: 0,
+  };
+
+  let client: PoolClient | null = null;
+  try {
+    // --- guard: never let source == target ---
+    const sDb = (await source.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+    const tDb = (await target.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+    if (sDb === tDb) throw new Error(`SOURCE and TARGET are the same database (${sDb}). Refusing to mirror onto itself.`);
+
+    // ===== 1. READ source seat truth (read-only) =====
+    const seatRows = (await source.query<SourceSeat>(
+      `SELECT lower(u.email) email, u.first_name, u.last_name,
+              c.name centre_name, c.type_code, c.category_code, c.sub_category_code, c.program_id,
+              sc.code school_code, sc.name school_name,
+              cp.role,
+              t.is_af_teacher, t.subject_id,
+              stf.employee_code, stf.staff_type, stf.designation
+       FROM centre_positions cp
+       JOIN centres c ON c.id = cp.centre_id
+       LEFT JOIN school sc ON sc.id = c.school_id
+       JOIN "user" u ON u.id = cp.user_id
+       LEFT JOIN teacher t ON t.user_id = u.id AND t.is_af_teacher = true
+       LEFT JOIN staff stf ON stf.user_id = u.id
+       WHERE cp.deleted_at IS NULL AND c.program_id = ANY($1::int[])`,
+      [cli.programs]
+    )).rows;
+
+    // dedupe seat tuples (a LEFT JOIN to teacher/staff can multiply rows); keep person attrs from first
+    const seatByTuple = new Map<string, SourceSeat>();
+    for (const r of seatRows) {
+      const k = `${r.email}|${centreKey(r.centre_name, r.type_code, r.program_id)}|${r.role}`;
+      if (!seatByTuple.has(k)) seatByTuple.set(k, r);
+    }
+    const seats = [...seatByTuple.values()];
+    counts.sourceSeats = seats.length;
+
+    // distinct people + distinct centres referenced
+    const people = new Map<string, SourceSeat>();
+    const centres = new Map<string, SourceSeat>();
+    for (const s of seats) {
+      if (!people.has(s.email)) people.set(s.email, s);
+      const ck = centreKey(s.centre_name, s.type_code, s.program_id);
+      if (!centres.has(ck)) centres.set(ck, s);
+    }
+
+    // ===== open TARGET transaction =====
+    client = await target.connect();
+    await client.query("BEGIN");
+
+    // target subject ids (for safe subject_id copy)
+    const targetSubjectIds = new Set(
+      (await client.query<{ id: number }>(`SELECT id FROM subject`)).rows.map((r) => r.id)
+    );
+
+    // ----- 1. CENTRES: resolve / link / create -----
+    const centreIdByKey = new Map<string, number | null>(); // null = needs-decision (skip its seats)
+    for (const [ck, c] of centres) {
+      // exact match by name+type+program
+      let found = await client.query<{ id: number; school_id: number | null }>(
+        `SELECT id, school_id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=coalesce($2,'') AND program_id IS NOT DISTINCT FROM $3`,
+        [c.centre_name, c.type_code, c.program_id]
+      );
+      if (found.rows.length === 1) {
+        const cid = found.rows[0].id;
+        centreIdByKey.set(ck, cid);
+        // link school if source has one and target centre is unlinked
+        if (found.rows[0].school_id == null && c.school_code) {
+          const sch = await client.query<{ id: number }>(`SELECT id FROM school WHERE code=$1`, [c.school_code]);
+          if (sch.rows[0]) {
+            await client.query(`UPDATE centres SET school_id=$1, updated_at=now() WHERE id=$2`, [sch.rows[0].id, cid]);
+            counts.centresLinked++; flags.centresLinked.push(`${c.centre_name} (${c.type_code}) -> school ${c.school_code}`);
+          } else flags.centreMissingSchool.push(`${c.centre_name}: school code ${c.school_code} absent in target`);
+        }
+        continue;
+      }
+      if (found.rows.length > 1) { centreIdByKey.set(ck, null); flags.centreNeedsDecision.push(`${c.centre_name} (${c.type_code}, prog${c.program_id}): ${found.rows.length} matches in target — ambiguous`); continue; }
+
+      // no exact match: does the name+type exist under a DIFFERENT program? -> needs decision, don't guess
+      const softer = await client.query<{ id: number; program_id: number | null }>(
+        `SELECT id, program_id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=coalesce($2,'')`,
+        [c.centre_name, c.type_code]
+      );
+      if (softer.rows.length > 0) {
+        centreIdByKey.set(ck, null);
+        flags.centreNeedsDecision.push(`${c.centre_name} (${c.type_code}): source prog${c.program_id} but target has it under prog${softer.rows.map((r) => r.program_id).join("/")} — resolve manually`);
+        continue;
+      }
+
+      // truly absent -> create (link school if resolvable)
+      let schoolId: number | null = null;
+      if (c.school_code) {
+        const sch = await client.query<{ id: number }>(`SELECT id FROM school WHERE code=$1`, [c.school_code]);
+        schoolId = sch.rows[0]?.id ?? null;
+        if (schoolId == null) flags.centreMissingSchool.push(`${c.centre_name}: school code ${c.school_code} absent in target — created UNLINKED`);
+      }
+      const ins = await client.query<{ id: number }>(
+        `INSERT INTO centres (name, school_id, type_code, category_code, sub_category_code, program_id, is_physical, is_active, inserted_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,true,true,now(),now()) RETURNING id`,
+        [c.centre_name, schoolId, c.type_code, c.category_code, c.sub_category_code, c.program_id]
+      );
+      centreIdByKey.set(ck, ins.rows[0].id);
+      counts.centresCreated++; flags.centresCreated.push(`${c.centre_name} (${c.type_code}, prog${c.program_id})${schoolId ? ` -> school ${c.school_code}` : " UNLINKED"}`);
+    }
+
+    // ----- 2. USERS: resolve / reuse dot-variant / create -----
+    const userIdByEmail = new Map<string, number>();
+    for (const [email, p] of people) {
+      let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+      if (u.rows.length === 1) { userIdByEmail.set(email, u.rows[0].id); continue; }
+      if (u.rows.length > 1) throw new Error(`Ambiguous target user email ${email} (${u.rows.length} rows)`);
+      // try dot-variant
+      const variants = await client.query<{ id: number; email: string }>(
+        `SELECT id, lower(email) email FROM "user" WHERE replace(lower(split_part(email,'@',1)),'.','')||'@'||lower(split_part(email,'@',2)) = $1`,
+        [dotKey(email)]
+      );
+      if (variants.rows.length === 1) {
+        userIdByEmail.set(email, variants.rows[0].id);
+        flags.usersDotVariant.push(`${email} -> reused target ${variants.rows[0].email}`);
+        continue;
+      }
+      // genuinely new
+      const ins = await client.query<{ id: number }>(
+        `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at) VALUES ($1,$2,$3,now(),now()) RETURNING id`,
+        [p.first_name, p.last_name, p.email]
+      );
+      userIdByEmail.set(email, ins.rows[0].id);
+      counts.usersCreated++; flags.usersCreated.push(p.email);
+    }
+
+    // ----- 3. TEACHER / STAFF rows + perm-row presence flag -----
+    for (const [email, p] of people) {
+      const uid = userIdByEmail.get(email)!;
+      // LINK the existing user_permission row to this user. In the old (prod) model
+      // user_permission.user_id is mostly NULL; without this link both resolveScope
+      // and the seat-as-source-of-truth clear (which join seats by user_id) can't
+      // see the seat — so the seat would be orphaned and the scope clear a no-op.
+      // This does NOT touch role/level/program_ids (owned by the perm importers).
+      const linked = await client.query(
+        `UPDATE user_permission SET user_id=$1, updated_at=now()
+         WHERE lower(email)=$2 AND revoked_at IS NULL AND user_id IS DISTINCT FROM $1`, [uid, email]);
+      counts.permLinked += linked.rowCount ?? 0;
+      // flag: a seat with NO user_permission row grants no access (perms owned by the perm importers)
+      const perm = await client.query<{ c: number }>(`SELECT count(*)::int c FROM user_permission WHERE lower(email)=$1 AND revoked_at IS NULL`, [email]);
+      if ((perm.rows[0]?.c ?? 0) === 0) flags.permMissing.push(email);
+
+      if (p.is_af_teacher) {
+        const tRow = await client.query<{ id: number; subject_id: number | null }>(`SELECT id, subject_id FROM teacher WHERE user_id=$1 AND is_af_teacher=true`, [uid]);
+        const subj = p.subject_id != null && targetSubjectIds.has(p.subject_id) ? p.subject_id : null;
+        if (p.subject_id != null && subj == null) flags.subjectDropped.push(`${email}: subject_id ${p.subject_id} absent in target -> NULL`);
+        if (tRow.rows.length === 0) {
+          await client.query(`INSERT INTO teacher (user_id, is_af_teacher, subject_id, inserted_at, updated_at) VALUES ($1,true,$2,now(),now())`, [uid, subj]);
+          counts.teacherRows++; flags.teacherRows.push(`${email} (subject ${subj ?? "—"})`);
+        }
+      }
+      if (p.employee_code) {
+        const st = await client.query<{ id: number }>(`SELECT id FROM staff WHERE upper(employee_code)=upper($1)`, [p.employee_code]);
+        if (st.rows.length === 0) {
+          await client.query(`INSERT INTO staff (user_id, employee_code, staff_type, designation, inserted_at, updated_at) VALUES ($1,$2,$3,$4,now(),now())`,
+            [uid, p.employee_code, p.staff_type, p.designation]);
+          counts.staffRows++; flags.staffRows.push(`${email} (${p.employee_code})`);
+        }
+      }
+    }
+
+    // ----- 4. SEATS: full replacement within programs P -----
+    const desired = new Set<string>(); // centreId|role|userId
+    for (const s of seats) {
+      const cid = centreIdByKey.get(centreKey(s.centre_name, s.type_code, s.program_id));
+      const uid = userIdByEmail.get(s.email);
+      if (cid == null) { flags.seatsUnresolved.push(`${s.email} @ ${s.centre_name} (${s.role}) — centre needs decision`); continue; }
+      if (uid == null) { flags.seatsUnresolved.push(`${s.email} @ ${s.centre_name} (${s.role}) — user unresolved`); continue; }
+      desired.add(`${cid}|${s.role}|${uid}`);
+    }
+    counts.desiredSeats = desired.size;
+
+    // existing active seats at ALL target centres in programs P (so dropped seats are removed)
+    const existing = (await client.query<{ id: number; centre_id: number; role: string; user_id: number | null }>(
+      `SELECT cp.id, cp.centre_id, cp.role, cp.user_id
+       FROM centre_positions cp JOIN centres c ON c.id = cp.centre_id
+       WHERE cp.deleted_at IS NULL AND c.program_id = ANY($1::int[])`,
+      [cli.programs]
+    )).rows;
+    const existingActive = new Set<string>();
+    for (const e of existing) {
+      const k = `${e.centre_id}|${e.role}|${e.user_id}`;
+      if (e.user_id != null && desired.has(k)) { existingActive.add(k); counts.seatsKept++; }
+      else { await client.query(`UPDATE centre_positions SET deleted_at=now(), updated_at=now() WHERE id=$1`, [e.id]); counts.seatsSoftDeleted++; }
+    }
+    for (const k of desired) {
+      if (existingActive.has(k)) continue;
+      const [cid, role, uid] = k.split("|");
+      await client.query(`INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at) VALUES ($1,$2,$3,now(),now())`,
+        [Number(cid), role, Number(uid)]);
+      counts.seatsAdded++;
+    }
+
+    // ----- 5. SCOPE CLEAR (seat-as-source-of-truth) — guarded, mirrors clear-seated-scope.ts -----
+    // report stranded / skipped BEFORE the update (within this txn, post-seat state)
+    const seatedScope = (await client.query<{ email: string; school_codes: string[] | null; regions: string[] | null; seat_school_codes: string[] | null }>(
+      `SELECT lower(up.email) email, up.school_codes, up.regions,
+              array_agg(DISTINCT s.code) FILTER (WHERE s.code IS NOT NULL) seat_school_codes
+       FROM user_permission up
+       JOIN centre_positions cp ON cp.user_id = up.user_id AND cp.deleted_at IS NULL
+       LEFT JOIN centres c ON c.id = cp.centre_id
+       LEFT JOIN school s ON s.id = c.school_id
+       WHERE up.revoked_at IS NULL
+       GROUP BY up.user_id, up.email, up.school_codes, up.regions`
+    )).rows;
+    const stranded: string[] = [];
+    const skippedWouldBeEmpty: string[] = [];
+    for (const r of seatedScope) {
+      const sc = r.school_codes ?? [], rg = r.regions ?? [], seat = new Set(r.seat_school_codes ?? []);
+      if (sc.length === 0 && rg.length === 0) continue;
+      if ((r.seat_school_codes ?? []).length === 0) { skippedWouldBeEmpty.push(r.email); continue; }
+      const uncovered = sc.filter((c) => !seat.has(c));
+      if (uncovered.length) stranded.push(`${r.email}: loses ${uncovered.join(",")}`);
+    }
+    const cleared = await client.query<{ user_id: number }>(
+      `UPDATE user_permission up SET school_codes=NULL, regions=NULL, updated_at=now()
+       WHERE up.revoked_at IS NULL AND (up.school_codes IS NOT NULL OR up.regions IS NOT NULL)
+         AND EXISTS (SELECT 1 FROM centre_positions cp JOIN centres c ON c.id=cp.centre_id
+                     WHERE cp.user_id=up.user_id AND cp.deleted_at IS NULL AND c.school_id IS NOT NULL)
+       RETURNING up.user_id`
+    );
+    counts.scopeUsersCleared = cleared.rowCount ?? 0;
+
+    // ===== commit / rollback =====
+    if (cli.mode === "apply") await client.query("COMMIT");
+    else await client.query("ROLLBACK");
+
+    // ===== report =====
+    const c = counts;
+    console.log(`\n=== Mirror centre seats: ${sDb} (source) -> ${tDb} (target) [${cli.mode}] ===`);
+    console.log(`programs: ${cli.programs.join(",")}`);
+    console.log(`source seats: ${c.sourceSeats}   desired (resolved): ${c.desiredSeats}`);
+    console.log(`\nCentres:  ${c.centresCreated} created, ${c.centresLinked} school-linked`);
+    console.log(`Users:    ${c.usersCreated} created, ${flags.usersDotVariant.length} dot-variant reused`);
+    console.log(`Rows:     ${c.teacherRows} teacher, ${c.staffRows} staff created`);
+    console.log(`Perms:    ${c.permLinked} user_permission rows linked to a user (user_id backfill)`);
+    console.log(`Seats:    ${c.seatsAdded} added, ${c.seatsSoftDeleted} soft-deleted, ${c.seatsKept} unchanged`);
+    console.log(`Scope:    ${c.scopeUsersCleared} user_permission rows cleared (school_codes/regions -> NULL)`);
+
+    const section = (title: string, items: string[]) => { if (items.length) { console.log(`\n${title} (${items.length}):`); for (const i of items) console.log(`  - ${i}`); } };
+    console.log(`\n----- NEEDS DECISION / FLAGS -----`);
+    section("⚠ centres NEEDS-DECISION (seats skipped)", flags.centreNeedsDecision);
+    section("⚠ centres missing school link", flags.centreMissingSchool);
+    section("⚠ seats UNRESOLVED (skipped)", flags.seatsUnresolved);
+    section("⚠ seated users with NO active user_permission row (no access until perms imported)", flags.permMissing);
+    section("⚠ scope-clear: users seated only at UNLINKED centres (skipped, keep explicit scope)", skippedWouldBeEmpty);
+    section("⚠ scope-clear: STRANDED (cleared but a school_code no seat covers — access lost)", stranded);
+    section("· subject_id dropped to NULL (absent in target)", flags.subjectDropped);
+    if (cli.verbose) {
+      section("centres created", flags.centresCreated);
+      section("centres linked", flags.centresLinked);
+      section("users created", flags.usersCreated);
+      section("users dot-variant reused", flags.usersDotVariant);
+      section("teacher rows created", flags.teacherRows);
+      section("staff rows created", flags.staffRows);
+    } else {
+      console.log(`\n(run with --verbose for full created/linked lists)`);
+    }
+    if (cli.mode === "dry-run") console.log(`\nDRY-RUN: target transaction rolled back, nothing written. Re-run with --apply to persist.`);
+    else console.log(`\nAPPLIED. Run the parity check next:  npm run pm:promodiff`);
+  } catch (e) {
+    if (client) await client.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    if (client) client.release();
+    await source.end();
+    await target.end();
+  }
+}
+
+main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/scripts/seat-pending-teachers.ts
+++ b/scripts/seat-pending-teachers.ts
@@ -1,0 +1,192 @@
+/**
+ * Seat "pending" teachers (level-1 user_permission teacher grants with no centre
+ * seat) onto their centre, so they show under the centre in the staff UI instead
+ * of "No Centre assigned".
+ *
+ * Centre is resolved by school_codes ∩ program_ids — the same rule PM seats use:
+ * a teacher on program 1 (CoE) at a multi-centre school lands on that school's
+ * CoE centre, program 2 (Nodal) on the Nodal centre. A school that resolves to
+ * exactly one centre (per school) is assigned; 0 (non-centre / NVS school) is
+ * left alone; >1 same-program centres at one school is ambiguous and skipped.
+ *
+ * Subject is left blank: each seat gets the `subject_tbd` placeholder role and a
+ * teacher record with subject_id NULL, for ops to correct in the staff UI. To be
+ * editable there the person must be a real `teacher` row (the UI can't edit
+ * pending rows), so this creates user + teacher + seat as needed.
+ *
+ * Dry-run executes in a transaction then ROLLBACKs (exact plan, nothing written).
+ *
+ * Usage:
+ *   npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/seat-pending-teachers.ts            # dry-run vs .env.local
+ *   npx ts-node ... scripts/seat-pending-teachers.ts --apply
+ */
+import * as dotenv from "dotenv";
+import type { PoolClient } from "pg";
+
+interface Cli { mode: "dry-run" | "apply"; envFile: string; verbose: boolean; }
+function parseArgs(argv: string[]): Cli {
+  const o: Cli = { mode: "dry-run", envFile: ".env.local", verbose: false };
+  for (const a of argv) {
+    if (a === "--") continue;
+    else if (a === "--apply") o.mode = "apply";
+    else if (a === "--dry-run") o.mode = "dry-run";
+    else if (a === "--verbose" || a === "-v") o.verbose = true;
+    else if (a.startsWith("--env=")) o.envFile = `.env.${a.slice(6)}`;
+    else if (a.startsWith("--env-file=")) o.envFile = a.slice(11);
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return o;
+}
+
+interface Pending {
+  email: string;
+  user_id: number | null;
+  full_name: string | null;
+  school_codes: string[];
+  program_ids: number[] | null;
+}
+
+async function run(client: PoolClient) {
+  // Level-1 teacher grants with school_codes and no active centre seat.
+  const pending = await client.query<Pending>(
+    `SELECT lower(up.email) AS email, up.user_id, up.full_name, up.school_codes, up.program_ids
+     FROM user_permission up
+     WHERE up.role = 'teacher' AND up.revoked_at IS NULL
+       AND up.school_codes IS NOT NULL AND cardinality(up.school_codes) > 0
+       AND NOT EXISTS (
+         SELECT 1 FROM centre_positions cp
+         WHERE cp.user_id = up.user_id AND cp.deleted_at IS NULL
+       )
+     ORDER BY lower(up.email)`
+  );
+
+  const counts = { considered: pending.rows.length, seatedTeachers: 0, seatsCreated: 0,
+    usersCreated: 0, teacherRowsCreated: 0, skippedNoCentre: 0, skippedAmbiguous: 0 };
+  const perCentre = new Map<string, number>();
+  const ambiguous: string[] = [];
+  const noCentre: string[] = [];
+  const assignmentsSample: string[] = [];
+
+  for (const p of pending.rows) {
+    const hasPrograms = (p.program_ids?.length ?? 0) > 0;
+    // candidate centres at the teacher's schools, narrowed by program
+    const cand = await client.query<{ school_code: string; centre_id: number; centre_name: string }>(
+      `SELECT s.code AS school_code, c.id AS centre_id, c.name AS centre_name
+       FROM centres c JOIN school s ON s.id = c.school_id
+       WHERE s.code = ANY($1) AND c.is_active = true
+         AND ($2::int[] IS NULL OR c.program_id IS NULL OR c.program_id = ANY($2))
+       ORDER BY s.code, c.id`,
+      [p.school_codes, hasPrograms ? p.program_ids : null]
+    );
+
+    // group by school; one unambiguous centre per school
+    const bySchool = new Map<string, { id: number; name: string }[]>();
+    for (const r of cand.rows) {
+      (bySchool.get(r.school_code) ?? bySchool.set(r.school_code, []).get(r.school_code)!)
+        .push({ id: r.centre_id, name: r.centre_name });
+    }
+    const targets: { id: number; name: string }[] = [];
+    let sawAmbiguous = false;
+    for (const [school, centresAtSchool] of bySchool) {
+      if (centresAtSchool.length === 1) targets.push(centresAtSchool[0]);
+      else if (centresAtSchool.length > 1) {
+        sawAmbiguous = true;
+        ambiguous.push(`${p.email} @ school ${school}: ${centresAtSchool.map((c) => c.name).join(" / ")}`);
+      }
+    }
+
+    if (targets.length === 0) {
+      if (sawAmbiguous) counts.skippedAmbiguous++;
+      else { counts.skippedNoCentre++; noCentre.push(p.email); }
+      continue;
+    }
+
+    // ensure user
+    let userId = p.user_id;
+    if (userId == null) {
+      const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [p.email]);
+      if (u.rows[0]) userId = u.rows[0].id;
+      else {
+        const name = (p.full_name ?? "").trim();
+        const tokens = name ? name.split(/\s+/) : [];
+        const ins = await client.query<{ id: number }>(
+          `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at)
+           VALUES ($1,$2,$3,now(),now()) RETURNING id`,
+          [tokens[0] ?? null, tokens.length > 1 ? tokens.slice(1).join(" ") : null, p.email]
+        );
+        userId = ins.rows[0].id; counts.usersCreated++;
+      }
+      await client.query(`UPDATE user_permission SET user_id=$1, updated_at=now() WHERE lower(email)=$2`, [userId, p.email]);
+    }
+
+    // ensure a teacher record (editable in the staff UI; subject blank)
+    const tRow = await client.query<{ id: number }>(`SELECT id FROM teacher WHERE user_id=$1 AND is_af_teacher=true`, [userId]);
+    if (tRow.rows.length === 0) {
+      await client.query(
+        `INSERT INTO teacher (user_id, is_af_teacher, subject_id, inserted_at, updated_at)
+         VALUES ($1, true, NULL, now(), now())`,
+        [userId]
+      );
+      counts.teacherRowsCreated++;
+    }
+
+    // seat at each resolved centre (skip if already seated there)
+    let seatedHere = false;
+    for (const t of targets) {
+      const dup = await client.query<{ id: number }>(
+        `SELECT id FROM centre_positions WHERE centre_id=$1 AND user_id=$2 AND deleted_at IS NULL`,
+        [t.id, userId]
+      );
+      if (dup.rows.length > 0) continue;
+      await client.query(
+        `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+         VALUES ($1,'subject_tbd',$2,now(),now())`,
+        [t.id, userId]
+      );
+      counts.seatsCreated++; seatedHere = true;
+      perCentre.set(t.name, (perCentre.get(t.name) ?? 0) + 1);
+      if (assignmentsSample.length < 12) assignmentsSample.push(`${p.email} -> ${t.name}`);
+    }
+    if (seatedHere) counts.seatedTeachers++;
+  }
+
+  return { counts, perCentre, ambiguous, noCentre, assignmentsSample };
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  dotenv.config({ path: cli.envFile, quiet: true });
+  const dbModule = await import("../src/lib/db");
+  const pool = dbModule.default;
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const r = await run(client);
+    if (cli.mode === "apply") await client.query("COMMIT");
+    else await client.query("ROLLBACK");
+
+    const c = r.counts;
+    console.log(`\nSeat pending teachers (${cli.mode}) :: env=${cli.envFile}`);
+    console.log(`Pending (level-1 teacher, no seat) considered: ${c.considered}`);
+    console.log(`Seated: ${c.seatedTeachers} teachers -> ${c.seatsCreated} seats (role=subject_tbd)`);
+    console.log(`Created: ${c.usersCreated} users, ${c.teacherRowsCreated} teacher records`);
+    console.log(`Skipped: ${c.skippedNoCentre} no-centre (NVS/non-centre school), ${c.skippedAmbiguous} ambiguous (>1 same-program centre)`);
+    if (r.perCentre.size) {
+      console.log(`\nSeats per centre:`);
+      for (const [name, n] of [...r.perCentre.entries()].sort((a, b) => a[0].localeCompare(b[0]))) console.log(`  ${name}: ${n}`);
+    }
+    console.log(`\nSample assignments:`);
+    for (const a of r.assignmentsSample) console.log(`  ${a}`);
+    if (r.ambiguous.length) { console.log(`\nAmbiguous (skipped, ops decides):`); for (const a of r.ambiguous) console.log(`  ${a}`); }
+    if (cli.verbose && r.noCentre.length) { console.log(`\nNo-centre teachers (left in place):`); for (const e of r.noCentre) console.log(`  ${e}`); }
+    if (cli.mode === "dry-run") console.log(`\nDRY-RUN: rolled back, nothing written.`);
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -133,6 +133,38 @@ describe("StaffGrid", () => {
     expect(screen.getByText("Physics")).toBeTruthy();
   });
 
+  it("shows the staff seat tier at a centre, not the generic PM", () => {
+    const phRows: StaffRosterRow[] = [
+      {
+        kind: "staff",
+        recordId: 20,
+        userId: 80,
+        name: "Subramanya A",
+        email: "subramanya@avantifellows.org",
+        employeeCode: "AF183",
+        subjectName: null,
+        staffType: "program_manager",
+        designation: "Director, Operations",
+        exitDate: null,
+        seats: [
+          { id: 99, centreId: 8, centreName: "JNV Adilabad - CoE", role: "ph" },
+        ],
+      },
+    ];
+    stubFetch();
+    render(
+      <StaffGrid
+        initialRows={phRows}
+        initialSummary={SUMMARY}
+        initialFilters={FILTERS}
+      />
+    );
+    expect(screen.getByText("Subramanya A")).toBeTruthy();
+    // Role column reflects the seat tier (PH), not the kind-derived "PM".
+    expect(screen.getByText("PH")).toBeTruthy();
+    expect(screen.queryByText("PM")).toBeNull();
+  });
+
   it("offers a Centre filter fed by the centres API", async () => {
     stubFetch();
     renderGrid();

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -365,6 +365,49 @@ describe("StaffGrid", () => {
     });
   });
 
+  it("adds a new teacher from scratch via POST /api/admin/staff", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url === "/api/admin/staff" && init?.method === "POST") {
+        return new Response(JSON.stringify({ ok: true }), { status: 201 });
+      }
+      return undefined;
+    });
+
+    renderGrid();
+    fireEvent.click(screen.getByLabelText("Add user")); // header button opens modal
+
+    // Subject + centre dropdowns are fed by the mount fetches.
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Subject") as HTMLSelectElement).querySelectorAll(
+          "option"
+        ).length
+      ).toBe(3); // placeholder + 2 subjects
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "new@avantifellows.org" },
+    });
+    fireEvent.change(screen.getByLabelText("Subject"), { target: { value: "4" } });
+    fireEvent.change(screen.getByLabelText("Centre"), { target: { value: "8" } });
+    // The modal's submit button (distinct from the header's "Add user").
+    fireEvent.click(screen.getByRole("button", { name: "Add User" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            email: "new@avantifellows.org",
+            kind: "teacher",
+            centre_id: 8,
+            subject_id: 4,
+          }),
+        })
+      );
+    });
+  });
+
   it("completes a pending_teacher via POST /staff/teachers (subject + centre + optional AF)", async () => {
     const mockFetch = stubFetch((url, init) => {
       if (url === "/api/admin/staff/teachers" && init?.method === "POST") {

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -86,6 +86,17 @@ function stubFetch(
         { status: 200 }
       );
     }
+    if (url.startsWith("/api/admin/subjects")) {
+      return new Response(
+        JSON.stringify({
+          subjects: [
+            { id: 4, name: "Physics" },
+            { id: 2, name: "Chemistry" },
+          ],
+        }),
+        { status: 200 }
+      );
+    }
     if (url.startsWith("/api/admin/staff?")) {
       return new Response(JSON.stringify({ rows: ROWS, summary: SUMMARY }), {
         status: 200,
@@ -354,14 +365,22 @@ describe("StaffGrid", () => {
     });
   });
 
-  it("hides the Edit button for not-backfilled teachers", () => {
-    stubFetch();
+  it("completes a pending_teacher via POST /staff/teachers (subject + centre + optional AF)", async () => {
+    const mockFetch = stubFetch((url, init) => {
+      if (url === "/api/admin/staff/teachers" && init?.method === "POST") {
+        return new Response(JSON.stringify({ ok: true }), { status: 201 });
+      }
+      return undefined;
+    });
+
     render(
       <StaffGrid
         initialRows={[
           {
             ...ROWS[1],
             kind: "pending_teacher",
+            recordId: 88, // user_permission id for pending rows
+            userId: null,
             name: "Pending Teacher",
           },
         ]}
@@ -369,6 +388,46 @@ describe("StaffGrid", () => {
         initialFilters={FILTERS}
       />
     );
-    expect(screen.queryByLabelText("Edit Pending Teacher")).toBeNull();
+
+    // pending_teacher is now editable — open the create-teacher modal.
+    fireEvent.click(screen.getByLabelText("Edit Pending Teacher"));
+
+    // "Create teacher" stays disabled until subject + centre are chosen.
+    const createBtn = screen.getByText("Create teacher");
+    expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+
+    // Subject dropdown is fed by /api/admin/subjects (fetched on mount).
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Subject") as HTMLSelectElement).querySelectorAll(
+          "option"
+        ).length
+      ).toBe(3); // placeholder + 2 subjects
+    });
+    fireEvent.change(screen.getByLabelText("Subject"), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByLabelText("Centre"), {
+      target: { value: "8" },
+    });
+    fireEvent.change(screen.getByLabelText("Employee code"), {
+      target: { value: "af777" },
+    });
+    fireEvent.click(screen.getByText("Create teacher"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff/teachers",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            user_permission_id: 88,
+            subject_id: 4,
+            centre_id: 8,
+            teacher_id: "AF777",
+          }),
+        })
+      );
+    });
   });
 });

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -281,6 +281,56 @@ describe("StaffGrid", () => {
     });
   });
 
+  it("changes a person's org tier across all seats via PATCH /positions", async () => {
+    const pmRow: StaffRosterRow[] = [
+      {
+        kind: "staff",
+        recordId: 20,
+        userId: 80,
+        name: "Rupesh PM",
+        email: "rupesh@avantifellows.org",
+        employeeCode: "AF462",
+        subjectName: null,
+        staffType: "program_manager",
+        designation: null,
+        exitDate: null,
+        seats: [
+          { id: 99, centreId: 8, centreName: "JNV Adilabad - CoE", role: "pm" },
+          { id: 100, centreId: 9, centreName: "JNV Nirmal - CoE", role: "pm" },
+        ],
+      },
+    ];
+    const mockFetch = stubFetch((url, init) => {
+      if (url === "/api/admin/staff/positions" && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return undefined;
+    });
+
+    render(
+      <StaffGrid
+        initialRows={pmRow}
+        initialSummary={SUMMARY}
+        initialFilters={FILTERS}
+      />
+    );
+    // The person appears under each of their centres; open from the first card.
+    fireEvent.click(screen.getAllByLabelText("Edit Rupesh PM")[0]);
+    const roleSelect = screen.getByLabelText("Edit role") as HTMLSelectElement;
+    expect(roleSelect.value).toBe("pm");
+    fireEvent.change(roleSelect, { target: { value: "spm" } });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/staff/positions",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ user_id: 80, role: "spm" }),
+        })
+      );
+    });
+  });
+
   it("requires arming before marking exited", async () => {
     const mockFetch = stubFetch((url, init) => {
       if (url.startsWith("/api/admin/staff/teachers/") && init?.method === "PATCH") {

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -28,6 +28,11 @@ interface CentreOptionItem {
   name: string;
 }
 
+interface SubjectOptionItem {
+  id: number;
+  name: string;
+}
+
 const KIND_LABELS: Record<StaffRosterRow["kind"], string> = {
   teacher: "Teacher",
   staff: "PM / Staff",
@@ -148,6 +153,10 @@ export default function StaffGrid({
   const [exitArmed, setExitArmed] = useState(false);
   const [seatCentreDraft, setSeatCentreDraft] = useState("");
   const [seatRoleDraft, setSeatRoleDraft] = useState<SeatRole>("physics");
+  // Create-teacher form (completing a pending_teacher): chosen subject + centre.
+  const [subjects, setSubjects] = useState<SubjectOptionItem[]>([]);
+  const [subjectDraft, setSubjectDraft] = useState("");
+  const [createCentreDraft, setCreateCentreDraft] = useState("");
   const [actionError, setActionError] = useState("");
   const [actionBusy, setActionBusy] = useState(false);
   // Seat id awaiting a "remove anyway" confirmation (the server flagged it as
@@ -215,6 +224,21 @@ export default function StaffGrid({
     })();
   }, []);
 
+  // Subject list for the create-teacher dropdown.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const response = await fetch("/api/admin/subjects");
+        const data = await response.json();
+        if (response.ok && Array.isArray(data.subjects)) {
+          setSubjects(data.subjects);
+        }
+      } catch {
+        // Create-teacher subject dropdown will be empty; form stays blocked.
+      }
+    })();
+  }, []);
+
   const groups = useMemo(() => {
     const grouped = groupByCentre(rows);
     return filters.centreId === null
@@ -229,6 +253,8 @@ export default function StaffGrid({
     setExitArmed(false);
     setSeatCentreDraft("");
     setSeatRoleDraft(row.kind === "teacher" ? "physics" : "pm");
+    setSubjectDraft("");
+    setCreateCentreDraft("");
     setActionError("");
   };
 
@@ -302,6 +328,28 @@ export default function StaffGrid({
           body: JSON.stringify({
             user_permission_id: row.recordId,
             employee_code: code,
+          }),
+        }),
+      { closeOnSuccess: true }
+    );
+  };
+
+  // Complete a pending_teacher: create the teacher record + seat at the chosen
+  // centre. Subject + centre are required; AF id is optional (a not-yet-hired
+  // teacher gets it later via the normal edit flow). row.recordId is the
+  // user_permission id for pending rows.
+  const createTeacher = (row: StaffRosterRow) => {
+    const code = codeDraft.trim().toUpperCase();
+    return runAction(
+      () =>
+        fetch(`/api/admin/staff/teachers`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            user_permission_id: row.recordId,
+            subject_id: Number(subjectDraft),
+            centre_id: Number(createCentreDraft),
+            teacher_id: code || undefined,
           }),
         }),
       { closeOnSuccess: true }
@@ -382,7 +430,6 @@ export default function StaffGrid({
     }
   };
 
-  const canEdit = (row: StaffRosterRow) => row.kind !== "pending_teacher";
 
   return (
     <div className="space-y-6">
@@ -578,16 +625,16 @@ export default function StaffGrid({
                       />
                     </div>
                   </div>
-                  {canEdit(row) && (
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => openModal(row)}
-                      aria-label={`Edit ${row.name || row.email}`}
-                    >
-                      <Edit2 className="mr-1 h-4 w-4" /> Edit
-                    </Button>
-                  )}
+                  {/* Every row is editable — pending_teacher opens the
+                      create-teacher flow; others open the edit/seat modal. */}
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => openModal(row)}
+                    aria-label={`Edit ${row.name || row.email}`}
+                  >
+                    <Edit2 className="mr-1 h-4 w-4" /> Edit
+                  </Button>
                 </div>
               </Card>
             ))}
@@ -621,7 +668,9 @@ export default function StaffGrid({
               <label className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
                 {modalRow.kind === "pending_pm"
                   ? "AF code (creates the staff record)"
-                  : "AF code"}
+                  : modalRow.kind === "pending_teacher"
+                    ? "AF id (optional)"
+                    : "AF code"}
               </label>
               <Input
                 value={codeDraft}
@@ -630,7 +679,63 @@ export default function StaffGrid({
                 aria-label="Employee code"
                 className="w-40"
               />
+              {modalRow.kind === "pending_teacher" && (
+                <p className="mt-1 text-xs text-text-muted">
+                  Leave blank for a not-yet-hired teacher — set it later via Edit.
+                </p>
+              )}
             </div>
+
+            {modalRow.kind === "pending_teacher" && (
+              <div className="mt-5">
+                <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-text-muted">
+                  Create teacher record
+                </h4>
+                <p className="mb-3 text-sm text-text-muted">
+                  Creates the teacher and seats them at a centre.
+                </p>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <label className="flex-1">
+                    <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                      Subject
+                    </span>
+                    <Select
+                      value={subjectDraft}
+                      onChange={(event) => setSubjectDraft(event.target.value)}
+                      aria-label="Subject"
+                      className="w-full"
+                    >
+                      <option value="">Select Subject…</option>
+                      {subjects.map((subject) => (
+                        <option key={subject.id} value={subject.id}>
+                          {subject.name}
+                        </option>
+                      ))}
+                    </Select>
+                  </label>
+                  <label className="flex-1">
+                    <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                      Centre
+                    </span>
+                    <Select
+                      value={createCentreDraft}
+                      onChange={(event) =>
+                        setCreateCentreDraft(event.target.value)
+                      }
+                      aria-label="Centre"
+                      className="w-full"
+                    >
+                      <option value="">Select Centre…</option>
+                      {centres.map((centre) => (
+                        <option key={centre.id} value={centre.id}>
+                          {centre.name}
+                        </option>
+                      ))}
+                    </Select>
+                  </label>
+                </div>
+              </div>
+            )}
 
             {modalRow.userId !== null &&
               (modalRow.kind === "staff" || modalRow.kind === "pending_pm") &&
@@ -821,12 +926,21 @@ export default function StaffGrid({
               <Button variant="secondary" onClick={closeModal}>
                 Cancel
               </Button>
-              <Button
-                onClick={() => void saveCode(modalRow)}
-                disabled={actionBusy}
-              >
-                Save
-              </Button>
+              {modalRow.kind === "pending_teacher" ? (
+                <Button
+                  onClick={() => void createTeacher(modalRow)}
+                  disabled={actionBusy || !subjectDraft || !createCentreDraft}
+                >
+                  Create teacher
+                </Button>
+              ) : (
+                <Button
+                  onClick={() => void saveCode(modalRow)}
+                  disabled={actionBusy}
+                >
+                  Save
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -7,6 +7,7 @@ import StatCard from "@/components/StatCard";
 import { Badge, Button, Card, Input, Modal, Select } from "@/components/ui";
 import { DetailField } from "@/components/ui/DetailField";
 import {
+  PM_SEAT_ROLES,
   SEAT_ROLES,
   type RosterCodeFilter,
   type RosterKindFilter,
@@ -53,6 +54,21 @@ const SEAT_ROLE_LABELS: Record<SeatRole, string> = {
   ph: "PH",
   subject_tbd: "Subject TBD",
 };
+
+// Subject-teaching seat roles (everything that isn't a PM/management tier).
+const TEACHER_SEAT_ROLES = SEAT_ROLES.filter(
+  (role) => !(PM_SEAT_ROLES as readonly SeatRole[]).includes(role)
+);
+
+// The roles offered when editing a seat: PM tiers for staff/PM rows, subject
+// roles for teachers. Keeps a PM from being re-tagged "Physics" and vice versa.
+function seatRoleOptionsFor(
+  kind: StaffRosterRow["kind"]
+): readonly SeatRole[] {
+  return kind === "teacher" || kind === "pending_teacher"
+    ? TEACHER_SEAT_ROLES
+    : PM_SEAT_ROLES;
+}
 
 function rowKey(row: StaffRosterRow): string {
   return `${row.kind}:${row.recordId}`;
@@ -321,6 +337,18 @@ export default function StaffGrid({
       })
     );
   };
+
+  // Change a person's org tier (role). It's a person-level attribute, so this
+  // updates every active seat they hold at once; refreshing reflects the new
+  // tier in each centre's Role column.
+  const changeRole = (row: StaffRosterRow, role: SeatRole) =>
+    runAction(() =>
+      fetch(`/api/admin/staff/positions`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_id: row.userId, role }),
+      })
+    );
 
   // Vacate a seat. The server blocks removing a person's *last* seat (409 with
   // code "last_seat") unless force=true; on that block we surface an inline
@@ -603,6 +631,34 @@ export default function StaffGrid({
                 className="w-40"
               />
             </div>
+
+            {modalRow.userId !== null &&
+              (modalRow.kind === "staff" || modalRow.kind === "pending_pm") &&
+              modalRow.seats.length > 0 && (
+                <div className="mt-5">
+                  <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-text-muted">
+                    Role
+                  </h4>
+                  <Select
+                    value={modalRow.seats[0].role}
+                    onChange={(event) =>
+                      void changeRole(modalRow, event.target.value as SeatRole)
+                    }
+                    disabled={actionBusy}
+                    aria-label="Edit role"
+                    className="w-40"
+                  >
+                    {seatRoleOptionsFor(modalRow.kind).map((role) => (
+                      <option key={role} value={role}>
+                        {SEAT_ROLE_LABELS[role]}
+                      </option>
+                    ))}
+                  </Select>
+                  <p className="mt-1 text-xs text-text-muted">
+                    Applies to all of this person&apos;s centres.
+                  </p>
+                </div>
+              )}
 
             {modalRow.userId !== null && (
               <div className="mt-5">

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -48,10 +48,29 @@ const SEAT_ROLE_LABELS: Record<SeatRole, string> = {
   biology: "Biology",
   apc: "APC",
   pm: "PM",
+  apm: "APM",
+  spm: "SPM",
+  ph: "PH",
 };
 
 function rowKey(row: StaffRosterRow): string {
   return `${row.kind}:${row.recordId}`;
+}
+
+// In the centre-grouped view a staff member's role is the tier of the seat they
+// hold AT THAT centre (PH/SPM/APM/PM) — not the coarse roster kind, which
+// collapses every staff tier to "PM". Teachers keep "Teacher" (their subject is
+// shown in its own column, so the seat role would just duplicate it). Falls back
+// to the kind label when there's no seat for the centre (e.g. "No Centre").
+function roleLabelForCentre(
+  row: StaffRosterRow,
+  centreId: number | null
+): string {
+  if (row.kind === "staff" && centreId !== null) {
+    const seat = row.seats.find((s) => s.centreId === centreId);
+    if (seat) return SEAT_ROLE_LABELS[seat.role];
+  }
+  return ROLE_LABELS[row.kind];
 }
 
 interface CentreGroup {
@@ -510,7 +529,10 @@ export default function StaffGrid({
                     </div>
                     <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 md:grid-cols-4">
                       <DetailField label="Email" value={row.email ?? "—"} />
-                      <DetailField label="Role" value={ROLE_LABELS[row.kind]} />
+                      <DetailField
+                        label="Role"
+                        value={roleLabelForCentre(row, group.centreId)}
+                      />
                       <DetailField
                         label="Subject"
                         value={row.subjectName ?? "—"}

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -51,6 +51,7 @@ const SEAT_ROLE_LABELS: Record<SeatRole, string> = {
   apm: "APM",
   spm: "SPM",
   ph: "PH",
+  subject_tbd: "Subject TBD",
 };
 
 function rowKey(row: StaffRosterRow): string {

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -165,6 +165,18 @@ export default function StaffGrid({
     null
   );
 
+  // Add-User (from-scratch) modal state.
+  const [addOpen, setAddOpen] = useState(false);
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState("");
+  const [addName, setAddName] = useState("");
+  const [addEmail, setAddEmail] = useState("");
+  const [addKind, setAddKind] = useState<"teacher" | "staff">("teacher");
+  const [addSubject, setAddSubject] = useState("");
+  const [addSeatRole, setAddSeatRole] = useState<SeatRole>("pm");
+  const [addCentre, setAddCentre] = useState("");
+  const [addCode, setAddCode] = useState("");
+
   const modalRow = useMemo(
     () => (modalKey === null ? null : (rows.find((row) => rowKey(row) === modalKey) ?? null)),
     [modalKey, rows]
@@ -356,6 +368,63 @@ export default function StaffGrid({
     );
   };
 
+  const openAddModal = () => {
+    setAddName("");
+    setAddEmail("");
+    setAddKind("teacher");
+    setAddSubject("");
+    setAddSeatRole("pm");
+    setAddCentre("");
+    setAddCode("");
+    setAddError("");
+    setAddOpen(true);
+  };
+  const closeAddModal = () => {
+    setAddOpen(false);
+    setAddError("");
+  };
+
+  // Create a new centre-staff person + seat in one atomic call (server does the
+  // permission + user + teacher/staff + seat together).
+  const submitAddUser = async () => {
+    setAddBusy(true);
+    setAddError("");
+    try {
+      const response = await fetch(`/api/admin/staff`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: addEmail.trim(),
+          full_name: addName.trim() || undefined,
+          kind: addKind,
+          centre_id: Number(addCentre),
+          subject_id: addKind === "teacher" ? Number(addSubject) : undefined,
+          role: addKind === "staff" ? addSeatRole : undefined,
+          af_id: addCode.trim() || undefined,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const fieldError =
+          data.fields && typeof data.fields === "object"
+            ? Object.values(data.fields as Record<string, string>)[0]
+            : undefined;
+        throw new Error(fieldError || data.error || "Failed to add user");
+      }
+      await fetchRoster(filters);
+      closeAddModal();
+    } catch (error) {
+      setAddError(error instanceof Error ? error.message : "Failed to add user");
+    } finally {
+      setAddBusy(false);
+    }
+  };
+
+  const addValid =
+    addEmail.trim().includes("@") &&
+    !!addCentre &&
+    (addKind === "teacher" ? !!addSubject : true);
+
   const saveExit = (row: StaffRosterRow) => {
     const url =
       row.kind === "teacher"
@@ -433,6 +502,16 @@ export default function StaffGrid({
 
   return (
     <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-text-muted">
+          Add centre staff (teachers &amp; PMs) and seat them here — no separate
+          permissions step.
+        </p>
+        <Button onClick={openAddModal} aria-label="Add user" className="shrink-0">
+          <Plus className="mr-1 h-4 w-4" /> Add User
+        </Button>
+      </div>
+
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
         <StatCard label="People" value={summary.total} size="sm" />
         <StatCard label="Teachers" value={summary.teachers} size="sm" />
@@ -944,6 +1023,156 @@ export default function StaffGrid({
             </div>
           </div>
         )}
+      </Modal>
+
+      <Modal open={addOpen} onClose={closeAddModal} className="max-w-xl">
+        <div className="p-6">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-lg font-bold text-text-primary">Add User</h3>
+              <p className="text-sm text-text-muted">
+                Creates the person and seats them at a centre in one step.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={closeAddModal}
+              className="text-text-muted hover:text-text-primary"
+              aria-label="Close"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label>
+              <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                Full name
+              </span>
+              <Input
+                value={addName}
+                onChange={(event) => setAddName(event.target.value)}
+                placeholder="Jane Doe"
+                aria-label="Full name"
+              />
+            </label>
+            <label>
+              <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                Email
+              </span>
+              <Input
+                value={addEmail}
+                onChange={(event) => setAddEmail(event.target.value)}
+                placeholder="jane@avantifellows.org"
+                aria-label="Email"
+              />
+            </label>
+            <label>
+              <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                Type
+              </span>
+              <Select
+                value={addKind}
+                onChange={(event) =>
+                  setAddKind(event.target.value as "teacher" | "staff")
+                }
+                aria-label="Type"
+              >
+                <option value="teacher">Teacher</option>
+                <option value="staff">PM / Staff</option>
+              </Select>
+            </label>
+            {addKind === "teacher" ? (
+              <label>
+                <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                  Subject
+                </span>
+                <Select
+                  value={addSubject}
+                  onChange={(event) => setAddSubject(event.target.value)}
+                  aria-label="Subject"
+                >
+                  <option value="">Select Subject…</option>
+                  {subjects.map((subject) => (
+                    <option key={subject.id} value={subject.id}>
+                      {subject.name}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            ) : (
+              <label>
+                <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                  Role
+                </span>
+                <Select
+                  value={addSeatRole}
+                  onChange={(event) =>
+                    setAddSeatRole(event.target.value as SeatRole)
+                  }
+                  aria-label="Role"
+                >
+                  {PM_SEAT_ROLES.map((role) => (
+                    <option key={role} value={role}>
+                      {SEAT_ROLE_LABELS[role]}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            )}
+            <label>
+              <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                Centre
+              </span>
+              <Select
+                value={addCentre}
+                onChange={(event) => setAddCentre(event.target.value)}
+                aria-label="Centre"
+              >
+                <option value="">Select Centre…</option>
+                {centres.map((centre) => (
+                  <option key={centre.id} value={centre.id}>
+                    {centre.name}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <label>
+              <span className="mb-1 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                AF id (optional)
+              </span>
+              <Input
+                value={addCode}
+                onChange={(event) => setAddCode(event.target.value)}
+                placeholder="AF123"
+                aria-label="AF id"
+              />
+            </label>
+          </div>
+
+          <p className="mt-3 text-xs text-text-muted">
+            Centre staff are seat-scoped: program is taken from the centre and
+            access follows the seat. AF id can be added later.
+          </p>
+
+          {addError && (
+            <p className="mt-4 text-sm text-danger" role="alert">
+              {addError}
+            </p>
+          )}
+
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="secondary" onClick={closeAddModal}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void submitAddUser()}
+              disabled={addBusy || !addValid}
+            >
+              Add User
+            </Button>
+          </div>
+        </div>
       </Modal>
     </div>
   );

--- a/src/app/admin/users/UserList.test.tsx
+++ b/src/app/admin/users/UserList.test.tsx
@@ -135,6 +135,32 @@ describe("UserList", () => {
       expect(within(cell).getByText("(you)")).toBeInTheDocument();
     });
 
+    it("disables Edit and shows a Staff Management note for seated users", () => {
+      renderList({
+        initialUsers: [
+          {
+            ...users[2],
+            id: 99,
+            email: "seated@example.com",
+            centres: [{ centreName: "EMRS Bhopal", role: "subject_tbd" }],
+          },
+        ] as unknown as typeof users,
+      });
+      const row = screen.getByText("seated@example.com").closest("tr")!;
+      expect(within(row).getByRole("button", { name: "Edit" })).toBeDisabled();
+      expect(
+        within(row).getByText("Edit in Staff Management only")
+      ).toBeInTheDocument();
+    });
+
+    it("keeps Edit enabled for users with no centre seat", () => {
+      renderList();
+      const row = screen.getByText("teacher@example.com").closest("tr")!;
+      expect(
+        within(row).getByRole("button", { name: "Edit" })
+      ).toBeEnabled();
+    });
+
     it("does not show (you) for other users", () => {
       renderList();
       const cell = screen.getByText("pm@avantifellows.org").closest("td")!;

--- a/src/app/admin/users/UserList.tsx
+++ b/src/app/admin/users/UserList.tsx
@@ -233,23 +233,44 @@ export default function UserList({ initialUsers, regions, schoolCodeToName, curr
                     )}
                   </div>
                 </td>
-                <td className="whitespace-nowrap px-3 py-4 text-sm">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setEditingUser(user)}
-                    className="mr-2"
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="danger-ghost"
-                    size="sm"
-                    onClick={() => handleDelete(user.id, user.email)}
-                    disabled={deleting === user.id || user.email.toLowerCase() === currentUserEmail.toLowerCase()}
-                  >
-                    {deleting === user.id ? "Deleting..." : "Delete"}
-                  </Button>
+                <td className="px-3 py-4 text-sm">
+                  <div className="flex items-center whitespace-nowrap">
+                    {(user.centres?.length ?? 0) > 0 ? (
+                      // Seated users' scope is derived from their centre, so it
+                      // can't be edited here (the API rejects it too) — point ops
+                      // at Staff Management instead.
+                      <span
+                        className="mr-2"
+                        title="This user is assigned to a centre. Edit their access in Staff Management."
+                      >
+                        <Button variant="ghost" size="sm" disabled>
+                          Edit
+                        </Button>
+                      </span>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingUser(user)}
+                        className="mr-2"
+                      >
+                        Edit
+                      </Button>
+                    )}
+                    <Button
+                      variant="danger-ghost"
+                      size="sm"
+                      onClick={() => handleDelete(user.id, user.email)}
+                      disabled={deleting === user.id || user.email.toLowerCase() === currentUserEmail.toLowerCase()}
+                    >
+                      {deleting === user.id ? "Deleting..." : "Delete"}
+                    </Button>
+                  </div>
+                  {(user.centres?.length ?? 0) > 0 && (
+                    <p className="mt-1 text-xs text-gray-400">
+                      Edit in Staff Management only
+                    </p>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/app/api/admin/staff/positions/route.ts
+++ b/src/app/api/admin/staff/positions/route.ts
@@ -6,6 +6,7 @@ import {
   createPosition,
   requireStaffAdmin,
   safeStaffApiError,
+  setUserRole,
 } from "@/lib/staff-admin";
 
 export async function POST(request: NextRequest) {
@@ -32,4 +33,32 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ ok: true }, { status: 201 });
+}
+
+// Set a person's org tier (role) across all their active seats at once — role
+// is a person-level attribute, not per-centre.
+export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await setUserRole({
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/staff/route.ts
+++ b/src/app/api/admin/staff/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
 import {
+  createSeatedUser,
   getStaffRoster,
   requireStaffAdmin,
   safeStaffApiError,
@@ -30,4 +31,32 @@ export async function GET(request: NextRequest) {
     rows: result.rows,
     summary: result.summary,
   });
+}
+
+// Create a new centre-staff person (teacher or PM-tier) and seat them in one
+// atomic action — the self-contained "Add User" on Staff Management.
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createSeatedUser({
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 });
 }

--- a/src/app/api/admin/staff/teachers/route.ts
+++ b/src/app/api/admin/staff/teachers/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  createTeacher,
+  requireStaffAdmin,
+  safeStaffApiError,
+} from "@/lib/staff-admin";
+
+// Complete a pending_teacher into a real teacher record + centre seat.
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createTeacher({
+    body: (body ?? {}) as Record<string, unknown>,
+  });
+  if (!result.ok) {
+    return NextResponse.json(safeStaffApiError(result), {
+      status: result.status,
+    });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/api/admin/subjects/route.ts
+++ b/src/app/api/admin/subjects/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { getSubjectOptions, requireStaffAdmin } from "@/lib/staff-admin";
+
+// Subject list for the staff-management create-teacher dropdown (admin only).
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const access = await requireStaffAdmin(session);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const subjects = await getSubjectOptions();
+  return NextResponse.json({ subjects });
+}

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -1,13 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { mockQuery, mockWithTransaction } = vi.hoisted(() => {
+  const mockQuery = vi.fn();
+  return {
+    mockQuery,
+    // Run the callback with a client whose query routes to the same mock, so
+    // top-level and in-transaction queries are captured in one call list.
+    mockWithTransaction: vi.fn(
+      async (fn: (client: { query: typeof mockQuery }) => Promise<unknown>) =>
+        fn({ query: mockQuery })
+    ),
+  };
+});
+
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", () => ({ isAdmin: vi.fn() }));
-vi.mock("@/lib/db", () => ({ query: vi.fn() }));
+vi.mock("@/lib/db", () => ({
+  query: mockQuery,
+  withTransaction: mockWithTransaction,
+}));
 
 import { getServerSession } from "next-auth";
 import { isAdmin } from "@/lib/permissions";
-import { query } from "@/lib/db";
 import { DELETE, PATCH } from "./route";
 import {
   jsonRequest,
@@ -18,10 +33,13 @@ import {
 
 const mockSession = vi.mocked(getServerSession);
 const mockIsAdmin = vi.mocked(isAdmin);
-const mockQuery = vi.mocked(query);
 
 beforeEach(() => {
   vi.resetAllMocks();
+  mockWithTransaction.mockImplementation(
+    async (fn: (client: { query: typeof mockQuery }) => Promise<unknown>) =>
+      fn({ query: mockQuery })
+  );
 });
 
 describe("DELETE /api/admin/users/[id]", () => {
@@ -54,18 +72,29 @@ describe("DELETE /api/admin/users/[id]", () => {
     expect(json.error).toContain("Cannot delete your own");
   });
 
-  it("deletes another user successfully", async () => {
+  it("deletes another user and vacates their centre seats", async () => {
     mockSession.mockResolvedValue(ADMIN_SESSION);
     mockIsAdmin.mockResolvedValue(true);
     mockQuery
-      .mockResolvedValueOnce([{ email: "other@test.com" }]) // lookup
-      .mockResolvedValueOnce([]); // delete
+      .mockResolvedValueOnce([{ email: "other@test.com", user_id: 70 }]) // lookup
+      .mockResolvedValueOnce([]) // vacate seats (soft-delete)
+      .mockResolvedValueOnce([]); // delete permission
 
     const req = jsonRequest("http://localhost/api/admin/users/5", { method: "DELETE" });
     const res = await DELETE(req as never, params);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.success).toBe(true);
+    // The seats are soft-deleted (removing them from the centre + roster).
+    expect(
+      mockQuery.mock.calls.some((c) =>
+        String(c[0]).includes("centre_positions SET deleted_at")
+      )
+    ).toBe(true);
+    // The teacher/staff/user identity rows are NOT destroyed.
+    expect(
+      mockQuery.mock.calls.some((c) => /DELETE FROM (teacher|staff|"user")/.test(String(c[0])))
+    ).toBe(false);
   });
 
   it("succeeds when user to delete does not exist", async () => {

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -143,6 +143,55 @@ describe("PATCH /api/admin/users/[id]", () => {
     expect(json.success).toBe(true);
   });
 
+  it("rejects (409) editing school_codes for a user with a centre seat", async () => {
+    mockSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsAdmin.mockResolvedValue(true);
+    mockQuery.mockResolvedValueOnce([{ one: 1 }]); // seated check → seated
+    const req = jsonRequest("http://localhost/api/admin/users/5", {
+      method: "PATCH",
+      body: { school_codes: ["54019"] },
+    });
+    const res = await PATCH(req as never, params);
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("centre");
+    // guard returns before the UPDATE — only the seated check ran
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces school_codes/regions to NULL when a seated user's other fields are edited", async () => {
+    mockSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsAdmin.mockResolvedValue(true);
+    mockQuery
+      .mockResolvedValueOnce([{ one: 1 }]) // seated check → seated
+      .mockResolvedValueOnce([]); // UPDATE
+    const req = jsonRequest("http://localhost/api/admin/users/5", {
+      method: "PATCH",
+      body: { level: 2 }, // no scope edit, so allowed
+    });
+    const res = await PATCH(req as never, params);
+    expect(res.status).toBe(200);
+    const updateArgs = mockQuery.mock.calls[1][1] as unknown[];
+    expect(updateArgs[2]).toBeNull(); // school_codes
+    expect(updateArgs[3]).toBeNull(); // regions
+  });
+
+  it("still allows editing school_codes for a user with NO centre seat", async () => {
+    mockSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsAdmin.mockResolvedValue(true);
+    mockQuery
+      .mockResolvedValueOnce([]) // seated check → not seated
+      .mockResolvedValueOnce([]); // UPDATE
+    const req = jsonRequest("http://localhost/api/admin/users/5", {
+      method: "PATCH",
+      body: { school_codes: ["54019"] },
+    });
+    const res = await PATCH(req as never, params);
+    expect(res.status).toBe(200);
+    const updateArgs = mockQuery.mock.calls[1][1] as unknown[];
+    expect(updateArgs[2]).toEqual(["54019"]); // school_codes applied
+  });
+
   it("ignores invalid role values", async () => {
     mockSession.mockResolvedValue(ADMIN_SESSION);
     mockIsAdmin.mockResolvedValue(true);

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -78,6 +78,33 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const validRoles = ["teacher", "program_manager", "program_admin", "admin"];
     const userRole = role && validRoles.includes(role) ? role : undefined;
 
+    // Centre seats are the source of truth for a seated user's school scope
+    // (staff-admin clears school_codes/regions on assignment; resolveScope derives
+    // schools from the seat). Editing explicit scope here would re-introduce the
+    // over-grant / move-doesn't-revoke staleness, so it's disabled for seated
+    // users: reject any attempt to set school_codes/regions, and keep both NULL.
+    const seated = await query<{ one: number }>(
+      `SELECT 1 AS one
+       FROM centre_positions cp
+       JOIN user_permission up ON up.user_id = cp.user_id
+       WHERE up.id = $1 AND cp.deleted_at IS NULL
+       LIMIT 1`,
+      [id]
+    );
+    const isSeated = seated.length > 0;
+    const wantsScopeEdit =
+      (Array.isArray(school_codes) && school_codes.length > 0) ||
+      (Array.isArray(regions) && regions.length > 0);
+    if (isSeated && wantsScopeEdit) {
+      return NextResponse.json(
+        {
+          error:
+            "This user is assigned to a centre, so their school scope is derived from that centre and can't be edited here. Change their centre assignment instead.",
+        },
+        { status: 409 }
+      );
+    }
+
     await query(
       `UPDATE user_permission
        SET level = COALESCE($1, level),
@@ -89,7 +116,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
            full_name = $7,
            updated_at = NOW()
        WHERE id = $8`,
-      [level, userRole, school_codes || null, regions || null, program_ids || null, read_only, full_name ?? null, id]
+      [level, userRole, isSeated ? null : school_codes || null, isSeated ? null : regions || null, program_ids || null, read_only, full_name ?? null, id]
     );
 
     return NextResponse.json({ success: true });

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { isAdmin } from "@/lib/permissions";
-import { query } from "@/lib/db";
+import { query, withTransaction } from "@/lib/db";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -23,8 +23,8 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   }
 
   // Prevent deleting yourself
-  const userToDelete = await query<{ email: string }>(
-    `SELECT email FROM user_permission WHERE id = $1`,
+  const userToDelete = await query<{ email: string; user_id: number | null }>(
+    `SELECT email, user_id FROM user_permission WHERE id = $1`,
     [id]
   );
 
@@ -35,7 +35,23 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  await query(`DELETE FROM user_permission WHERE id = $1`, [id]);
+  // Removing a user also frees their centre seats: soft-delete the person's
+  // active centre_positions so they vacate the centre (and stop appearing in
+  // Staff Management). We deliberately do NOT delete the teacher/staff/user
+  // rows — those live in the shared db-service DB and may be referenced by
+  // other systems; the roster already hides them once no live permission
+  // exists, and a later re-add reactivates the dormant record.
+  const targetUserId = userToDelete[0]?.user_id ?? null;
+  await withTransaction(async (client) => {
+    if (targetUserId != null) {
+      await client.query(
+        `UPDATE centre_positions SET deleted_at = now(), updated_at = now()
+         WHERE user_id = $1 AND deleted_at IS NULL`,
+        [targetUserId]
+      );
+    }
+    await client.query(`DELETE FROM user_permission WHERE id = $1`, [id]);
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/src/lib/clear-seated-scope.test.ts
+++ b/src/lib/clear-seated-scope.test.ts
@@ -78,6 +78,29 @@ describe("runClearSeatedScope", () => {
     expect(report.strandedUsers).toHaveLength(0);
   });
 
+  it("skips seated users whose seats cover no school (would-be-empty), issuing NO update", async () => {
+    mockQuery.mockResolvedValueOnce([
+      // seated only at an unlinked (school-less) centre → seat covers nothing
+      {
+        user_id: "40",
+        email: "unlinked@af.org",
+        school_codes: ["84082"],
+        regions: null,
+        seat_school_codes: null,
+      },
+    ]);
+
+    const report = await runClearSeatedScope({ mode: "apply" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1); // read only — nothing clearable
+    expect(report.usersWithExplicitScope).toBe(1);
+    expect(report.usersCleared).toBe(0);
+    expect(report.skippedWouldBeEmpty.map((u) => u.email)).toEqual([
+      "unlinked@af.org",
+    ]);
+    expect(report.strandedUsers).toHaveLength(0); // not cleared → not stranded
+  });
+
   it("treats regions-only seated users as needing a clear", async () => {
     mockQuery
       .mockResolvedValueOnce([

--- a/src/lib/clear-seated-scope.ts
+++ b/src/lib/clear-seated-scope.ts
@@ -7,12 +7,17 @@
  * cutover is stale and must be cleared — otherwise a later seat move leaves the
  * old school reachable (the move-doesn't-revoke bug).
  *
- * This clears explicit scope for every active person holding ≥1 active seat. It
- * is LOUD about "stranded" people: those whose `school_codes` include a school
- * that NO seat covers (e.g. the centre isn't created/linked yet). Clearing their
- * scope removes access to those schools until ops creates the missing seats, so
- * the dry-run worklist is the ops to-do list. Idempotent: re-running clears
- * nothing once scopes are already null.
+ * This clears explicit scope for every active person holding ≥1 seat at a
+ * LINKED centre (centre.school_id set). A person whose seats are ALL at unlinked
+ * (school-less) centres is SKIPPED — clearing them would leave an empty scope and
+ * lock them out of their own data; they keep their explicit school_codes until
+ * their centre gets a school link (reported as skippedWouldBeEmpty — the ops
+ * to-do list).
+ *
+ * It is also LOUD about "stranded" people among those it DOES clear: those whose
+ * `school_codes` include a school no seat covers (usually an over-grant being
+ * corrected, occasionally a real seat gap) — surfaced so ops can tell them apart.
+ * Idempotent: re-running clears nothing once scopes are already null.
  */
 import { query } from "./db";
 
@@ -37,6 +42,9 @@ export interface ClearSeatedScopeReport {
   usersCleared: number;
   // Seated people who lose access to ≥1 uncovered school on clear (ops worklist).
   strandedUsers: SeatedScopeRow[];
+  // Seated people SKIPPED because their seats cover no school — clearing would
+  // empty their scope. They keep their explicit codes until a centre is linked.
+  skippedWouldBeEmpty: SeatedScopeRow[];
   rows: SeatedScopeRow[];
 }
 
@@ -80,10 +88,17 @@ export async function runClearSeatedScope(opts: {
     };
   });
 
-  const toClear = rows.filter(
+  const withExplicit = rows.filter(
     (r) => r.schoolCodes.length > 0 || r.regions.length > 0
   );
-  const strandedUsers = rows.filter((r) => r.uncoveredCodes.length > 0);
+  // Only clear people whose seats cover ≥1 school — clearing someone whose seats
+  // cover none would zero their scope (lock them out). Skip those until a centre
+  // they sit at gets a school link.
+  const toClear = withExplicit.filter((r) => r.seatSchoolCodes.length > 0);
+  const skippedWouldBeEmpty = withExplicit.filter(
+    (r) => r.seatSchoolCodes.length === 0
+  );
+  const strandedUsers = toClear.filter((r) => r.uncoveredCodes.length > 0);
 
   let usersCleared = toClear.length; // dry-run = would-clear count
   if (opts.mode === "apply" && toClear.length > 0) {
@@ -94,7 +109,9 @@ export async function runClearSeatedScope(opts: {
          AND (up.school_codes IS NOT NULL OR up.regions IS NOT NULL)
          AND EXISTS (
            SELECT 1 FROM centre_positions cp
+           JOIN centres c ON c.id = cp.centre_id
            WHERE cp.user_id = up.user_id AND cp.deleted_at IS NULL
+             AND c.school_id IS NOT NULL
          )
        RETURNING up.user_id`
     );
@@ -104,9 +121,10 @@ export async function runClearSeatedScope(opts: {
   return {
     mode: opts.mode,
     ok: true,
-    usersWithExplicitScope: toClear.length,
+    usersWithExplicitScope: withExplicit.length,
     usersCleared,
     strandedUsers,
+    skippedWouldBeEmpty,
     rows,
   };
 }

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -25,6 +25,7 @@ vi.mock("./permissions", () => ({
 import {
   STAFF_REQUIRED_COLUMNS,
   createPosition,
+  createSeatedUser,
   createStaffMember,
   createTeacher,
   deletePosition,
@@ -727,6 +728,121 @@ describe("positions", () => {
     expect(
       await createTeacher({ body: { user_permission_id: 88, subject_id: 4, centre_id: 8 } })
     ).toMatchObject({ ok: false, status: 409 });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createSeatedUser creates a teacher + permission + seat atomically", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre + program
+    mockQuery.mockResolvedValueOnce([]); // existing permission (none)
+    mockQuery.mockResolvedValueOnce([]); // existing teacher/staff record (none)
+    mockQuery.mockResolvedValueOnce([]); // AF clash (none)
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [{ id: 600 }] }) // INSERT user_permission
+      .mockResolvedValueOnce({ rows: [] }) // SELECT user (none)
+      .mockResolvedValueOnce({ rows: [{ id: 700 }] }); // INSERT user
+    expect(
+      await createSeatedUser({
+        body: {
+          email: "new@x.org",
+          full_name: "New Teach",
+          kind: "teacher",
+          centre_id: 8,
+          subject_id: 4,
+          af_id: "af9",
+        },
+      })
+    ).toEqual({ ok: true });
+    const permInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO user_permission")
+    );
+    expect(permInsert![1]).toEqual(["new@x.org", "teacher", [2], "New Teach"]);
+    const teacherInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO teacher")
+    );
+    expect(teacherInsert![1]).toEqual([700, 4, "AF9"]);
+    const seatInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO centre_positions")
+    );
+    expect(seatInsert![1]).toEqual([8, "subject_tbd", 700]);
+  });
+
+  it("createSeatedUser creates a PM/staff member + tier seat (AF optional)", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre
+    mockQuery.mockResolvedValueOnce([]); // existing permission (none)
+    mockQuery.mockResolvedValueOnce([]); // existing teacher/staff record (none)
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [{ id: 601 }] }) // INSERT user_permission
+      .mockResolvedValueOnce({ rows: [] }) // SELECT user (none)
+      .mockResolvedValueOnce({ rows: [{ id: 701 }] }); // INSERT user
+    expect(
+      await createSeatedUser({
+        body: { email: "pm@x.org", kind: "staff", role: "spm", centre_id: 8 },
+      })
+    ).toEqual({ ok: true });
+    const permInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO user_permission")
+    );
+    expect(permInsert![1]).toEqual(["pm@x.org", "program_manager", [2], null]);
+    const staffInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO staff")
+    );
+    expect(staffInsert![1]).toEqual([701, null]); // employee_code null (no AF)
+    const seatInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO centre_positions")
+    );
+    expect(seatInsert![1]).toEqual([8, "spm", 701]);
+  });
+
+  it("createSeatedUser refuses an email that already exists", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre
+    mockQuery.mockResolvedValueOnce([{ id: 593 }]); // existing permission → conflict
+    expect(
+      await createSeatedUser({
+        body: { email: "dup@x.org", kind: "teacher", centre_id: 8, subject_id: 4 },
+      })
+    ).toMatchObject({ ok: false, status: 409 });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createSeatedUser refuses an orphaned teacher record (re-add after delete)", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre
+    mockQuery.mockResolvedValueOnce([]); // existing permission (none — was deleted)
+    mockQuery.mockResolvedValueOnce([{ id: 3098 }]); // orphaned teacher record exists
+    expect(
+      await createSeatedUser({
+        body: { email: "orphan@x.org", kind: "teacher", centre_id: 8, subject_id: 4 },
+      })
+    ).toMatchObject({ ok: false, status: 409 });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createSeatedUser blocks a centre with no program", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 8, program_id: null }]); // no program
+    expect(
+      await createSeatedUser({
+        body: { email: "x@x.org", kind: "teacher", centre_id: 8, subject_id: 4 },
+      })
+    ).toMatchObject({ ok: false, status: 422, fields: { centre_id: expect.any(String) } });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createSeatedUser requires a subject for teachers and a valid tier for staff", async () => {
+    mockSchemaReady();
+    expect(
+      await createSeatedUser({ body: { email: "x@x.org", kind: "teacher", centre_id: 8 } })
+    ).toMatchObject({ ok: false, status: 422, fields: { subject_id: expect.any(String) } });
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    expect(
+      await createSeatedUser({
+        body: { email: "x@x.org", kind: "staff", role: "principal", centre_id: 8 },
+      })
+    ).toMatchObject({ ok: false, status: 422, fields: { role: expect.any(String) } });
     expect(mockClientQuery).not.toHaveBeenCalled();
   });
 

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -26,7 +26,9 @@ import {
   STAFF_REQUIRED_COLUMNS,
   createPosition,
   createStaffMember,
+  createTeacher,
   deletePosition,
+  getSubjectOptions,
   getStaffRoster,
   isSeatRole,
   normalizeEmployeeCode,
@@ -640,6 +642,103 @@ describe("positions", () => {
     expect(
       await setUserRole({ body: { user_id: 70, role: "spm" } })
     ).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it("createTeacher creates the user, teacher record, and seat", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 88, email: "t@x.org", full_name: "Pending Teacher", role: "teacher", level: 1, user_id: null },
+    ]); // permission
+    mockQuery.mockResolvedValueOnce([{ id: 4 }]); // subject exists
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre exists
+    mockQuery.mockResolvedValueOnce([]); // teacher_id clash (none)
+    mockQuery.mockResolvedValueOnce([]); // reuse-by-email (no existing user)
+    mockClientQuery.mockResolvedValueOnce({ rows: [{ id: 500 }] }); // INSERT user
+    expect(
+      await createTeacher({
+        body: { user_permission_id: 88, subject_id: 4, centre_id: 8, teacher_id: "af777" },
+      })
+    ).toEqual({ ok: true });
+    const teacherInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO teacher")
+    );
+    expect(teacherInsert![1]).toEqual([500, 4, "AF777"]);
+    const seatInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO centre_positions")
+    );
+    expect(String(seatInsert![0])).toContain("'subject_tbd'");
+    expect(seatInsert![1]).toEqual([8, 500]);
+    // seat-as-source-of-truth: explicit scope cleared on seat creation
+    expect(
+      mockClientQuery.mock.calls.some((c) =>
+        String(c[0]).includes("school_codes = NULL")
+      )
+    ).toBe(true);
+  });
+
+  it("createTeacher allows a blank AF id (not-yet-hired) and reuses an existing user", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 88, email: "t@x.org", full_name: "T", role: "teacher", level: 1, user_id: 70 },
+    ]); // permission (already linked to a user)
+    mockQuery.mockResolvedValueOnce([{ id: 4 }]); // subject
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([]); // teacher clash (none)
+    expect(
+      await createTeacher({ body: { user_permission_id: 88, subject_id: 4, centre_id: 8 } })
+    ).toEqual({ ok: true });
+    const teacherInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO teacher")
+    );
+    expect(teacherInsert![1]).toEqual([70, 4, null]); // teacher_id null
+  });
+
+  it("createTeacher requires subject and centre", async () => {
+    mockSchemaReady();
+    expect(
+      await createTeacher({ body: { user_permission_id: 88 } })
+    ).toMatchObject({
+      ok: false,
+      status: 422,
+      fields: { subject_id: expect.any(String), centre_id: expect.any(String) },
+    });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createTeacher rejects region-level users", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 88, email: "t@x.org", full_name: "T", role: "teacher", level: 2, user_id: 70 },
+    ]);
+    expect(
+      await createTeacher({ body: { user_permission_id: 88, subject_id: 4, centre_id: 8 } })
+    ).toMatchObject({ ok: false, status: 422 });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("createTeacher 409s when the person already has a teacher record", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([
+      { id: 88, email: "t@x.org", full_name: "T", role: "teacher", level: 1, user_id: 70 },
+    ]);
+    mockQuery.mockResolvedValueOnce([{ id: 4 }]); // subject
+    mockQuery.mockResolvedValueOnce([{ id: 8 }]); // centre
+    mockQuery.mockResolvedValueOnce([{ id: 999 }]); // teacher clash → exists
+    expect(
+      await createTeacher({ body: { user_permission_id: 88, subject_id: 4, centre_id: 8 } })
+    ).toMatchObject({ ok: false, status: 409 });
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("getSubjectOptions returns id + English label", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { id: 4, name: "Physics" },
+      { id: 2, name: "Chemistry" },
+    ]);
+    expect(await getSubjectOptions()).toEqual([
+      { id: 4, name: "Physics" },
+      { id: 2, name: "Chemistry" },
+    ]);
   });
 
   it("deletePosition soft-deletes a vacant seat", async () => {

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -735,7 +735,6 @@ describe("positions", () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre + program
     mockQuery.mockResolvedValueOnce([]); // existing permission (none)
-    mockQuery.mockResolvedValueOnce([]); // existing teacher/staff record (none)
     mockQuery.mockResolvedValueOnce([]); // AF clash (none)
     mockClientQuery
       .mockResolvedValueOnce({ rows: [{ id: 600 }] }) // INSERT user_permission
@@ -771,7 +770,6 @@ describe("positions", () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre
     mockQuery.mockResolvedValueOnce([]); // existing permission (none)
-    mockQuery.mockResolvedValueOnce([]); // existing teacher/staff record (none)
     mockClientQuery
       .mockResolvedValueOnce({ rows: [{ id: 601 }] }) // INSERT user_permission
       .mockResolvedValueOnce({ rows: [] }) // SELECT user (none)
@@ -807,17 +805,31 @@ describe("positions", () => {
     expect(mockClientQuery).not.toHaveBeenCalled();
   });
 
-  it("createSeatedUser refuses an orphaned teacher record (re-add after delete)", async () => {
+  it("createSeatedUser reactivates a dormant teacher record instead of duplicating (re-add after delete)", async () => {
     mockSchemaReady();
     mockQuery.mockResolvedValueOnce([{ id: 8, program_id: 2 }]); // centre
     mockQuery.mockResolvedValueOnce([]); // existing permission (none — was deleted)
-    mockQuery.mockResolvedValueOnce([{ id: 3098 }]); // orphaned teacher record exists
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [{ id: 602 }] }) // INSERT user_permission
+      .mockResolvedValueOnce({ rows: [{ id: 246195 }] }) // SELECT user (exists by email)
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE user_permission user_id
+      .mockResolvedValueOnce({ rows: [{ id: 3098 }] }); // dormant teacher row exists
     expect(
       await createSeatedUser({
         body: { email: "orphan@x.org", kind: "teacher", centre_id: 8, subject_id: 4 },
       })
-    ).toMatchObject({ ok: false, status: 409 });
-    expect(mockClientQuery).not.toHaveBeenCalled();
+    ).toEqual({ ok: true });
+    // Reuses the dormant row — no duplicate teacher inserted.
+    expect(
+      mockClientQuery.mock.calls.some((c) =>
+        String(c[0]).includes("UPDATE teacher SET")
+      )
+    ).toBe(true);
+    expect(
+      mockClientQuery.mock.calls.some((c) =>
+        String(c[0]).includes("INSERT INTO teacher")
+      )
+    ).toBe(false);
   });
 
   it("createSeatedUser blocks a centre with no program", async () => {

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -33,6 +33,7 @@ import {
   normalizeStaffRosterParams,
   requireStaffAdmin,
   resetStaffSchemaCheckForTests,
+  setUserRole,
   updatePosition,
   updateStaffMember,
   updateTeacherRecord,
@@ -607,6 +608,38 @@ describe("positions", () => {
     const clearCall = mockClientQuery.mock.calls[1];
     expect(clearCall[0]).toContain("SET school_codes = NULL, regions = NULL");
     expect(clearCall[1]).toEqual([70]);
+  });
+
+  it("setUserRole updates every active seat for the person", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([{ id: 44 }, { id: 51 }]); // 2 seats updated
+    expect(
+      await setUserRole({ body: { user_id: 70, role: "spm" } })
+    ).toEqual({ ok: true });
+    const updateCall = mockQuery.mock.calls.at(-1)!;
+    expect(updateCall[0]).toContain("UPDATE centre_positions SET role = $1");
+    expect(updateCall[0]).toContain("WHERE user_id = $2 AND deleted_at IS NULL");
+    expect(updateCall[1]).toEqual(["spm", 70]);
+  });
+
+  it("setUserRole validates user_id and role", async () => {
+    mockSchemaReady();
+    expect(
+      await setUserRole({ body: { user_id: 0, role: "spm" } })
+    ).toMatchObject({ ok: false, status: 422, fields: { user_id: expect.any(String) } });
+    resetStaffSchemaCheckForTests();
+    mockQuery.mockResolvedValueOnce(SCHEMA_ROWS);
+    expect(
+      await setUserRole({ body: { user_id: 70, role: "principal" } })
+    ).toMatchObject({ ok: false, status: 422, fields: { role: expect.any(String) } });
+  });
+
+  it("setUserRole 404s when the person holds no active seats", async () => {
+    mockSchemaReady();
+    mockQuery.mockResolvedValueOnce([]); // no seats updated
+    expect(
+      await setUserRole({ body: { user_id: 70, role: "spm" } })
+    ).toMatchObject({ ok: false, status: 404 });
   });
 
   it("deletePosition soft-deletes a vacant seat", async () => {

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -1055,27 +1055,6 @@ export async function createSeatedUser(params: {
     };
   }
 
-  // Even with no permission, the email may still own an orphaned teacher/staff
-  // record (e.g. left behind when its permission was hard-deleted). Re-creating
-  // one would duplicate the person in the roster (two records, same user → seats
-  // cross-product), so refuse — they should be edited/cleaned from the roster.
-  const dupRecord = await query<{ id: number }>(
-    kind === "teacher"
-      ? `SELECT t.id FROM teacher t JOIN "user" u ON u.id = t.user_id
-         WHERE t.is_af_teacher = true AND LOWER(u.email) = LOWER($1)`
-      : `SELECT s.id FROM staff s JOIN "user" u ON u.id = s.user_id
-         WHERE LOWER(u.email) = LOWER($1)`,
-    [email]
-  );
-  if (dupRecord.length > 0) {
-    return {
-      ok: false,
-      status: 409,
-      error:
-        "This person already has a teacher/staff record — edit them from the roster instead of adding again.",
-    };
-  }
-
   if (code) {
     const codeClash = await query<{ id: number }>(
       kind === "teacher"
@@ -1127,18 +1106,47 @@ export async function createSeatedUser(params: {
       [userId, permissionId]
     );
 
+    // Reuse a dormant teacher/staff record if one exists (e.g. left behind when
+    // this person was previously removed) rather than inserting a duplicate —
+    // this is what makes remove → re-add seamless and dup-free.
     if (kind === "teacher") {
-      await client.query(
-        `INSERT INTO teacher (user_id, is_af_teacher, subject_id, teacher_id, inserted_at, updated_at)
-         VALUES ($1, true, $2, $3, now(), now())`,
-        [userId, subjectId, code]
+      const existing = await client.query<{ id: number }>(
+        `SELECT id FROM teacher WHERE user_id = $1 AND is_af_teacher = true ORDER BY id LIMIT 1`,
+        [userId]
       );
+      if (existing.rows.length > 0) {
+        await client.query(
+          `UPDATE teacher SET subject_id = $1, teacher_id = COALESCE($2, teacher_id),
+             is_af_teacher = true, exit_date = NULL, updated_at = now()
+           WHERE id = $3`,
+          [subjectId, code, existing.rows[0].id]
+        );
+      } else {
+        await client.query(
+          `INSERT INTO teacher (user_id, is_af_teacher, subject_id, teacher_id, inserted_at, updated_at)
+           VALUES ($1, true, $2, $3, now(), now())`,
+          [userId, subjectId, code]
+        );
+      }
     } else {
-      await client.query(
-        `INSERT INTO staff (user_id, employee_code, staff_type, inserted_at, updated_at)
-         VALUES ($1, $2, 'program_manager', now(), now())`,
-        [userId, code]
+      const existing = await client.query<{ id: number }>(
+        `SELECT id FROM staff WHERE user_id = $1 ORDER BY id LIMIT 1`,
+        [userId]
       );
+      if (existing.rows.length > 0) {
+        await client.query(
+          `UPDATE staff SET employee_code = COALESCE($1, employee_code),
+             exit_date = NULL, updated_at = now()
+           WHERE id = $2`,
+          [code, existing.rows[0].id]
+        );
+      } else {
+        await client.query(
+          `INSERT INTO staff (user_id, employee_code, staff_type, inserted_at, updated_at)
+           VALUES ($1, $2, 'program_manager', now(), now())`,
+          [userId, code]
+        );
+      }
     }
 
     await client.query(

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -229,10 +229,22 @@ const ROSTER_CTE = `
     FROM user_permission up
     WHERE up.role IN ('teacher', 'program_manager')
       AND up.revoked_at IS NULL
+      -- A permission row is "pending" only if no real teacher/staff record
+      -- exists for this person. Match by user_id OR email: an orphaned
+      -- user_permission (user_id never linked) whose email already has a
+      -- teacher/staff record is the SAME person, not a second account — keying
+      -- on email too dedupes that phantom out of the roster.
       AND NOT EXISTS (
-        SELECT 1 FROM teacher t WHERE t.user_id = up.user_id AND t.is_af_teacher = true
+        SELECT 1 FROM teacher t
+        JOIN "user" u ON u.id = t.user_id
+        WHERE t.is_af_teacher = true
+          AND (t.user_id = up.user_id OR LOWER(u.email) = LOWER(up.email))
       )
-      AND NOT EXISTS (SELECT 1 FROM staff s WHERE s.user_id = up.user_id)
+      AND NOT EXISTS (
+        SELECT 1 FROM staff s
+        JOIN "user" u ON u.id = s.user_id
+        WHERE (s.user_id = up.user_id OR LOWER(u.email) = LOWER(up.email))
+      )
   )
 `;
 
@@ -741,6 +753,191 @@ export async function createStaffMember(params: {
   });
 
   return { ok: true };
+}
+
+// --- Teachers: LMS-direct create + seat (closes the pending_teacher dead-end) ---
+
+export interface CreateTeacherBody {
+  user_permission_id?: unknown;
+  subject_id?: unknown;
+  centre_id?: unknown;
+  teacher_id?: unknown; // optional AF code; blank => not-yet-hired (TBH)
+}
+
+// Complete a pending_teacher (a role=teacher user_permission with no teacher
+// row) entirely from the UI: create/reuse the user, link it, create the teacher
+// record (subject required), and seat them at a centre — mirroring the PM path
+// (createStaffMember + createPosition) and preserving the seat-as-source-of-truth
+// invariant (clear explicit school scope on seat creation).
+export async function createTeacher(params: {
+  body: CreateTeacherBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const permissionId = Number(params.body.user_permission_id);
+  if (!Number.isInteger(permissionId) || permissionId <= 0) {
+    fields.user_permission_id = "user_permission_id is required";
+  }
+  const subjectId = Number(params.body.subject_id);
+  if (!Number.isInteger(subjectId) || subjectId <= 0) {
+    fields.subject_id = "Subject is required";
+  }
+  const centreId = Number(params.body.centre_id);
+  if (!Number.isInteger(centreId) || centreId <= 0) {
+    fields.centre_id = "Centre is required";
+  }
+  // AF id is optional — blank means a not-yet-hired teacher, set later via edit.
+  let code: string | null = null;
+  const rawCode = params.body.teacher_id;
+  if (rawCode !== undefined && rawCode !== null && String(rawCode).trim() !== "") {
+    code = normalizeEmployeeCode(rawCode);
+    if (!code) {
+      fields.teacher_id = "AF id must look like AF123";
+    }
+  }
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+
+  const permissions = await query<{
+    id: number;
+    email: string;
+    full_name: string | null;
+    role: string;
+    level: number | null;
+    user_id: number | null;
+  }>(
+    `SELECT id, lower(email) AS email, full_name, role, level, user_id
+     FROM user_permission WHERE id = $1`,
+    [permissionId]
+  );
+  if (permissions.length === 0 || permissions[0].role !== "teacher") {
+    return { ok: false, status: 404, error: "Teacher permission row not found" };
+  }
+  const permission = permissions[0];
+
+  // Region-level (level 2) users are scoped by region, not by centre seat —
+  // mirror rejectIfRegionLevelUser, but read level off the permission row since
+  // a pending teacher's user_id may not be linked yet.
+  if (permission.level === 2) {
+    return {
+      ok: false,
+      status: 422,
+      error:
+        "Region-level users can't hold centre seats — their access is scoped by region, not by seat.",
+      fields: { user_id: "This user has region-level access" },
+    };
+  }
+
+  const subjects = await query<{ id: number }>(
+    `SELECT id FROM subject WHERE id = $1`,
+    [subjectId]
+  );
+  if (subjects.length === 0) {
+    return { ok: false, status: 404, error: "Subject not found" };
+  }
+
+  const centres = await query<{ id: number }>(
+    `SELECT id FROM centres WHERE id = $1`,
+    [centreId]
+  );
+  if (centres.length === 0) {
+    return { ok: false, status: 404, error: "Centre not found" };
+  }
+
+  if (code) {
+    const codeClash = await query<{ id: number }>(
+      `SELECT id FROM teacher WHERE teacher_id = $1`,
+      [code]
+    );
+    if (codeClash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: `AF id ${code} is already used by another teacher`,
+      };
+    }
+  }
+
+  // Resolve the effective user identity (reuse-by-email; mirrors
+  // createStaffMember) so we never mint a duplicate that orphans links.
+  let existingUserId: number | null =
+    permission.user_id === null ? null : Number(permission.user_id);
+  if (existingUserId === null) {
+    const found = await query<{ id: number | string }>(
+      `SELECT id FROM "user" WHERE LOWER(email) = $1 ORDER BY id LIMIT 1`,
+      [permission.email]
+    );
+    if (found.length > 0) existingUserId = Number(found[0].id);
+  }
+
+  if (existingUserId !== null) {
+    const teacherClash = await query<{ id: number }>(
+      `SELECT id FROM teacher WHERE user_id = $1 AND is_af_teacher = true`,
+      [existingUserId]
+    );
+    if (teacherClash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: "This person already has a teacher record",
+      };
+    }
+  }
+
+  await withTransaction(async (client) => {
+    let userId = existingUserId;
+    if (userId === null) {
+      const name = (permission.full_name ?? "").trim();
+      const tokens = name.split(/\s+/).filter(Boolean);
+      const inserted = await client.query(
+        `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at)
+         VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+        [
+          tokens[0] ?? null,
+          tokens.length > 1 ? tokens.slice(1).join(" ") : null,
+          permission.email,
+        ]
+      );
+      userId = Number(inserted.rows[0].id);
+    }
+    if (userId !== permission.user_id) {
+      await client.query(
+        `UPDATE user_permission SET user_id = $1, updated_at = now() WHERE id = $2`,
+        [userId, permission.id]
+      );
+    }
+    // Teacher seats carry role 'subject_tbd' (the displayed subject lives in
+    // teacher.subject_id, not the seat role) — same shape seat-pending-teachers.ts uses.
+    await client.query(
+      `INSERT INTO teacher (user_id, is_af_teacher, subject_id, teacher_id, inserted_at, updated_at)
+       VALUES ($1, true, $2, $3, now(), now())`,
+      [userId, subjectId, code]
+    );
+    await client.query(
+      `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+       VALUES ($1, 'subject_tbd', $2, now(), now())`,
+      [centreId, userId]
+    );
+    await clearExplicitSchoolScope(client, userId);
+  });
+
+  return { ok: true };
+}
+
+// Subject options for the create-teacher dropdown. `subject.name` is a
+// multilingual jsonb array; the English label is name->0->>'subject'.
+export async function getSubjectOptions(): Promise<
+  { id: number; name: string }[]
+> {
+  const rows = await query<{ id: number | string; name: string | null }>(
+    `SELECT id, name->0->>'subject' AS name FROM subject
+     WHERE name->0->>'subject' IS NOT NULL
+     ORDER BY name->0->>'subject'`
+  );
+  return rows.map((r) => ({ id: Number(r.id), name: r.name ?? "" }));
 }
 
 export interface UpdateStaffMemberBody {

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -1007,6 +1007,51 @@ export async function updatePosition(params: {
   return { ok: true };
 }
 
+// Org tier (PM/APM/SPM/PH) is a person-level attribute, not per-centre: someone
+// is the same tier at every centre they sit at. It is physically stored on each
+// centre_positions row, so setting a person's role updates *all* their active
+// seats at once, keeping them uniform.
+export interface SetUserRoleBody {
+  user_id?: unknown;
+  role?: unknown;
+}
+
+export async function setUserRole(params: {
+  body: SetUserRoleBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const userId = Number(params.body.user_id);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    fields.user_id = "user_id is required";
+  }
+  if (!isSeatRole(params.body.role)) {
+    fields.role = `Role must be one of: ${SEAT_ROLES.join(", ")}`;
+  }
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+  const role = params.body.role as SeatRole;
+
+  const updated = await query<{ id: number }>(
+    `UPDATE centre_positions SET role = $1, updated_at = now()
+     WHERE user_id = $2 AND deleted_at IS NULL
+     RETURNING id`,
+    [role, userId]
+  );
+  if (updated.length === 0) {
+    return {
+      ok: false,
+      status: 404,
+      error: "This person has no centre assignments to set a role on",
+    };
+  }
+
+  return { ok: true };
+}
+
 export async function deletePosition(params: {
   id: number;
   force?: boolean;

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -111,6 +111,7 @@ export function resetStaffSchemaCheckForTests() {
 // --- Shared shapes (client-safe values/types live in staff-shared) ---
 
 import {
+  PM_SEAT_ROLES,
   SEAT_ROLES,
   isSeatRole,
   normalizeEmployeeCode,
@@ -211,6 +212,14 @@ const ROSTER_CTE = `
     JOIN "user" u ON u.id = t.user_id
     LEFT JOIN subject sub ON sub.id = t.subject_id
     WHERE t.is_af_teacher = true
+      -- An active user_permission is the source of truth for personhood:
+      -- deleting a user from the permissions screen removes them from the roster
+      -- (and orphaned teacher/staff rows with no live permission stay hidden).
+      AND EXISTS (
+        SELECT 1 FROM user_permission up
+        WHERE (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+          AND up.revoked_at IS NULL
+      )
     UNION ALL
     SELECT
       'staff', s.id, u.id,
@@ -219,6 +228,11 @@ const ROSTER_CTE = `
       s.exit_date::text
     FROM staff s
     JOIN "user" u ON u.id = s.user_id
+    WHERE EXISTS (
+      SELECT 1 FROM user_permission up
+      WHERE (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+        AND up.revoked_at IS NULL
+    )
     UNION ALL
     SELECT
       CASE WHEN up.role = 'teacher' THEN 'pending_teacher' ELSE 'pending_pm' END,
@@ -922,6 +936,216 @@ export async function createTeacher(params: {
       [centreId, userId]
     );
     await clearExplicitSchoolScope(client, userId);
+  });
+
+  return { ok: true };
+}
+
+// --- Add centre staff from scratch (self-contained Staff Management) ---
+
+export interface CreateSeatedUserBody {
+  email?: unknown;
+  full_name?: unknown;
+  kind?: unknown; // "teacher" | "staff"
+  centre_id?: unknown;
+  subject_id?: unknown; // teacher only (required)
+  role?: unknown; // staff only: PM tier (apm/pm/spm/ph)
+  af_id?: unknown; // optional AF code
+}
+
+function isPmSeatRole(value: unknown): value is SeatRole {
+  return (
+    typeof value === "string" &&
+    (PM_SEAT_ROLES as readonly string[]).includes(value)
+  );
+}
+
+// Create a brand-new centre-staff person and seat them in ONE transaction —
+// permission + user + teacher/staff record + centre seat — so the Staff
+// Management page is self-contained (no separate Add User on /admin/users).
+// Centre staff are level-1, seat-scoped: program_ids derive from the centre's
+// program and explicit school scope is left NULL (resolveScope uses the seat).
+// Atomic by design: a failure rolls back the whole thing rather than leaving an
+// orphaned user_permission (the phantom-duplicate failure mode).
+export async function createSeatedUser(params: {
+  body: CreateSeatedUserBody;
+}): Promise<StaffMutationResult> {
+  const schema = await checkStaffManagementSchema();
+  if (!schema.ok) return schema;
+
+  const fields: Record<string, string> = {};
+  const email =
+    typeof params.body.email === "string" ? params.body.email.trim() : "";
+  if (!email || !email.includes("@")) {
+    fields.email = "A valid email is required";
+  }
+  const kind = params.body.kind;
+  if (kind !== "teacher" && kind !== "staff") {
+    fields.kind = "kind must be 'teacher' or 'staff'";
+  }
+  const centreId = Number(params.body.centre_id);
+  if (!Number.isInteger(centreId) || centreId <= 0) {
+    fields.centre_id = "Centre is required";
+  }
+  let subjectId: number | null = null;
+  let seatRole: SeatRole = "subject_tbd";
+  if (kind === "teacher") {
+    subjectId = Number(params.body.subject_id);
+    if (!Number.isInteger(subjectId) || subjectId <= 0) {
+      fields.subject_id = "Subject is required";
+    }
+    seatRole = "subject_tbd";
+  } else if (kind === "staff") {
+    if (!isPmSeatRole(params.body.role)) {
+      fields.role = `Role must be one of: ${PM_SEAT_ROLES.join(", ")}`;
+    } else {
+      seatRole = params.body.role as SeatRole;
+    }
+  }
+  let code: string | null = null;
+  const rawCode = params.body.af_id;
+  if (rawCode !== undefined && rawCode !== null && String(rawCode).trim() !== "") {
+    code = normalizeEmployeeCode(rawCode);
+    if (!code) {
+      fields.af_id = "AF id must look like AF123";
+    }
+  }
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, status: 422, error: "Validation failed", fields };
+  }
+
+  const fullName =
+    typeof params.body.full_name === "string"
+      ? params.body.full_name.trim()
+      : "";
+
+  // The centre supplies the program scope (level-1 centre staff see students by
+  // program ∩ school). A centre with no program can't seed program_ids.
+  const centres = await query<{ id: number; program_id: number | null }>(
+    `SELECT id, program_id FROM centres WHERE id = $1`,
+    [centreId]
+  );
+  if (centres.length === 0) {
+    return { ok: false, status: 404, error: "Centre not found" };
+  }
+  const programId = centres[0].program_id;
+  if (programId == null) {
+    return {
+      ok: false,
+      status: 422,
+      error:
+        "This centre has no program set — set its program in Centres first, then add staff.",
+      fields: { centre_id: "Centre has no program" },
+    };
+  }
+
+  // "Add" is for NEW people. Refuse (case-insensitively, closing the
+  // case-variant dup gap for this path) when a permission already exists — the
+  // admin should edit that person from the roster instead.
+  const existingPerm = await query<{ id: number }>(
+    `SELECT id FROM user_permission WHERE LOWER(email) = LOWER($1)`,
+    [email]
+  );
+  if (existingPerm.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "A user with this email already exists — edit them from the roster instead of adding again.",
+    };
+  }
+
+  // Even with no permission, the email may still own an orphaned teacher/staff
+  // record (e.g. left behind when its permission was hard-deleted). Re-creating
+  // one would duplicate the person in the roster (two records, same user → seats
+  // cross-product), so refuse — they should be edited/cleaned from the roster.
+  const dupRecord = await query<{ id: number }>(
+    kind === "teacher"
+      ? `SELECT t.id FROM teacher t JOIN "user" u ON u.id = t.user_id
+         WHERE t.is_af_teacher = true AND LOWER(u.email) = LOWER($1)`
+      : `SELECT s.id FROM staff s JOIN "user" u ON u.id = s.user_id
+         WHERE LOWER(u.email) = LOWER($1)`,
+    [email]
+  );
+  if (dupRecord.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "This person already has a teacher/staff record — edit them from the roster instead of adding again.",
+    };
+  }
+
+  if (code) {
+    const codeClash = await query<{ id: number }>(
+      kind === "teacher"
+        ? `SELECT id FROM teacher WHERE teacher_id = $1`
+        : `SELECT id FROM staff WHERE employee_code = $1`,
+      [code]
+    );
+    if (codeClash.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: `AF id ${code} is already in use`,
+      };
+    }
+  }
+
+  const role = kind === "teacher" ? "teacher" : "program_manager";
+
+  await withTransaction(async (client) => {
+    const permIns = await client.query(
+      `INSERT INTO user_permission
+         (email, level, role, school_codes, regions, program_ids, read_only, full_name, inserted_at, updated_at)
+       VALUES ($1, 1, $2, NULL, NULL, $3, false, $4, now(), now())
+       RETURNING id`,
+      [email, role, [programId], fullName || null]
+    );
+    const permissionId = Number(permIns.rows[0].id);
+
+    // Reuse an existing user row for this email if one somehow exists; else mint.
+    let userId: number | null = null;
+    const foundUser = await client.query<{ id: number | string }>(
+      `SELECT id FROM "user" WHERE LOWER(email) = LOWER($1) ORDER BY id LIMIT 1`,
+      [email]
+    );
+    if (foundUser.rows.length > 0) {
+      userId = Number(foundUser.rows[0].id);
+    } else {
+      const tokens = fullName.split(/\s+/).filter(Boolean);
+      const userIns = await client.query(
+        `INSERT INTO "user" (first_name, last_name, email, inserted_at, updated_at)
+         VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+        [tokens[0] ?? null, tokens.length > 1 ? tokens.slice(1).join(" ") : null, email]
+      );
+      userId = Number(userIns.rows[0].id);
+    }
+
+    await client.query(
+      `UPDATE user_permission SET user_id = $1, updated_at = now() WHERE id = $2`,
+      [userId, permissionId]
+    );
+
+    if (kind === "teacher") {
+      await client.query(
+        `INSERT INTO teacher (user_id, is_af_teacher, subject_id, teacher_id, inserted_at, updated_at)
+         VALUES ($1, true, $2, $3, now(), now())`,
+        [userId, subjectId, code]
+      );
+    } else {
+      await client.query(
+        `INSERT INTO staff (user_id, employee_code, staff_type, inserted_at, updated_at)
+         VALUES ($1, $2, 'program_manager', now(), now())`,
+        [userId, code]
+      );
+    }
+
+    await client.query(
+      `INSERT INTO centre_positions (centre_id, role, user_id, inserted_at, updated_at)
+       VALUES ($1, $2, $3, now(), now())`,
+      [centreId, seatRole, userId]
+    );
   });
 
   return { ok: true };

--- a/src/lib/staff-shared.ts
+++ b/src/lib/staff-shared.ts
@@ -14,6 +14,9 @@ export const SEAT_ROLES = [
   "apm",
   "spm",
   "ph",
+  // Placeholder for a teacher seated at a centre before their subject is known
+  // (auto-assigned from school+program). Ops edits it to the real subject.
+  "subject_tbd",
 ] as const;
 
 /** Program-management seat tiers (vs subject-teaching seats). */

--- a/src/lib/staff-shared.ts
+++ b/src/lib/staff-shared.ts
@@ -11,7 +11,13 @@ export const SEAT_ROLES = [
   "biology",
   "apc",
   "pm",
+  "apm",
+  "spm",
+  "ph",
 ] as const;
+
+/** Program-management seat tiers (vs subject-teaching seats). */
+export const PM_SEAT_ROLES = ["apm", "pm", "spm", "ph"] as const;
 
 export type SeatRole = (typeof SEAT_ROLES)[number];
 


### PR DESCRIPTION
Stacked on `feat/staff-management-v1` (PR #124). Continues the centre-seat access model for the PM + teacher centre-assignment rollout. All work verified on **staging**.

## What's here

**PM-family centre seats** (earlier commits on this branch): apm/spm/ph seat tiers + sheet importer, StaffGrid role-display fix, teacher `user_permission` mirror (prod→staging), auto-seat pending teachers by school∩program.

**This session:**
- **Seat ops-named teachers** (`scripts/seat-named-teachers.ts`) — explicit email→centre→program list → user + teacher row + `subject_tbd` seat, so they're editable in Staff Management. Env-portable, idempotent, dry-run/apply.
- **Seats are the source of truth for school scope:**
  - `clear-seated-scope`: never clears someone into an empty scope — skips users whose seats cover no linked school (avoids lockout); reports them as `skippedWouldBeEmpty`.
  - `PATCH /api/admin/users/[id]`: rejects (409) `school_codes`/`regions` edits for a seated user and forces those columns NULL.
  - `UserList`: disables Edit + shows "Edit in Staff Management only" for seated users.

## Staging results
- Seated 6 ops-named teachers (EMRS Bhopal / Chandrapur / RGJNV Dehradun).
- Ran `clear-seated-scope --apply`: cleared 45 seated users' explicit scope; **teacher seat/school mismatches 9 → 0**; protected the one unlinked-centre teacher from lockout.

## Tests
Lint + source typecheck clean. 43 tests pass across the touched files (clear-seated-scope, users route, UserList) incl. new cases for the guard, the 409, and the disabled-Edit UI.

## Notes
- Base is `feat/staff-management-v1` (unmerged); rebase/retarget to `main` once that lands.
- The `clear-seated-scope --apply` + seating scripts will be replayed on prod during promotion (per the prod-promotion plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)