### PR TITLE
Update visit action point fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "eslint-config-next": "16.0.5",
         "fallow": "^2.96.0",
         "jsdom": "^28.1.0",
-        "monocart-coverage-reports": "^2.12.9",
         "monocart-reporter": "^2.10.0",
         "tailwindcss": "^4",
         "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-config-next": "16.0.5",
     "fallow": "^2.96.0",
     "jsdom": "^28.1.0",
-    "monocart-coverage-reports": "^2.12.9",
     "monocart-reporter": "^2.10.0",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",

--- a/src/app/api/pm/classroom-observation-options/route.test.ts
+++ b/src/app/api/pm/classroom-observation-options/route.test.ts
@@ -1,0 +1,126 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ADMIN_SESSION,
+  NO_SESSION,
+  PASSCODE_SESSION,
+  PM_SESSION,
+} from "@/app/api/__test-utils__/api-test-helpers";
+
+vi.mock("next-auth");
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db");
+vi.mock("@/lib/classroom-observation-curriculum", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/classroom-observation-curriculum")>();
+  return {
+    ...actual,
+    getClassroomObservationCurriculumOptions: vi.fn(),
+  };
+});
+
+import { getServerSession } from "next-auth";
+
+import { getClassroomObservationCurriculumOptions } from "@/lib/classroom-observation-curriculum";
+import { query } from "@/lib/db";
+import { GET } from "./route";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockQuery = vi.mocked(query);
+const mockGetOptions = vi.mocked(getClassroomObservationCurriculumOptions);
+
+function optionsRequest(params = "school_code=SCH001&grade=11"): NextRequest {
+  return new NextRequest(new URL(`http://localhost/api/pm/classroom-observation-options?${params}`));
+}
+
+function stubPermission(overrides: Record<string, unknown> = {}) {
+  mockQuery.mockResolvedValueOnce([
+    {
+      role: "program_manager",
+      level: 3,
+      school_codes: [],
+      regions: [],
+      program_ids: [1],
+      read_only: false,
+      ...overrides,
+    },
+  ] as never);
+}
+
+describe("GET /api/pm/classroom-observation-options", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValueOnce(NO_SESSION);
+
+    const response = await GET(optionsRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for passcode users", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PASSCODE_SESSION);
+
+    const response = await GET(optionsRequest());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when school_code is missing", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission();
+
+    const response = await GET(optionsRequest("grade=11"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "school_code query parameter is required",
+    });
+  });
+
+  it("returns 400 when grade is invalid", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission();
+
+    const response = await GET(optionsRequest("school_code=SCH001&grade=9"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "grade must be one of: 10, 11, 12",
+    });
+  });
+
+  it("returns 403 when PM cannot access the requested school", async () => {
+    mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
+    stubPermission({ level: 1, school_codes: ["OTHER"] });
+    mockQuery.mockResolvedValueOnce([{ region: "North" }] as never);
+
+    const response = await GET(optionsRequest());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns classroom observation curriculum options for an accessible school", async () => {
+    mockGetServerSession.mockResolvedValueOnce(ADMIN_SESSION);
+    stubPermission({ role: "admin" });
+    mockQuery.mockResolvedValueOnce([{ region: "North" }] as never);
+    mockGetOptions.mockResolvedValueOnce({
+      curricula: [{ id: 1, name: "JEE Mains", code: "JMNS" }],
+      chapters: [],
+      topics: [],
+    });
+
+    const response = await GET(optionsRequest("school_code=SCH001&grade=12"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      curricula: [{ id: 1, name: "JEE Mains", code: "JMNS" }],
+      chapters: [],
+      topics: [],
+    });
+    expect(mockGetOptions).toHaveBeenCalledWith({ grade: 12 });
+  });
+});

--- a/src/app/api/pm/classroom-observation-options/route.ts
+++ b/src/app/api/pm/classroom-observation-options/route.ts
@@ -6,12 +6,7 @@ import {
   getClassroomObservationCurriculumOptions,
   isClassroomObservationGrade,
 } from "@/lib/classroom-observation-curriculum";
-import { query } from "@/lib/db";
-import { apiError, canAccessVisitSchoolScope, requireVisitsAccess } from "@/lib/visits-policy";
-
-interface SchoolRow {
-  region: string | null;
-}
+import { apiError, requireVisitsAccess, resolveAccessibleVisitSchoolRegion } from "@/lib/visits-policy";
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -30,14 +25,9 @@ export async function GET(request: NextRequest) {
     return apiError(400, "grade must be one of: 10, 11, 12");
   }
 
-  const schoolRows = await query<SchoolRow>(
-    `SELECT region FROM school WHERE code = $1`,
-    [schoolCode]
-  );
-  const schoolRegion = schoolRows[0]?.region ?? null;
-
-  if (!canAccessVisitSchoolScope(access.actor, schoolCode, schoolRegion)) {
-    return apiError(403, "Forbidden");
+  const schoolAccess = await resolveAccessibleVisitSchoolRegion(access.actor, schoolCode);
+  if (!schoolAccess.ok) {
+    return schoolAccess.response;
   }
 
   const options = await getClassroomObservationCurriculumOptions({ grade });

--- a/src/app/api/pm/classroom-observation-options/route.ts
+++ b/src/app/api/pm/classroom-observation-options/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  getClassroomObservationCurriculumOptions,
+  isClassroomObservationGrade,
+} from "@/lib/classroom-observation-curriculum";
+import { query } from "@/lib/db";
+import { apiError, canAccessVisitSchoolScope, requireVisitsAccess } from "@/lib/visits-policy";
+
+interface SchoolRow {
+  region: string | null;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const access = await requireVisitsAccess(session, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
+  if (!schoolCode) {
+    return apiError(400, "school_code query parameter is required");
+  }
+
+  const grade = Number.parseInt(request.nextUrl.searchParams.get("grade") || "", 10);
+  if (!Number.isFinite(grade) || !isClassroomObservationGrade(grade)) {
+    return apiError(400, "grade must be one of: 10, 11, 12");
+  }
+
+  const schoolRows = await query<SchoolRow>(
+    `SELECT region FROM school WHERE code = $1`,
+    [schoolCode]
+  );
+  const schoolRegion = schoolRows[0]?.region ?? null;
+
+  if (!canAccessVisitSchoolScope(access.actor, schoolCode, schoolRegion)) {
+    return apiError(403, "Forbidden");
+  }
+
+  const options = await getClassroomObservationCurriculumOptions({ grade });
+  return NextResponse.json(options);
+}

--- a/src/app/api/pm/teachers/route.ts
+++ b/src/app/api/pm/teachers/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
-import { apiError, canAccessVisitSchoolScope, requireVisitsAccess } from "@/lib/visits-policy";
+import { apiError, requireVisitsAccess, resolveAccessibleVisitSchoolRegion } from "@/lib/visits-policy";
 
 interface TeacherRow {
   id: number;
@@ -24,18 +24,10 @@ export async function GET(request: NextRequest) {
     return apiError(400, "school_code query parameter is required");
   }
 
-  // Find the school's region so we can include region-level teachers
-  const schoolRows = await query<{ region: string | null }>(
-    `SELECT region FROM school WHERE code = $1`,
-    [schoolCode]
-  );
-  const schoolRegion = schoolRows[0]?.region ?? null;
-
-  // Check if the user can access this school
-  if (!canAccessVisitSchoolScope(access.actor, schoolCode, schoolRegion)) {
-    return apiError(403, "Forbidden");
+  const schoolAccess = await resolveAccessibleVisitSchoolRegion(access.actor, schoolCode);
+  if (!schoolAccess.ok) {
+    return schoolAccess.response;
   }
-
 
   // Match teachers who either:
   // 1. Have this school_code in their school_codes array (level 1), OR
@@ -51,7 +43,7 @@ export async function GET(request: NextRequest) {
          OR level = 3
        )
      ORDER BY full_name NULLS LAST, email`,
-    [schoolCode, schoolRegion]
+    [schoolCode, schoolAccess.schoolRegion]
   );
 
   return NextResponse.json({ teachers });

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/route.test.ts
@@ -1052,6 +1052,30 @@ describe("PATCH /api/pm/visits/[id]/actions/[actionId]", () => {
     await expect(res.json()).resolves.toEqual({ action: updated });
   });
 
+  it("accepts action-level additional notes for in-progress principal interaction", async () => {
+    setupPmView();
+    const action = { ...BASE_ACTION_ROW, action_type: "principal_interaction" };
+    const payload = { questions: {}, additional_notes: "Follow up on timetable changes" };
+    const updated = { ...action, data: payload };
+    mockQuery
+      .mockResolvedValueOnce([VISIT_ROW])
+      .mockResolvedValueOnce([action])
+      .mockResolvedValueOnce([updated]);
+
+    const req = new Request("http://localhost/api/pm/visits/10/actions/101", {
+      method: "PATCH",
+      body: JSON.stringify({ data: payload }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await PATCH(req as never, params);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ action: updated });
+    const [updateQueryText, updateParams] = mockQuery.mock.calls[2] as [string, unknown[]];
+    expect(updateQueryText).toContain("UPDATE lms_pm_school_visit_actions");
+    expect(JSON.parse(String(updateParams[2]))).toEqual(payload);
+  });
+
   it("returns 422 for principal interaction with unknown top-level keys (lenient)", async () => {
     setupPmView();
     mockQuery

--- a/src/app/api/pm/visits/[id]/complete/route.test.ts
+++ b/src/app/api/pm/visits/[id]/complete/route.test.ts
@@ -14,7 +14,6 @@ vi.mock("@/lib/db", () => ({ query: vi.fn() }));
 
 import { getServerSession } from "next-auth";
 
-import { AF_TEAM_INTERACTION_CONFIG } from "@/lib/af-team-interaction";
 import {
   CLASSROOM_OBSERVATION_RUBRIC,
   CURRENT_RUBRIC_VERSION,
@@ -86,17 +85,6 @@ const COMPLETED_VISIT_ROW = {
   status: "completed",
   completed_at: "2026-02-19T12:00:00.000Z",
 };
-
-function buildValidAFTeamData() {
-  const questions = Object.fromEntries(
-    AF_TEAM_INTERACTION_CONFIG.allQuestionKeys.map((key) => [key, { answer: true }])
-  );
-  return {
-    teachers: [{ id: 1, name: "Teacher A" }],
-    questions,
-  };
-}
-
 
 function buildValidClassroomData() {
   const params = Object.fromEntries(
@@ -290,7 +278,6 @@ describe("POST /api/pm/visits/[id]/complete", () => {
       .mockResolvedValueOnce([{ id: 601 }]) // completed principal_interaction
       .mockResolvedValueOnce([{ id: 701 }]) // completed group_student_discussion
       .mockResolvedValueOnce([{ id: 801 }]) // completed individual_student_discussion
-      .mockResolvedValueOnce([{ id: 901 }]) // completed school_staff_interaction
       .mockResolvedValueOnce([
         {
           id: 10,
@@ -318,7 +305,7 @@ describe("POST /api/pm/visits/[id]/complete", () => {
     expect(visitQueryText).toContain("v.deleted_at IS NULL");
     expect(visitParams).toEqual(["10"]);
 
-    const [completionQueryText, completionParams] = mockQuery.mock.calls[9] as [string, unknown[]];
+    const [completionQueryText, completionParams] = mockQuery.mock.calls[8] as [string, unknown[]];
     expect(completionQueryText).toContain("UPDATE lms_pm_school_visits v");
     expect(completionQueryText).toContain("status = 'completed'");
     expect(completionQueryText).toContain("completed_at = (NOW() AT TIME ZONE 'UTC')");
@@ -368,7 +355,6 @@ describe("POST /api/pm/visits/[id]/complete", () => {
       .mockResolvedValueOnce([{ id: 602 }]) // completed principal_interaction
       .mockResolvedValueOnce([{ id: 702 }]) // completed group_student_discussion
       .mockResolvedValueOnce([{ id: 802 }]) // completed individual_student_discussion
-      .mockResolvedValueOnce([{ id: 902 }]) // completed school_staff_interaction
       .mockResolvedValueOnce([
         {
           id: 10,
@@ -509,7 +495,7 @@ describe("POST /api/pm/visits/[id]/complete", () => {
     });
   });
 
-  it("returns 422 when school_staff_interaction is missing", async () => {
+  it("completes visit when school_staff_interaction is missing", async () => {
     setupPmEdit();
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
@@ -525,18 +511,28 @@ describe("POST /api/pm/visits/[id]/complete", () => {
       .mockResolvedValueOnce([{ id: 601 }]) // completed principal_interaction
       .mockResolvedValueOnce([{ id: 701 }]) // completed group_student_discussion
       .mockResolvedValueOnce([{ id: 801 }]) // completed individual_student_discussion
-      .mockResolvedValueOnce([]); // no completed school_staff_interaction
+      .mockResolvedValueOnce([
+        {
+          id: 10,
+          status: "completed",
+          completed_at: "2026-02-19T12:25:00.000Z",
+        },
+      ]);
 
     const res = await POST(completionRequest() as never, params);
 
-    expect(res.status).toBe(422);
+    expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({
-      error: "At least one completed School Staff Interaction is required to complete visit",
-      details: ["No completed school_staff_interaction action found for this visit"],
+      visit: {
+        id: 10,
+        status: "completed",
+        completed_at: "2026-02-19T12:25:00.000Z",
+      },
     });
+    expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes("school_staff_interaction"))).toBe(false);
   });
 
-  it("completes visit when all 7 action types have completed actions", async () => {
+  it("completes visit when all required action types have completed actions", async () => {
     setupPmEdit();
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
@@ -552,7 +548,6 @@ describe("POST /api/pm/visits/[id]/complete", () => {
       .mockResolvedValueOnce([{ id: 601 }]) // completed principal_interaction
       .mockResolvedValueOnce([{ id: 701 }]) // completed group_student_discussion
       .mockResolvedValueOnce([{ id: 801 }]) // completed individual_student_discussion
-      .mockResolvedValueOnce([{ id: 901 }]) // completed school_staff_interaction
       .mockResolvedValueOnce([
         {
           id: 10,
@@ -589,7 +584,6 @@ describe("POST /api/pm/visits/[id]/complete", () => {
       .mockResolvedValueOnce([{ id: 601 }]) // completed principal_interaction
       .mockResolvedValueOnce([{ id: 701 }]) // completed group_student_discussion
       .mockResolvedValueOnce([{ id: 801, data: { entries: [{ invalid: true }] } }]) // status-only check
-      .mockResolvedValueOnce([{ id: 901 }]) // completed school_staff_interaction
       .mockResolvedValueOnce([
         {
           id: 10,

--- a/src/app/api/pm/visits/[id]/complete/route.ts
+++ b/src/app/api/pm/visits/[id]/complete/route.ts
@@ -262,25 +262,6 @@ export async function POST(
     );
   }
 
-  const completedSchoolStaffActions = await query<{ id: number }>(
-    `SELECT a.id
-     FROM lms_pm_school_visit_actions a
-     WHERE a.visit_id = $1
-       AND a.deleted_at IS NULL
-       AND a.action_type = 'school_staff_interaction'
-       AND a.status = 'completed'
-     LIMIT 1`,
-    [id]
-  );
-
-  if (completedSchoolStaffActions.length === 0) {
-    return apiError(
-      422,
-      "At least one completed School Staff Interaction is required to complete visit",
-      ["No completed school_staff_interaction action found for this visit"]
-    );
-  }
-
   const updatedVisit = await query<Pick<VisitAccessRow, "id" | "status" | "completed_at">>(
     `UPDATE lms_pm_school_visits v
      SET status = 'completed',

--- a/src/app/school-visit-summary/[id]/page.test.tsx
+++ b/src/app/school-visit-summary/[id]/page.test.tsx
@@ -168,6 +168,7 @@ const actions = [
     action_type: "principal_interaction",
     status: "completed",
     data: {
+      additional_notes: "Bring district schedule next visit",
       questions: {
         oh_program_feedback: { answer: true, remark: "Principal asked for monthly updates" },
       },
@@ -338,6 +339,8 @@ describe("SchoolVisitSummaryDetailPage", () => {
     expect(within(remarks).getByText("Students were engaged")).toBeInTheDocument();
     expect(within(remarks).getByText("Classes are on schedule")).toBeInTheDocument();
     expect(within(remarks).getByText("Principal asked for monthly updates")).toBeInTheDocument();
+    expect(within(remarks).getByText("Additional Notes or Concerns")).toBeInTheDocument();
+    expect(within(remarks).getByText("Bring district schedule next visit")).toBeInTheDocument();
     expect(within(remarks).getByText("Students want slower pacing")).toBeInTheDocument();
 
     expect(screen.queryByText("Delete")).not.toBeInTheDocument();

--- a/src/app/school-visit-summary/[id]/page.test.tsx
+++ b/src/app/school-visit-summary/[id]/page.test.tsx
@@ -112,6 +112,12 @@ const actions = [
     action_type: "classroom_observation",
     status: "completed",
     data: {
+      teacher_name: "Anita Teacher",
+      grade: "11",
+      curriculum_name: "JEE Mains",
+      chapter_name: "Fundamentals of Mathematics",
+      subject_name: "Maths",
+      topic_name: "Introduction",
       params: { teacher_on_time: { score: 1, remarks: "Started on time" } },
       observer_summary_strengths: "Students were engaged",
     },
@@ -312,20 +318,24 @@ describe("SchoolVisitSummaryDetailPage", () => {
     expect(screen.getByText("2h 30m")).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "GPS" })).toHaveLength(2);
 
-    expect(screen.getByRole("heading", { name: "Classroom Observation" })).toBeInTheDocument();
-    expect(screen.getByText("Score 1/45")).toBeInTheDocument();
-    expect(screen.getByText("Remarks 1")).toBeInTheDocument();
-    expect(screen.getByText("Answered 2/9")).toBeInTheDocument();
-    expect(screen.getByText("Teachers 2")).toBeInTheDocument();
-    expect(screen.getByText("Teachers 3 (1 present, 1 on leave, 1 absent)")).toBeInTheDocument();
-    expect(screen.getByText("Avg answered 2/13")).toBeInTheDocument();
-    expect(screen.getByText("Answered 1/7")).toBeInTheDocument();
-    expect(screen.getByText("Grade 12")).toBeInTheDocument();
-    expect(screen.getByText("Answered 1/4")).toBeInTheDocument();
-    expect(screen.getByText("Entries 2")).toBeInTheDocument();
-    expect(screen.getByText("Students 3")).toBeInTheDocument();
-    expect(screen.getByText("Avg answered 1/2")).toBeInTheDocument();
-    expect(screen.getByText("Answered 1/2")).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { name: "Classroom Observation" }).length).toBeGreaterThan(0);
+    for (const chip of [
+      "Score 1/45",
+      "Remarks 1",
+      "Answered 2/9",
+      "Teachers 2",
+      "Teachers 3 (1 present, 1 on leave, 1 absent)",
+      "Avg answered 2/13",
+      "Answered 1/7",
+      "Grade 12",
+      "Answered 1/4",
+      "Entries 2",
+      "Students 3",
+      "Avg answered 1/2",
+      "Answered 1/2",
+    ]) {
+      expect(screen.getAllByText(chip).length).toBeGreaterThan(0);
+    }
     expect(screen.getByRole("heading", { name: "Other" })).toBeInTheDocument();
 
     const detailLinks = screen.getAllByRole("link", { name: "View full detail" });
@@ -335,13 +345,37 @@ describe("SchoolVisitSummaryDetailPage", () => {
     expect(detailHrefs).toContain("/visits/101/actions/208?from=summary");
 
     const remarks = screen.getByRole("region", { name: "Remarks" });
-    expect(within(remarks).getByText("Started on time")).toBeInTheDocument();
-    expect(within(remarks).getByText("Students were engaged")).toBeInTheDocument();
-    expect(within(remarks).getByText("Classes are on schedule")).toBeInTheDocument();
-    expect(within(remarks).getByText("Principal asked for monthly updates")).toBeInTheDocument();
-    expect(within(remarks).getByText("Additional Notes or Concerns")).toBeInTheDocument();
-    expect(within(remarks).getByText("Bring district schedule next visit")).toBeInTheDocument();
-    expect(within(remarks).getByText("Students want slower pacing")).toBeInTheDocument();
+    const classroomRemarks = within(remarks).getByRole("group", {
+      name: "Classroom Observation #201",
+    });
+    expect(within(classroomRemarks).getByText("Action #201")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Teacher Anita Teacher")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Grade 11")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Curriculum JEE Mains")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Chapter Maths - Fundamentals of Mathematics")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Topic Introduction")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Started on time")).toBeInTheDocument();
+    expect(within(classroomRemarks).getByText("Students were engaged")).toBeInTheDocument();
+    expect(within(classroomRemarks).queryByText("Classes are on schedule")).not.toBeInTheDocument();
+
+    const afTeamRemarks = within(remarks).getByRole("group", {
+      name: "AF Team Interaction #202",
+    });
+    expect(within(afTeamRemarks).getByText("Classes are on schedule")).toBeInTheDocument();
+
+    const principalRemarks = within(remarks).getByRole("group", {
+      name: "Principal Interaction #204",
+    });
+    expect(within(principalRemarks).getByText("Principal asked for monthly updates")).toBeInTheDocument();
+    expect(within(principalRemarks).getByText("Additional Notes or Concerns")).toBeInTheDocument();
+    expect(within(principalRemarks).getByText("Bring district schedule next visit")).toBeInTheDocument();
+    expect(within(principalRemarks).queryByText("Students want slower pacing")).not.toBeInTheDocument();
+
+    const individualStudentRemarks = within(remarks).getByRole("group", {
+      name: "Individual Student Interaction #206",
+    });
+    expect(within(individualStudentRemarks).getByText("Students want slower pacing")).toBeInTheDocument();
+    expect(within(remarks).queryByRole("group", { name: "Other #208" })).not.toBeInTheDocument();
 
     expect(screen.queryByText("Delete")).not.toBeInTheDocument();
     expect(screen.queryByText("Start")).not.toBeInTheDocument();

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -62,6 +62,16 @@ interface VisitActionDetail {
 
 type InlineStats = Record<string, unknown>;
 
+interface RemarkGroup {
+  actionId: number;
+  actionType: string;
+  actionLabel: string;
+  status: string;
+  detailHref: string;
+  chips: string[];
+  remarks: RemarkEntry[];
+}
+
 function formatDate(value: string): string {
   return new Date(value).toLocaleDateString("en-IN", {
     day: "2-digit",
@@ -199,6 +209,39 @@ function statsChips(actionType: string, stats: unknown): string[] {
   return buildChips && isStats(stats) ? buildChips(stats) : [];
 }
 
+function isDataRecord(data: unknown): data is Record<string, unknown> {
+  return data !== null && typeof data === "object" && !Array.isArray(data);
+}
+
+function nonEmptyDataString(data: Record<string, unknown>, key: string): string | null {
+  const value = data[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function classroomRemarkContextChips(data: unknown): string[] {
+  if (!isDataRecord(data)) {
+    return [];
+  }
+
+  const teacherName = nonEmptyDataString(data, "teacher_name");
+  const grade = nonEmptyDataString(data, "grade");
+  return [
+    ...(teacherName ? [`Teacher ${teacherName}`] : []),
+    ...(grade ? [`Grade ${grade}`] : []),
+  ];
+}
+
+function remarkGroupChips(action: VisitActionDetail): string[] {
+  const summaryChips = statsChips(
+    action.action_type,
+    dispatchComputeInlineStats(action.action_type, action.data)
+  ).filter((chip) => !chip.startsWith("Remarks "));
+
+  return action.action_type === "classroom_observation"
+    ? [...classroomRemarkContextChips(action.data), ...summaryChips]
+    : summaryChips;
+}
+
 function actionTypeLabel(actionType: string): string {
   return isActionType(actionType) ? ACTION_TYPES[actionType] : "Other";
 }
@@ -225,17 +268,23 @@ function groupActions(actions: VisitActionDetail[]): Array<{
   ];
 }
 
-function collectRemarks(actions: VisitActionDetail[]): Array<RemarkEntry & {
-  actionId: number;
-  actionLabel: string;
-}> {
-  return actions.flatMap((action) =>
-    dispatchExtractRemarks(action.action_type, action.data).map((remark) => ({
-      ...remark,
+function collectRemarkGroups(actions: VisitActionDetail[]): RemarkGroup[] {
+  return actions.flatMap((action) => {
+    const remarks = dispatchExtractRemarks(action.action_type, action.data);
+    if (remarks.length === 0) {
+      return [];
+    }
+
+    return [{
       actionId: action.id,
+      actionType: action.action_type,
       actionLabel: actionTypeLabel(action.action_type),
-    }))
-  );
+      status: action.status,
+      detailHref: `/visits/${action.visit_id}/actions/${action.id}?from=summary`,
+      chips: remarkGroupChips(action),
+      remarks,
+    }];
+  });
 }
 
 async function getVisitSummaryDetail(id: string, actorEmail: string, permission: NonNullable<Awaited<ReturnType<typeof getUserPermission>>>) {
@@ -388,22 +437,63 @@ function ActionsSection({ actions }: { actions: VisitActionDetail[] }) {
   );
 }
 
-function RemarksSection({ remarks }: { remarks: ReturnType<typeof collectRemarks> }) {
+function RemarksSection({ groups }: { groups: RemarkGroup[] }) {
   return (
     <Card elevation="sm" className="p-4" role="region" aria-label="Remarks">
       <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">Remarks</h2>
-      {remarks.length === 0 ? (
+      {groups.length === 0 ? (
         <p className="mt-3 text-sm text-text-muted">No remarks</p>
       ) : (
-        <div className="mt-4 space-y-3">
-          {remarks.map((remark, index) => (
-            <div key={`${remark.actionId}-${index}`} className="border-l-4 border-border-accent pl-3">
-              <div className="text-xs font-bold uppercase tracking-wide text-text-muted">
-                {remark.actionLabel} #{remark.actionId}
+        <div className="mt-4 space-y-4">
+          {groups.map((group) => (
+            <section
+              key={`${group.actionType}-${group.actionId}`}
+              role="group"
+              aria-label={`${group.actionLabel} #${group.actionId}`}
+              className="border border-border bg-bg-card-alt"
+            >
+              <div className="border-b border-border bg-bg-card px-3 py-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="font-mono text-xs text-text-muted">Action #{group.actionId}</div>
+                    <h3 className="mt-1 text-sm font-bold uppercase tracking-wide text-text-primary">
+                      {group.actionLabel}
+                    </h3>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className={`inline-flex ${statusBadgeClass(group.status)}`}>
+                      {formatStatus(group.status)}
+                    </span>
+                    <Link
+                      href={group.detailHref}
+                      className="text-xs font-bold uppercase text-accent hover:text-accent-hover"
+                    >
+                      Open action
+                    </Link>
+                  </div>
+                </div>
+                {group.chips.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {group.chips.map((chip) => (
+                      <span
+                        key={chip}
+                        className="border border-border bg-bg-card-alt px-2 py-1 font-mono text-xs text-text-secondary"
+                      >
+                        {chip}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
-              <div className="mt-1 text-sm font-medium text-text-primary">{remark.label}</div>
-              <p className="mt-1 text-sm text-text-secondary">{remark.text}</p>
-            </div>
+              <div className="divide-y divide-border/70">
+                {group.remarks.map((remark, index) => (
+                  <div key={`${group.actionId}-${index}`} className="px-3 py-3">
+                    <div className="text-sm font-medium text-text-primary">{remark.label}</div>
+                    <p className="mt-1 text-sm text-text-secondary">{remark.text}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       )}
@@ -456,7 +546,7 @@ export default async function SchoolVisitSummaryDetailPage({ params }: PageProps
     notFound();
   }
 
-  const remarks = collectRemarks(actions);
+  const remarkGroups = collectRemarkGroups(actions);
 
   return (
     <div className="min-h-screen bg-bg">
@@ -502,7 +592,7 @@ export default async function SchoolVisitSummaryDetailPage({ params }: PageProps
           <ActionsSection actions={actions} />
         </section>
 
-        <RemarksSection remarks={remarks} />
+        <RemarksSection groups={remarkGroups} />
       </main>
     </div>
   );

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -138,10 +138,24 @@ function statsChips(actionType: string, stats: unknown): string[] {
   }
 
   if (actionType === "classroom_observation") {
-    return [
+    const chips = [
       `Score ${stats.totalScore}/${stats.maxScore}`,
       `Remarks ${stats.remarkCount}`,
     ];
+    if (typeof stats.curriculumName === "string" && stats.curriculumName) {
+      chips.push(`Curriculum ${stats.curriculumName}`);
+    }
+    if (typeof stats.chapterName === "string" && stats.chapterName) {
+      const subjectPrefix =
+        typeof stats.subjectName === "string" && stats.subjectName
+          ? `${stats.subjectName} - `
+          : "";
+      chips.push(`Chapter ${subjectPrefix}${stats.chapterName}`);
+    }
+    if (typeof stats.topicName === "string" && stats.topicName) {
+      chips.push(`Topic ${stats.topicName}`);
+    }
+    return chips;
   }
   if (actionType === "af_team_interaction") {
     return [

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -132,67 +132,71 @@ function formatNumber(value: unknown): string | null {
     : null;
 }
 
-function statsChips(actionType: string, stats: unknown): string[] {
-  if (!isStats(stats)) {
-    return [];
-  }
+type StatsChipBuilder = (stats: InlineStats) => string[];
 
-  if (actionType === "classroom_observation") {
-    const chips = [
-      `Score ${stats.totalScore}/${stats.maxScore}`,
-      `Remarks ${stats.remarkCount}`,
-    ];
-    if (typeof stats.curriculumName === "string" && stats.curriculumName) {
-      chips.push(`Curriculum ${stats.curriculumName}`);
-    }
-    if (typeof stats.chapterName === "string" && stats.chapterName) {
-      const subjectPrefix =
-        typeof stats.subjectName === "string" && stats.subjectName
-          ? `${stats.subjectName} - `
-          : "";
-      chips.push(`Chapter ${subjectPrefix}${stats.chapterName}`);
-    }
-    if (typeof stats.topicName === "string" && stats.topicName) {
-      chips.push(`Topic ${stats.topicName}`);
-    }
-    return chips;
+function classroomObservationChips(stats: InlineStats): string[] {
+  const chips = [
+    `Score ${stats.totalScore}/${stats.maxScore}`,
+    `Remarks ${stats.remarkCount}`,
+  ];
+  if (typeof stats.curriculumName === "string" && stats.curriculumName) {
+    chips.push(`Curriculum ${stats.curriculumName}`);
   }
-  if (actionType === "af_team_interaction") {
-    return [
-      `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
-      `Teachers ${stats.teacherCount}`,
-    ];
+  if (typeof stats.chapterName === "string" && stats.chapterName) {
+    const subjectPrefix =
+      typeof stats.subjectName === "string" && stats.subjectName
+        ? `${stats.subjectName} - `
+        : "";
+    chips.push(`Chapter ${subjectPrefix}${stats.chapterName}`);
   }
-  if (actionType === "individual_af_teacher_interaction") {
-    const avgAnswered = formatNumber(stats.avgAnswered);
-    return [
-      `Teachers ${stats.teacherCount} (${stats.presentCount} present, ${stats.onLeaveCount} on leave, ${stats.absentCount} absent)`,
-      `Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`,
-    ];
+  if (typeof stats.topicName === "string" && stats.topicName) {
+    chips.push(`Topic ${stats.topicName}`);
   }
-  if (actionType === "principal_interaction") {
-    return [`Answered ${stats.answeredCount}/${stats.totalQuestions}`];
+  return chips;
+}
+
+function individualTeacherInteractionChips(stats: InlineStats): string[] {
+  const avgAnswered = formatNumber(stats.avgAnswered);
+  return [
+    `Teachers ${stats.teacherCount} (${stats.presentCount} present, ${stats.onLeaveCount} on leave, ${stats.absentCount} absent)`,
+    `Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`,
+  ];
+}
+
+function groupStudentDiscussionChips(stats: InlineStats): string[] {
+  return [
+    stats.grade === null || stats.grade === undefined ? "Grade -" : `Grade ${stats.grade}`,
+    `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
+  ];
+}
+
+function individualStudentDiscussionChips(stats: InlineStats): string[] {
+  const avgAnswered = formatNumber(stats.avgAnswered);
+  const chips: string[] = [];
+  if (stats.entryCount !== null) {
+    chips.push(`Entries ${stats.entryCount}`);
   }
-  if (actionType === "group_student_discussion") {
-    return [
-      stats.grade === null || stats.grade === undefined ? "Grade -" : `Grade ${stats.grade}`,
-      `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
-    ];
-  }
-  if (actionType === "individual_student_discussion") {
-    const avgAnswered = formatNumber(stats.avgAnswered);
-    const chips: string[] = [];
-    if (stats.entryCount !== null) {
-      chips.push(`Entries ${stats.entryCount}`);
-    }
-    chips.push(`Students ${stats.studentCount}`);
-    chips.push(`Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`);
-    return chips;
-  }
-  if (actionType === "school_staff_interaction") {
-    return [`Answered ${stats.answeredCount}/${stats.totalQuestions}`];
-  }
-  return [];
+  chips.push(`Students ${stats.studentCount}`);
+  chips.push(`Avg answered ${avgAnswered ?? "-"}/${stats.totalQuestions}`);
+  return chips;
+}
+
+const STATS_CHIP_BUILDERS: Record<string, StatsChipBuilder> = {
+  classroom_observation: classroomObservationChips,
+  af_team_interaction: (stats) => [
+    `Answered ${stats.answeredCount}/${stats.totalQuestions}`,
+    `Teachers ${stats.teacherCount}`,
+  ],
+  individual_af_teacher_interaction: individualTeacherInteractionChips,
+  principal_interaction: (stats) => [`Answered ${stats.answeredCount}/${stats.totalQuestions}`],
+  group_student_discussion: groupStudentDiscussionChips,
+  individual_student_discussion: individualStudentDiscussionChips,
+  school_staff_interaction: (stats) => [`Answered ${stats.answeredCount}/${stats.totalQuestions}`],
+};
+
+function statsChips(actionType: string, stats: unknown): string[] {
+  const buildChips = STATS_CHIP_BUILDERS[actionType];
+  return buildChips && isStats(stats) ? buildChips(stats) : [];
 }
 
 function actionTypeLabel(actionType: string): string {

--- a/src/app/school-visit-summary/page.test.tsx
+++ b/src/app/school-visit-summary/page.test.tsx
@@ -251,7 +251,7 @@ describe("SchoolVisitSummaryPage", () => {
       expect(sql).toContain("COALESCE(s.region, '') = ANY($3)");
       expect(params).toEqual([
         expect.any(Array),
-        7,
+        6,
         ["AHMEDABAD"],
       ]);
     });
@@ -266,7 +266,7 @@ describe("SchoolVisitSummaryPage", () => {
       expect(sql).toContain("v.school_code = ANY($3)");
       expect(params).toEqual([
         expect.any(Array),
-        7,
+        6,
         ["SC001"],
       ]);
     });
@@ -325,9 +325,9 @@ describe("SchoolVisitSummaryPage", () => {
       expect(params[0]).toEqual(expect.arrayContaining([
         "classroom_observation",
         "af_team_interaction",
-        "school_staff_interaction",
       ]));
-      expect(params[1]).toBe(7);
+      expect(params[0]).not.toContain("school_staff_interaction");
+      expect(params[1]).toBe(6);
     });
   });
 
@@ -345,7 +345,7 @@ describe("SchoolVisitSummaryPage", () => {
       expect(statsSql).toContain("v.status = $3");
       expect(statsParams).toEqual([
         expect.any(Array),
-        7,
+        6,
         "completed",
       ]);
       expect(visitsSql).toContain("v.status = $1");
@@ -456,10 +456,11 @@ describe("SchoolVisitSummaryPage", () => {
       expect(visitsSql).toContain("COUNT(DISTINCT CASE WHEN status = 'completed' AND action_type = ANY($1::text[]) THEN action_type END) AS completed_types");
       expect(visitsSql).toContain("COALESCE(action_agg.touched_types, 0) = 0");
       expect(visitsParams).toEqual([
-        expect.arrayContaining(["classroom_observation", "school_staff_interaction"]),
+        expect.arrayContaining(["classroom_observation", "af_team_interaction"]),
         20,
         0,
       ]);
+      expect(visitsParams[0]).not.toContain("school_staff_interaction");
     });
   });
 
@@ -575,11 +576,11 @@ describe("SchoolVisitSummaryPage", () => {
       expect(screen.getByText("Avg Completion")).toBeInTheDocument();
       expect(screen.getByText("43%")).toBeInTheDocument();
       expect(screen.getByText("4 total, 1 completed")).toBeInTheDocument();
-      expect(screen.getAllByText("14%").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("17%").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Classroom Observation: completed").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("AF Team Interaction: pending").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Principal Interaction: in progress").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText("1/7 complete").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("1/6 required complete").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByRole("link", { name: "View visit" })[0]).toHaveAttribute(
         "href",
         "/school-visit-summary/101"

--- a/src/app/school-visit-summary/page.tsx
+++ b/src/app/school-visit-summary/page.tsx
@@ -9,7 +9,14 @@ import { Card } from "@/components/ui";
 import { authOptions } from "@/lib/auth";
 import { query } from "@/lib/db";
 import { getFeatureAccess, getUserPermission, type UserPermission } from "@/lib/permissions";
-import { ACTION_TYPES, ACTION_TYPE_VALUES, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
+import {
+  ACTION_TYPES,
+  ACTION_TYPE_VALUES,
+  REQUIRED_ACTION_TYPE_VALUES,
+  isOptionalActionType,
+  statusBadgeClass,
+  type ActionType,
+} from "@/lib/visit-actions";
 import {
   resolvePresetDateRange,
   rollupActionTypes,
@@ -325,17 +332,17 @@ function buildWhereClause(
         GROUP BY visit_id
       ) AS action_agg ON action_agg.visit_id = v.id`
     );
-    params.push(ACTION_TYPE_VALUES);
+    params.push(REQUIRED_ACTION_TYPE_VALUES);
     nextIndex += 1;
 
     if (filters.bucket === "none") {
       predicates.push("COALESCE(action_agg.touched_types, 0) = 0");
     } else if (filters.bucket === "partial") {
-      predicates.push(`COALESCE(action_agg.touched_types, 0) > 0 AND COALESCE(action_agg.touched_types, 0) < ${ACTION_TYPE_VALUES.length}`);
+      predicates.push(`COALESCE(action_agg.touched_types, 0) > 0 AND COALESCE(action_agg.touched_types, 0) < ${REQUIRED_ACTION_TYPE_VALUES.length}`);
     } else if (filters.bucket === "all_present") {
-      predicates.push(`COALESCE(action_agg.touched_types, 0) = ${ACTION_TYPE_VALUES.length} AND COALESCE(action_agg.completed_types, 0) < ${ACTION_TYPE_VALUES.length}`);
+      predicates.push(`COALESCE(action_agg.touched_types, 0) = ${REQUIRED_ACTION_TYPE_VALUES.length} AND COALESCE(action_agg.completed_types, 0) < ${REQUIRED_ACTION_TYPE_VALUES.length}`);
     } else {
-      predicates.push(`COALESCE(action_agg.completed_types, 0) = ${ACTION_TYPE_VALUES.length}`);
+      predicates.push(`COALESCE(action_agg.completed_types, 0) = ${REQUIRED_ACTION_TYPE_VALUES.length}`);
     }
   }
 
@@ -408,7 +415,7 @@ async function getSummaryStats(
      LEFT JOIN action_completion ac ON ac.visit_id = v.id
      ${joinSql}
      WHERE ${whereSql}`,
-    [ACTION_TYPE_VALUES, ACTION_TYPE_VALUES.length, ...params]
+    [REQUIRED_ACTION_TYPE_VALUES, REQUIRED_ACTION_TYPE_VALUES.length, ...params]
   );
 
   const row = rows[0];
@@ -503,7 +510,7 @@ async function getActionRowsForVisits(visitIds: number[]): Promise<VisitActionRo
 
 function summarizeActions(actions: VisitActionRow[]): VisitActionSummary {
   const rollup = rollupActionTypes(actions);
-  const countStatuses = (statuses: ActionTypeRollupStatus[]) => ACTION_TYPE_VALUES.filter(
+  const countStatuses = (statuses: ActionTypeRollupStatus[]) => REQUIRED_ACTION_TYPE_VALUES.filter(
     (actionType: ActionType) => statuses.includes(rollup[actionType])
   ).length;
   const completedTypes = countStatuses(["completed"]);
@@ -517,7 +524,7 @@ function summarizeActions(actions: VisitActionRow[]): VisitActionSummary {
     notStartedTypes: countStatuses(["not_started"]),
     completionPercent: totalActions === 0
       ? null
-      : (completedTypes / ACTION_TYPE_VALUES.length) * 100,
+      : (completedTypes / REQUIRED_ACTION_TYPE_VALUES.length) * 100,
     rollup,
   };
 }
@@ -700,7 +707,7 @@ function ActionTypeBar({ summary }: { summary: VisitActionSummary }) {
         {ACTION_TYPE_VALUES.map((actionType) => {
           const status = summary.rollup[actionType];
           const label = ACTION_TYPES[actionType];
-          const statusLabel = status.replace("_", " ");
+          const statusLabel = `${status.replace("_", " ")}${isOptionalActionType(actionType) ? " (optional)" : ""}`;
           const colorClass =
             status === "completed"
               ? "bg-success"
@@ -726,7 +733,7 @@ function ActionTypeBar({ summary }: { summary: VisitActionSummary }) {
 }
 
 function formatMobileActionSummary(summary: VisitActionSummary): string {
-  return `${summary.completedTypes}/${ACTION_TYPE_VALUES.length} complete`;
+  return `${summary.completedTypes}/${REQUIRED_ACTION_TYPE_VALUES.length} required complete`;
 }
 
 function StatCards({ stats }: { stats: SummaryStats }) {

--- a/src/app/visits/[id]/actions/[actionId]/page.test.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.test.tsx
@@ -296,6 +296,15 @@ describe("VisitActionDetailPage", () => {
               teacher_on_time: { score: 1, remarks: "Observed" },
             },
             observer_summary_strengths: "Strong opening",
+            curriculum_id: 1,
+            curriculum_name: "JEE Mains",
+            chapter_id: 44,
+            chapter_name: "Units and Measurement",
+            chapter_topic_count: 2,
+            subject_id: 4,
+            subject_name: "Physics",
+            topic_id: 101,
+            topic_name: "Physical Quantities",
           },
         }),
       ]);
@@ -315,6 +324,15 @@ describe("VisitActionDetailPage", () => {
                     teacher_on_time: { score: 1, remarks: "Observed" },
                   },
                   observer_summary_strengths: "Strong opening",
+                  curriculum_id: 1,
+                  curriculum_name: "JEE Mains",
+                  chapter_id: 44,
+                  chapter_name: "Units and Measurement",
+                  chapter_topic_count: 2,
+                  subject_id: 4,
+                  subject_name: "Physics",
+                  topic_id: 101,
+                  topic_name: "Physical Quantities",
                 },
               }),
             }),
@@ -342,6 +360,17 @@ describe("VisitActionDetailPage", () => {
       teacher_on_time: { score: 1, remarks: "Observed" },
     });
     expect(body.data.observer_summary_strengths).toBe("Strong opening");
+    expect(body.data).toMatchObject({
+      curriculum_id: 1,
+      curriculum_name: "JEE Mains",
+      chapter_id: 44,
+      chapter_name: "Units and Measurement",
+      chapter_topic_count: 2,
+      subject_id: 4,
+      subject_name: "Physics",
+      topic_id: 101,
+      topic_name: "Physical Quantities",
+    });
     expect(body.data).not.toHaveProperty("class_details");
     expect(body.data).not.toHaveProperty("observations");
     expect(body.data).not.toHaveProperty("support_needed");

--- a/src/app/visits/[id]/actions/[actionId]/page.test.tsx
+++ b/src/app/visits/[id]/actions/[actionId]/page.test.tsx
@@ -602,6 +602,10 @@ describe("VisitActionDetailPage", () => {
 
     // Click a radio button to change form data
     await user.click(screen.getByTestId("principal-interaction-ip_curriculum_progress-no"));
+    await user.type(
+      screen.getByTestId("action-additional-notes"),
+      "Principal asked for extra monthly context"
+    );
     await user.click(screen.getByRole("button", { name: "Save Now" }));
 
     await waitFor(() => {
@@ -612,8 +616,11 @@ describe("VisitActionDetailPage", () => {
     expect(url).toBe("/api/pm/visits/1/actions/101");
     expect(init.method).toBe("PATCH");
 
-    const parsedBody = JSON.parse(String(init.body)) as { data: { questions: Record<string, unknown> } };
+    const parsedBody = JSON.parse(String(init.body)) as {
+      data: { questions: Record<string, unknown>; additional_notes?: string };
+    };
     expect(parsedBody.data.questions).toBeDefined();
+    expect(parsedBody.data.additional_notes).toBe("Principal asked for extra monthly context");
   });
 
   it("ends an action via save-before-end + /end using GPS and updates UI to completed", async () => {
@@ -690,6 +697,7 @@ describe("VisitActionDetailPage", () => {
     render(jsx);
 
     expect(screen.getByText("Completed actions are read-only for your role.")).toBeInTheDocument();
+    expect(screen.getByTestId("action-additional-notes")).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Save Now" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "End Action" })).not.toBeInTheDocument();
   });

--- a/src/components/visits/ActionDetailForm.tsx
+++ b/src/components/visits/ActionDetailForm.tsx
@@ -198,6 +198,38 @@ function assignStringField(
   }
 }
 
+function assignPositiveNumberField(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value > 0
+  ) {
+    target[key] = value;
+  }
+}
+
+function assignNonNegativeNumberField(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  ) {
+    target[key] = value;
+  }
+}
+
 function sanitizeRubricParam(value: unknown): Record<string, unknown> | null {
   if (!isPlainObject(value)) {
     return null;
@@ -305,12 +337,21 @@ function sanitizeClassroomPayload(data: unknown): Record<string, unknown> {
   assignStringField(sanitized, data, "observer_summary_strengths");
   assignStringField(sanitized, data, "observer_summary_improvements");
 
-  if (typeof data.teacher_id === "number" && Number.isFinite(data.teacher_id) && data.teacher_id > 0) {
-    sanitized.teacher_id = data.teacher_id;
-  }
-
+  assignPositiveNumberField(sanitized, data, "teacher_id");
   assignStringField(sanitized, data, "teacher_name");
   assignStringField(sanitized, data, "grade");
+  assignPositiveNumberField(sanitized, data, "curriculum_id");
+  assignStringField(sanitized, data, "curriculum_name");
+  assignStringField(sanitized, data, "curriculum_code");
+  assignPositiveNumberField(sanitized, data, "chapter_id");
+  assignStringField(sanitized, data, "chapter_name");
+  assignStringField(sanitized, data, "chapter_code");
+  assignNonNegativeNumberField(sanitized, data, "chapter_topic_count");
+  assignPositiveNumberField(sanitized, data, "subject_id");
+  assignStringField(sanitized, data, "subject_name");
+  assignPositiveNumberField(sanitized, data, "topic_id");
+  assignStringField(sanitized, data, "topic_name");
+  assignStringField(sanitized, data, "topic_code");
 
   appendActionAdditionalNotes(sanitized, data);
 

--- a/src/components/visits/ActionDetailForm.tsx
+++ b/src/components/visits/ActionDetailForm.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { useAutoSave, type AutoSaveStatus } from "@/hooks/use-auto-save";
 
 import Toast from "@/components/Toast";
+import { FormSection, baseInputClasses } from "@/components/ui";
 import AFTeamInteractionForm from "@/components/visits/AFTeamInteractionForm";
 import ClassroomObservationForm from "@/components/visits/ClassroomObservationForm";
 import IndividualAFTeacherInteractionForm from "@/components/visits/IndividualAFTeacherInteractionForm";
@@ -26,7 +27,13 @@ import {
 } from "@/lib/classroom-observation-rubric";
 import { getAccurateLocation } from "@/lib/geolocation";
 import { getActionTypeLabel, isActionType, statusBadgeClass, type ActionType } from "@/lib/visit-actions";
-import { isPlainObject } from "@/lib/visit-form-utils";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  ACTION_ADDITIONAL_NOTES_LABEL,
+  appendActionAdditionalNotes,
+  isPlainObject,
+  readActionAdditionalNotes,
+} from "@/lib/visit-form-utils";
 
 interface ActionRecord {
   id: number;
@@ -237,6 +244,8 @@ function sanitizeClassroomPayload(data: unknown): Record<string, unknown> {
     sanitized.grade = data.grade;
   }
 
+  appendActionAdditionalNotes(sanitized, data);
+
   return sanitized;
 }
 
@@ -288,7 +297,9 @@ function sanitizeAFTeamPayload(data: Record<string, unknown>): Record<string, un
     }
   }
 
-  return { teachers, questions };
+  const sanitized = { teachers, questions };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapAFTeamPayload(data: unknown): Record<string, unknown> {
@@ -345,7 +356,9 @@ function sanitizeIndividualTeacherPayload(data: unknown): Record<string, unknown
     }
   }
 
-  return { teachers };
+  const sanitized = { teachers };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapIndividualTeacherPayload(data: unknown): Record<string, unknown> {
@@ -379,7 +392,9 @@ function sanitizePrincipalInteractionPayload(data: unknown): Record<string, unkn
     }
   }
 
-  return { questions };
+  const sanitized = { questions };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapPrincipalInteractionPayload(data: unknown): Record<string, unknown> {
@@ -415,7 +430,9 @@ function sanitizeGroupStudentDiscussionPayload(data: unknown): Record<string, un
     }
   }
 
-  return { grade, questions };
+  const sanitized = { grade, questions };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapGroupStudentDiscussionPayload(data: unknown): Record<string, unknown> {
@@ -484,12 +501,14 @@ function sanitizeIndividualStudentDiscussionPayload(data: unknown): Record<strin
     }
   }
 
-  return { entries };
+  const sanitized = { entries };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapIndividualStudentDiscussionPayload(data: unknown): Record<string, unknown> {
-  if (data && typeof data === "object" && !Array.isArray(data) && "entries" in data) {
-    return data as Record<string, unknown>;
+  if (isPlainObject(data)) {
+    return sanitizeIndividualStudentDiscussionPayload(data);
   }
   return { entries: [] };
 }
@@ -518,7 +537,9 @@ function sanitizeSchoolStaffInteractionPayload(data: unknown): Record<string, un
     }
   }
 
-  return { questions };
+  const sanitized = { questions };
+  appendActionAdditionalNotes(sanitized, data);
+  return sanitized;
 }
 
 function bootstrapSchoolStaffInteractionPayload(data: unknown): Record<string, unknown> {
@@ -746,6 +767,7 @@ export default function ActionDetailForm({
     isClassroomObservation && rubricVersion !== null && getRubricConfig(rubricVersion) === null;
 
   const isVisitCompleted = visitStatus === "completed";
+  const additionalNotes = readActionAdditionalNotes(formData);
   const canSave =
     !isVisitCompleted &&
     canWrite &&
@@ -1097,6 +1119,29 @@ export default function ActionDetailForm({
             </label>
           ))
         )}
+
+        <FormSection spacing="space-y-2" className="bg-bg-card-alt">
+          <label className="block">
+            <span className="mb-1 block text-sm font-semibold uppercase text-text-primary">
+              {ACTION_ADDITIONAL_NOTES_LABEL}
+            </span>
+            <textarea
+              value={additionalNotes}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                setFormData((current) => ({
+                  ...current,
+                  [ACTION_ADDITIONAL_NOTES_KEY]: nextValue,
+                }));
+              }}
+              disabled={!canSave || isBusy}
+              rows={4}
+              placeholder="Capture extra context, observations, or concerns"
+              className={`w-full ${baseInputClasses}`}
+              data-testid="action-additional-notes"
+            />
+          </label>
+        </FormSection>
 
         <div className="flex flex-wrap items-center gap-2 pt-2">
           {canSave && (

--- a/src/components/visits/ActionDetailForm.tsx
+++ b/src/components/visits/ActionDetailForm.tsx
@@ -187,6 +187,105 @@ function isLocationCancelled(error: unknown): boolean {
   );
 }
 
+function assignStringField(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (typeof value === "string") {
+    target[key] = value;
+  }
+}
+
+function sanitizeRubricParam(value: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const nextValue: Record<string, unknown> = {};
+
+  if (typeof value.score === "number" && Number.isFinite(value.score)) {
+    nextValue.score = value.score;
+  }
+
+  if (typeof value.remarks === "string") {
+    nextValue.remarks = value.remarks;
+  }
+
+  return Object.keys(nextValue).length > 0 ? nextValue : null;
+}
+
+function sanitizeRubricParams(paramsValue: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(paramsValue)) {
+    return null;
+  }
+
+  const params: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(paramsValue)) {
+    const sanitizedParam = sanitizeRubricParam(value);
+    if (sanitizedParam) {
+      params[key] = sanitizedParam;
+    }
+  }
+
+  return params;
+}
+
+function sanitizeQuestionEntry(value: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const entry: Record<string, unknown> = {};
+  if (value.answer === null || typeof value.answer === "boolean") {
+    entry.answer = value.answer;
+  }
+  if (typeof value.remark === "string") {
+    entry.remark = value.remark;
+  }
+
+  return Object.keys(entry).length > 0 ? entry : null;
+}
+
+function sanitizeQuestionMap(
+  questionsValue: unknown,
+  questionKeys: readonly string[]
+): Record<string, unknown> {
+  const questions: Record<string, unknown> = {};
+  if (!isPlainObject(questionsValue)) {
+    return questions;
+  }
+
+  for (const key of questionKeys) {
+    const entry = sanitizeQuestionEntry(questionsValue[key]);
+    if (entry) {
+      questions[key] = entry;
+    }
+  }
+
+  return questions;
+}
+
+function sanitizeTeacherRefs(value: unknown): Array<{ id: number; name: string }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (
+      isPlainObject(entry) &&
+      typeof entry.id === "number" &&
+      Number.isFinite(entry.id) &&
+      typeof entry.name === "string"
+    ) {
+      return [{ id: entry.id, name: entry.name }];
+    }
+
+    return [];
+  });
+}
+
 function sanitizeClassroomPayload(data: unknown): Record<string, unknown> {
   if (!isPlainObject(data)) {
     return {};
@@ -198,51 +297,20 @@ function sanitizeClassroomPayload(data: unknown): Record<string, unknown> {
     sanitized.rubric_version = data.rubric_version;
   }
 
-  if (isPlainObject(data.params)) {
-    const params: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(data.params)) {
-      if (!isPlainObject(value)) {
-        continue;
-      }
-
-      const nextValue: Record<string, unknown> = {};
-
-      if (typeof value.score === "number" && Number.isFinite(value.score)) {
-        nextValue.score = value.score;
-      }
-
-      if (typeof value.remarks === "string") {
-        nextValue.remarks = value.remarks;
-      }
-
-      if (Object.keys(nextValue).length > 0) {
-        params[key] = nextValue;
-      }
-    }
-
+  const params = sanitizeRubricParams(data.params);
+  if (params) {
     sanitized.params = params;
   }
 
-  if (typeof data.observer_summary_strengths === "string") {
-    sanitized.observer_summary_strengths = data.observer_summary_strengths;
-  }
-
-  if (typeof data.observer_summary_improvements === "string") {
-    sanitized.observer_summary_improvements = data.observer_summary_improvements;
-  }
+  assignStringField(sanitized, data, "observer_summary_strengths");
+  assignStringField(sanitized, data, "observer_summary_improvements");
 
   if (typeof data.teacher_id === "number" && Number.isFinite(data.teacher_id) && data.teacher_id > 0) {
     sanitized.teacher_id = data.teacher_id;
   }
 
-  if (typeof data.teacher_name === "string") {
-    sanitized.teacher_name = data.teacher_name;
-  }
-
-  if (typeof data.grade === "string") {
-    sanitized.grade = data.grade;
-  }
+  assignStringField(sanitized, data, "teacher_name");
+  assignStringField(sanitized, data, "grade");
 
   appendActionAdditionalNotes(sanitized, data);
 
@@ -259,45 +327,18 @@ function bootstrapClassroomPayload(data: unknown): Record<string, unknown> {
   return sanitized;
 }
 
-function sanitizeAFTeamPayload(data: Record<string, unknown>): Record<string, unknown> {
+function sanitizeAFTeamPayload(data: unknown): Record<string, unknown> {
   if (!isPlainObject(data)) {
     return { teachers: [], questions: {} };
   }
 
-  const teachers: Array<{ id: number; name: string }> = [];
-  if (Array.isArray(data.teachers)) {
-    for (const entry of data.teachers) {
-      if (
-        isPlainObject(entry) &&
-        typeof entry.id === "number" &&
-        Number.isFinite(entry.id) &&
-        typeof entry.name === "string"
-      ) {
-        teachers.push({ id: entry.id, name: entry.name });
-      }
-    }
-  }
-
-  const questions: Record<string, unknown> = {};
-  if (isPlainObject(data.questions)) {
-    for (const key of AF_TEAM_INTERACTION_CONFIG.allQuestionKeys) {
-      const value = (data.questions as Record<string, unknown>)[key];
-      if (isPlainObject(value)) {
-        const entry: Record<string, unknown> = {};
-        if (value.answer === null || typeof value.answer === "boolean") {
-          entry.answer = value.answer;
-        }
-        if (typeof value.remark === "string") {
-          entry.remark = value.remark;
-        }
-        if (Object.keys(entry).length > 0) {
-          questions[key] = entry;
-        }
-      }
-    }
-  }
-
-  const sanitized = { teachers, questions };
+  const sanitized = {
+    teachers: sanitizeTeacherRefs(data.teachers),
+    questions: sanitizeQuestionMap(
+      data.questions,
+      AF_TEAM_INTERACTION_CONFIG.allQuestionKeys
+    ),
+  };
   appendActionAdditionalNotes(sanitized, data);
   return sanitized;
 }
@@ -373,26 +414,12 @@ function sanitizePrincipalInteractionPayload(data: unknown): Record<string, unkn
     return { questions: {} };
   }
 
-  const questions: Record<string, unknown> = {};
-  if (isPlainObject(data.questions)) {
-    for (const key of PRINCIPAL_INTERACTION_CONFIG.allQuestionKeys) {
-      const value = (data.questions as Record<string, unknown>)[key];
-      if (isPlainObject(value)) {
-        const entry: Record<string, unknown> = {};
-        if (value.answer === null || typeof value.answer === "boolean") {
-          entry.answer = value.answer;
-        }
-        if (typeof value.remark === "string") {
-          entry.remark = value.remark;
-        }
-        if (Object.keys(entry).length > 0) {
-          questions[key] = entry;
-        }
-      }
-    }
-  }
-
-  const sanitized = { questions };
+  const sanitized = {
+    questions: sanitizeQuestionMap(
+      data.questions,
+      PRINCIPAL_INTERACTION_CONFIG.allQuestionKeys
+    ),
+  };
   appendActionAdditionalNotes(sanitized, data);
   return sanitized;
 }
@@ -410,27 +437,13 @@ function sanitizeGroupStudentDiscussionPayload(data: unknown): Record<string, un
   }
 
   const grade = typeof data.grade === "number" && Number.isFinite(data.grade) ? data.grade : null;
-
-  const questions: Record<string, unknown> = {};
-  if (isPlainObject(data.questions)) {
-    for (const key of GROUP_STUDENT_DISCUSSION_CONFIG.allQuestionKeys) {
-      const value = (data.questions as Record<string, unknown>)[key];
-      if (isPlainObject(value)) {
-        const entry: Record<string, unknown> = {};
-        if (value.answer === null || typeof value.answer === "boolean") {
-          entry.answer = value.answer;
-        }
-        if (typeof value.remark === "string") {
-          entry.remark = value.remark;
-        }
-        if (Object.keys(entry).length > 0) {
-          questions[key] = entry;
-        }
-      }
-    }
-  }
-
-  const sanitized = { grade, questions };
+  const sanitized = {
+    grade,
+    questions: sanitizeQuestionMap(
+      data.questions,
+      GROUP_STUDENT_DISCUSSION_CONFIG.allQuestionKeys
+    ),
+  };
   appendActionAdditionalNotes(sanitized, data);
   return sanitized;
 }
@@ -518,26 +531,12 @@ function sanitizeSchoolStaffInteractionPayload(data: unknown): Record<string, un
     return { questions: {} };
   }
 
-  const questions: Record<string, unknown> = {};
-  if (isPlainObject(data.questions)) {
-    for (const key of SCHOOL_STAFF_INTERACTION_CONFIG.allQuestionKeys) {
-      const value = (data.questions as Record<string, unknown>)[key];
-      if (isPlainObject(value)) {
-        const entry: Record<string, unknown> = {};
-        if (value.answer === null || typeof value.answer === "boolean") {
-          entry.answer = value.answer;
-        }
-        if (typeof value.remark === "string") {
-          entry.remark = value.remark;
-        }
-        if (Object.keys(entry).length > 0) {
-          questions[key] = entry;
-        }
-      }
-    }
-  }
-
-  const sanitized = { questions };
+  const sanitized = {
+    questions: sanitizeQuestionMap(
+      data.questions,
+      SCHOOL_STAFF_INTERACTION_CONFIG.allQuestionKeys
+    ),
+  };
   appendActionAdditionalNotes(sanitized, data);
   return sanitized;
 }

--- a/src/components/visits/ActionPointList.tsx
+++ b/src/components/visits/ActionPointList.tsx
@@ -137,42 +137,58 @@ interface ClassroomObservationStats {
   maxScore: number;
 }
 
-function getClassroomObservationStats(data: Record<string, unknown> | undefined): ClassroomObservationStats | null {
-  if (!data || typeof data !== "object") {
-    return null;
-  }
+function readStatsString(data: Record<string, unknown>, key: string): string | null {
+  const value = data[key];
+  return typeof value === "string" ? value : null;
+}
 
-  const teacherName = typeof data.teacher_name === "string" ? data.teacher_name : null;
-  const grade = typeof data.grade === "string" ? data.grade : null;
-  const curriculumName = typeof data.curriculum_name === "string" ? data.curriculum_name : null;
-  const chapterName = typeof data.chapter_name === "string" ? data.chapter_name : null;
-  const subjectName = typeof data.subject_name === "string" ? data.subject_name : null;
-  const topicName = typeof data.topic_name === "string" ? data.topic_name : null;
-  const params = data.params && typeof data.params === "object" && !Array.isArray(data.params)
+function readClassroomObservationParams(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  return data.params && typeof data.params === "object" && !Array.isArray(data.params)
     ? (data.params as Record<string, unknown>)
     : {};
+}
 
+function summarizeClassroomObservationScores(params: Record<string, unknown>): {
+  answeredCount: number;
+  score: number;
+} {
   let answeredCount = 0;
   let score = 0;
 
   for (const parameter of CLASSROOM_OBSERVATION_RUBRIC.parameters) {
     const paramValue = params[parameter.key];
-    if (paramValue && typeof paramValue === "object" && "score" in paramValue) {
-      const paramScore = (paramValue as { score: unknown }).score;
-      if (typeof paramScore === "number" && parameter.options.some((o) => o.score === paramScore)) {
-        answeredCount += 1;
-        score += paramScore;
-      }
+    if (!paramValue || typeof paramValue !== "object" || !("score" in paramValue)) {
+      continue;
+    }
+
+    const paramScore = (paramValue as { score: unknown }).score;
+    if (typeof paramScore === "number" && parameter.options.some((o) => o.score === paramScore)) {
+      answeredCount += 1;
+      score += paramScore;
     }
   }
 
+  return { answeredCount, score };
+}
+
+function getClassroomObservationStats(data: Record<string, unknown> | undefined): ClassroomObservationStats | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const { answeredCount, score } = summarizeClassroomObservationScores(
+    readClassroomObservationParams(data)
+  );
+
   return {
-    teacherName,
-    grade,
-    curriculumName,
-    chapterName,
-    subjectName,
-    topicName,
+    teacherName: readStatsString(data, "teacher_name"),
+    grade: readStatsString(data, "grade"),
+    curriculumName: readStatsString(data, "curriculum_name"),
+    chapterName: readStatsString(data, "chapter_name"),
+    subjectName: readStatsString(data, "subject_name"),
+    topicName: readStatsString(data, "topic_name"),
     answeredCount,
     totalParams: CLASSROOM_OBSERVATION_RUBRIC.parameters.length,
     score,

--- a/src/components/visits/ActionPointList.tsx
+++ b/src/components/visits/ActionPointList.tsx
@@ -127,6 +127,10 @@ function formatTimestamp(value: string | null): string {
 interface ClassroomObservationStats {
   teacherName: string | null;
   grade: string | null;
+  curriculumName: string | null;
+  chapterName: string | null;
+  subjectName: string | null;
+  topicName: string | null;
   answeredCount: number;
   totalParams: number;
   score: number;
@@ -140,6 +144,10 @@ function getClassroomObservationStats(data: Record<string, unknown> | undefined)
 
   const teacherName = typeof data.teacher_name === "string" ? data.teacher_name : null;
   const grade = typeof data.grade === "string" ? data.grade : null;
+  const curriculumName = typeof data.curriculum_name === "string" ? data.curriculum_name : null;
+  const chapterName = typeof data.chapter_name === "string" ? data.chapter_name : null;
+  const subjectName = typeof data.subject_name === "string" ? data.subject_name : null;
+  const topicName = typeof data.topic_name === "string" ? data.topic_name : null;
   const params = data.params && typeof data.params === "object" && !Array.isArray(data.params)
     ? (data.params as Record<string, unknown>)
     : {};
@@ -161,6 +169,10 @@ function getClassroomObservationStats(data: Record<string, unknown> | undefined)
   return {
     teacherName,
     grade,
+    curriculumName,
+    chapterName,
+    subjectName,
+    topicName,
     answeredCount,
     totalParams: CLASSROOM_OBSERVATION_RUBRIC.parameters.length,
     score,
@@ -714,6 +726,23 @@ export default function ActionPointList({
                     {stats.grade && (
                       <span className="text-text-secondary">
                         <span className="text-text-muted">Grade:</span> {stats.grade}
+                      </span>
+                    )}
+                    {stats.curriculumName && (
+                      <span className="text-text-secondary">
+                        <span className="text-text-muted">Curriculum:</span> {stats.curriculumName}
+                      </span>
+                    )}
+                    {stats.chapterName && (
+                      <span className="text-text-secondary">
+                        <span className="text-text-muted">Chapter:</span>{" "}
+                        {stats.subjectName ? `${stats.subjectName} - ` : ""}
+                        {stats.chapterName}
+                      </span>
+                    )}
+                    {stats.topicName && (
+                      <span className="text-text-secondary">
+                        <span className="text-text-muted">Topic:</span> {stats.topicName}
                       </span>
                     )}
                     <span className="font-mono text-accent font-bold">

--- a/src/components/visits/ActionTypePickerModal.test.tsx
+++ b/src/components/visits/ActionTypePickerModal.test.tsx
@@ -260,6 +260,7 @@ describe("ActionTypePickerModal", () => {
 
     const radio = screen.getByLabelText("School Staff Interaction");
     expect(radio).not.toBeDisabled();
+    expect(screen.getByText("Optional")).toBeInTheDocument();
   });
 
   it("submits school_staff_interaction when selected and Add clicked", async () => {

--- a/src/components/visits/ActionTypePickerModal.tsx
+++ b/src/components/visits/ActionTypePickerModal.tsx
@@ -2,7 +2,12 @@
 
 import { useMemo, useState } from "react";
 
-import { ACTION_TYPE_VALUES, getActionTypeLabel, type ActionType } from "@/lib/visit-actions";
+import {
+  ACTION_TYPE_VALUES,
+  getActionTypeLabel,
+  isOptionalActionType,
+  type ActionType,
+} from "@/lib/visit-actions";
 import { Modal } from "@/components/ui";
 
 interface ActionTypePickerModalProps {
@@ -59,14 +64,20 @@ export default function ActionTypePickerModal({
                   type="radio"
                   name="action-type"
                   value={actionType}
+                  aria-label={getActionTypeLabel(actionType)}
                   checked={selectedType === actionType}
                   onChange={() => {
                     setSelectedType(actionType);
                   }}
                   className="h-5 w-5 accent-accent"
                 />
-                <span className="text-base font-medium text-text-primary">
-                  {getActionTypeLabel(actionType)}
+                <span className="flex min-w-0 flex-1 items-center justify-between gap-3 text-base font-medium text-text-primary">
+                  <span>{getActionTypeLabel(actionType)}</span>
+                  {isOptionalActionType(actionType) && (
+                    <span className="shrink-0 rounded-full border border-border-accent bg-bg-card-alt px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide text-text-muted">
+                      Optional
+                    </span>
+                  )}
                 </span>
               </label>
             ))}

--- a/src/components/visits/ClassroomObservationContextFields.tsx
+++ b/src/components/visits/ClassroomObservationContextFields.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ChangeEventHandler,
   type Dispatch,
+  type ReactNode,
   type SetStateAction,
 } from "react";
 
@@ -86,6 +87,35 @@ function topicLabel(topic: ClassroomObservationTopicOption): string {
   return `${topic.name}${suffix}`;
 }
 
+function normalizeOptionsBody(body: unknown): CurriculumOptionsState {
+  if (!body || typeof body !== "object") {
+    return EMPTY_CURRICULUM_OPTIONS;
+  }
+
+  const record = body as Record<string, unknown>;
+  return {
+    curricula: Array.isArray(record.curricula) ? record.curricula : [],
+    chapters: Array.isArray(record.chapters) ? record.chapters : [],
+    topics: Array.isArray(record.topics) ? record.topics : [],
+  };
+}
+
+async function loadCurriculumOptions(
+  schoolCode: string,
+  selectedGrade: string
+): Promise<CurriculumOptionsState> {
+  const params = new URLSearchParams({
+    school_code: schoolCode,
+    grade: selectedGrade,
+  });
+  const response = await fetch(`/api/pm/classroom-observation-options?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error("Failed to load curriculum options");
+  }
+
+  return normalizeOptionsBody(await response.json());
+}
+
 function useCurriculumOptions(schoolCode: string, selectedGrade: string) {
   const [options, setOptions] = useState<CurriculumOptionsState>(EMPTY_CURRICULUM_OPTIONS);
   const [loading, setLoading] = useState(false);
@@ -106,22 +136,9 @@ function useCurriculumOptions(schoolCode: string, selectedGrade: string) {
       setError(null);
 
       try {
-        const params = new URLSearchParams({
-          school_code: schoolCode,
-          grade: selectedGrade,
-        });
-        const response = await fetch(`/api/pm/classroom-observation-options?${params.toString()}`);
-        if (!response.ok) {
-          throw new Error("Failed to load curriculum options");
-        }
-
-        const body = await response.json();
+        const nextOptions = await loadCurriculumOptions(schoolCode, selectedGrade);
         if (!cancelled) {
-          setOptions({
-            curricula: Array.isArray(body.curricula) ? body.curricula : [],
-            chapters: Array.isArray(body.chapters) ? body.chapters : [],
-            topics: Array.isArray(body.topics) ? body.topics : [],
-          });
+          setOptions(nextOptions);
         }
       } catch {
         if (!cancelled) {
@@ -162,34 +179,41 @@ function CurriculumField({
   selectedCurriculumName: string;
   onChange: ChangeEventHandler<HTMLSelectElement>;
 }) {
+  let content: ReactNode;
+  if (disabled) {
+    content = (
+      <p className="text-sm text-text-primary" data-testid="curriculum-display">
+        {selectedCurriculumName || "No curriculum selected"}
+      </p>
+    );
+  } else if (loading) {
+    content = <p className="text-sm text-text-muted" data-testid="curriculum-loading">Loading curriculum...</p>;
+  } else if (error) {
+    content = <p className="text-sm text-danger" data-testid="curriculum-error">{error}</p>;
+  } else {
+    content = (
+      <Select
+        value={selectedCurriculumId !== null ? String(selectedCurriculumId) : ""}
+        onChange={onChange}
+        className="w-full"
+        data-testid="curriculum-select"
+      >
+        <option value="" disabled>
+          {options.length === 0 ? "No curricula found" : "Select a curriculum"}
+        </option>
+        {options.map((curriculum) => (
+          <option key={curriculum.id} value={String(curriculum.id)}>
+            {curriculum.name}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
   return (
     <FormSection spacing="" data-testid="curriculum-selection">
       <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Curriculum</h3>
-      {disabled ? (
-        <p className="text-sm text-text-primary" data-testid="curriculum-display">
-          {selectedCurriculumName || "No curriculum selected"}
-        </p>
-      ) : loading ? (
-        <p className="text-sm text-text-muted" data-testid="curriculum-loading">Loading curriculum...</p>
-      ) : error ? (
-        <p className="text-sm text-danger" data-testid="curriculum-error">{error}</p>
-      ) : (
-        <Select
-          value={selectedCurriculumId !== null ? String(selectedCurriculumId) : ""}
-          onChange={onChange}
-          className="w-full"
-          data-testid="curriculum-select"
-        >
-          <option value="" disabled>
-            {options.length === 0 ? "No curricula found" : "Select a curriculum"}
-          </option>
-          {options.map((curriculum) => (
-            <option key={curriculum.id} value={String(curriculum.id)}>
-              {curriculum.name}
-            </option>
-          ))}
-        </Select>
-      )}
+      {content}
     </FormSection>
   );
 }
@@ -211,35 +235,42 @@ function ChapterField({
   selectedSubjectName: string;
   onChange: ChangeEventHandler<HTMLSelectElement>;
 }) {
+  let content: ReactNode;
+  if (disabled) {
+    content = (
+      <p className="text-sm text-text-primary" data-testid="chapter-display">
+        {selectedChapterName
+          ? `${selectedSubjectName ? `${selectedSubjectName} - ` : ""}${selectedChapterName}`
+          : "No chapter selected"}
+      </p>
+    );
+  } else if (loading) {
+    content = <p className="text-sm text-text-muted" data-testid="chapter-loading">Loading chapters...</p>;
+  } else {
+    content = (
+      <Select
+        value={selectedChapterId !== null ? String(selectedChapterId) : ""}
+        onChange={onChange}
+        className="w-full"
+        data-testid="chapter-select"
+        disabled={chapters.length === 0}
+      >
+        <option value="" disabled>
+          {chapters.length === 0 ? "No chapters found" : "Select a chapter"}
+        </option>
+        {chapters.map((chapter) => (
+          <option key={`${chapter.curriculumId}-${chapter.id}`} value={String(chapter.id)}>
+            {chapterLabel(chapter)}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
   return (
     <FormSection spacing="" data-testid="chapter-selection">
       <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Chapter</h3>
-      {disabled ? (
-        <p className="text-sm text-text-primary" data-testid="chapter-display">
-          {selectedChapterName
-            ? `${selectedSubjectName ? `${selectedSubjectName} - ` : ""}${selectedChapterName}`
-            : "No chapter selected"}
-        </p>
-      ) : loading ? (
-        <p className="text-sm text-text-muted" data-testid="chapter-loading">Loading chapters...</p>
-      ) : (
-        <Select
-          value={selectedChapterId !== null ? String(selectedChapterId) : ""}
-          onChange={onChange}
-          className="w-full"
-          data-testid="chapter-select"
-          disabled={chapters.length === 0}
-        >
-          <option value="" disabled>
-            {chapters.length === 0 ? "No chapters found" : "Select a chapter"}
-          </option>
-          {chapters.map((chapter) => (
-            <option key={`${chapter.curriculumId}-${chapter.id}`} value={String(chapter.id)}>
-              {chapterLabel(chapter)}
-            </option>
-          ))}
-        </Select>
-      )}
+      {content}
     </FormSection>
   );
 }

--- a/src/components/visits/ClassroomObservationContextFields.tsx
+++ b/src/components/visits/ClassroomObservationContextFields.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEventHandler,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import type {
+  ClassroomObservationChapterOption,
+  ClassroomObservationCurriculumOption,
+  ClassroomObservationTopicOption,
+} from "@/lib/classroom-observation-curriculum";
+import { VALID_GRADES } from "@/lib/classroom-observation-rubric";
+import { FormSection, Select } from "@/components/ui";
+
+interface ClassroomObservationContextFieldsProps {
+  data: Record<string, unknown>;
+  setData: Dispatch<SetStateAction<Record<string, unknown>>>;
+  disabled: boolean;
+  schoolCode: string;
+  selectedGrade: string;
+}
+
+interface CurriculumOptionsState {
+  curricula: ClassroomObservationCurriculumOption[];
+  chapters: ClassroomObservationChapterOption[];
+  topics: ClassroomObservationTopicOption[];
+}
+
+const EMPTY_CURRICULUM_OPTIONS: CurriculumOptionsState = {
+  curricula: [],
+  chapters: [],
+  topics: [],
+};
+
+const CHAPTER_FIELD_KEYS = [
+  "chapter_id",
+  "chapter_name",
+  "chapter_code",
+  "chapter_topic_count",
+  "subject_id",
+  "subject_name",
+  "topic_id",
+  "topic_name",
+  "topic_code",
+] as const;
+
+const TOPIC_FIELD_KEYS = ["topic_id", "topic_name", "topic_code"] as const;
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value > 0
+    ? value
+    : null;
+}
+
+function clearFields(
+  data: Record<string, unknown>,
+  keys: readonly string[]
+): Record<string, unknown> {
+  const next = { ...data };
+  for (const key of keys) {
+    delete next[key];
+  }
+  return next;
+}
+
+function chapterLabel(chapter: ClassroomObservationChapterOption): string {
+  const suffix = chapter.code ? ` (${chapter.code})` : "";
+  return `${chapter.subjectName} - ${chapter.name}${suffix}`;
+}
+
+function topicLabel(topic: ClassroomObservationTopicOption): string {
+  const suffix = topic.code ? ` (${topic.code})` : "";
+  return `${topic.name}${suffix}`;
+}
+
+function useCurriculumOptions(schoolCode: string, selectedGrade: string) {
+  const [options, setOptions] = useState<CurriculumOptionsState>(EMPTY_CURRICULUM_OPTIONS);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchOptions() {
+      if (!(VALID_GRADES as readonly string[]).includes(selectedGrade)) {
+        setOptions(EMPTY_CURRICULUM_OPTIONS);
+        setLoading(false);
+        setError(null);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const params = new URLSearchParams({
+          school_code: schoolCode,
+          grade: selectedGrade,
+        });
+        const response = await fetch(`/api/pm/classroom-observation-options?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error("Failed to load curriculum options");
+        }
+
+        const body = await response.json();
+        if (!cancelled) {
+          setOptions({
+            curricula: Array.isArray(body.curricula) ? body.curricula : [],
+            chapters: Array.isArray(body.chapters) ? body.chapters : [],
+            topics: Array.isArray(body.topics) ? body.topics : [],
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setOptions(EMPTY_CURRICULUM_OPTIONS);
+          setError("Failed to load curriculum options");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [schoolCode, selectedGrade]);
+
+  return { options, loading, error };
+}
+
+function CurriculumField({
+  disabled,
+  error,
+  loading,
+  options,
+  selectedCurriculumId,
+  selectedCurriculumName,
+  onChange,
+}: {
+  disabled: boolean;
+  error: string | null;
+  loading: boolean;
+  options: ClassroomObservationCurriculumOption[];
+  selectedCurriculumId: number | null;
+  selectedCurriculumName: string;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+}) {
+  return (
+    <FormSection spacing="" data-testid="curriculum-selection">
+      <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Curriculum</h3>
+      {disabled ? (
+        <p className="text-sm text-text-primary" data-testid="curriculum-display">
+          {selectedCurriculumName || "No curriculum selected"}
+        </p>
+      ) : loading ? (
+        <p className="text-sm text-text-muted" data-testid="curriculum-loading">Loading curriculum...</p>
+      ) : error ? (
+        <p className="text-sm text-danger" data-testid="curriculum-error">{error}</p>
+      ) : (
+        <Select
+          value={selectedCurriculumId !== null ? String(selectedCurriculumId) : ""}
+          onChange={onChange}
+          className="w-full"
+          data-testid="curriculum-select"
+        >
+          <option value="" disabled>
+            {options.length === 0 ? "No curricula found" : "Select a curriculum"}
+          </option>
+          {options.map((curriculum) => (
+            <option key={curriculum.id} value={String(curriculum.id)}>
+              {curriculum.name}
+            </option>
+          ))}
+        </Select>
+      )}
+    </FormSection>
+  );
+}
+
+function ChapterField({
+  chapters,
+  disabled,
+  loading,
+  selectedChapterId,
+  selectedChapterName,
+  selectedSubjectName,
+  onChange,
+}: {
+  chapters: ClassroomObservationChapterOption[];
+  disabled: boolean;
+  loading: boolean;
+  selectedChapterId: number | null;
+  selectedChapterName: string;
+  selectedSubjectName: string;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+}) {
+  return (
+    <FormSection spacing="" data-testid="chapter-selection">
+      <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Chapter</h3>
+      {disabled ? (
+        <p className="text-sm text-text-primary" data-testid="chapter-display">
+          {selectedChapterName
+            ? `${selectedSubjectName ? `${selectedSubjectName} - ` : ""}${selectedChapterName}`
+            : "No chapter selected"}
+        </p>
+      ) : loading ? (
+        <p className="text-sm text-text-muted" data-testid="chapter-loading">Loading chapters...</p>
+      ) : (
+        <Select
+          value={selectedChapterId !== null ? String(selectedChapterId) : ""}
+          onChange={onChange}
+          className="w-full"
+          data-testid="chapter-select"
+          disabled={chapters.length === 0}
+        >
+          <option value="" disabled>
+            {chapters.length === 0 ? "No chapters found" : "Select a chapter"}
+          </option>
+          {chapters.map((chapter) => (
+            <option key={`${chapter.curriculumId}-${chapter.id}`} value={String(chapter.id)}>
+              {chapterLabel(chapter)}
+            </option>
+          ))}
+        </Select>
+      )}
+    </FormSection>
+  );
+}
+
+function TopicField({
+  disabled,
+  loading,
+  selectedTopicId,
+  selectedTopicName,
+  topics,
+  onChange,
+}: {
+  disabled: boolean;
+  loading: boolean;
+  selectedTopicId: number | null;
+  selectedTopicName: string;
+  topics: ClassroomObservationTopicOption[];
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+}) {
+  return (
+    <FormSection spacing="" data-testid="topic-selection">
+      <h3 className="mb-2 text-sm font-semibold text-text-primary uppercase">Topic</h3>
+      {disabled ? (
+        <p className="text-sm text-text-primary" data-testid="topic-display">
+          {selectedTopicName || "No topic selected"}
+        </p>
+      ) : loading ? (
+        <p className="text-sm text-text-muted" data-testid="topic-loading">Loading topics...</p>
+      ) : (
+        <Select
+          value={selectedTopicId !== null ? String(selectedTopicId) : ""}
+          onChange={onChange}
+          className="w-full"
+          data-testid="topic-select"
+          disabled={topics.length === 0}
+        >
+          <option value="">
+            {topics.length === 0 ? "No topics found" : "No topic selected"}
+          </option>
+          {topics.map((topic) => (
+            <option key={`${topic.curriculumId}-${topic.id}`} value={String(topic.id)}>
+              {topicLabel(topic)}
+            </option>
+          ))}
+        </Select>
+      )}
+    </FormSection>
+  );
+}
+
+export default function ClassroomObservationContextFields({
+  data,
+  setData,
+  disabled,
+  schoolCode,
+  selectedGrade,
+}: ClassroomObservationContextFieldsProps) {
+  const { options, loading, error } = useCurriculumOptions(schoolCode, selectedGrade);
+
+  const selectedCurriculumId = readPositiveInteger(data.curriculum_id);
+  const selectedCurriculumName = readString(data.curriculum_name);
+  const selectedChapterId = readPositiveInteger(data.chapter_id);
+  const selectedChapterName = readString(data.chapter_name);
+  const selectedSubjectName = readString(data.subject_name);
+  const selectedTopicId = readPositiveInteger(data.topic_id);
+  const selectedTopicName = readString(data.topic_name);
+
+  const chaptersForCurriculum = useMemo(() => {
+    if (selectedCurriculumId === null) {
+      return [];
+    }
+    return options.chapters.filter(
+      (chapter) => chapter.curriculumId === selectedCurriculumId
+    );
+  }, [options.chapters, selectedCurriculumId]);
+
+  const topicsForChapter = useMemo(() => {
+    if (selectedCurriculumId === null || selectedChapterId === null) {
+      return [];
+    }
+    return options.topics.filter(
+      (topic) =>
+        topic.curriculumId === selectedCurriculumId &&
+        topic.chapterId === selectedChapterId
+    );
+  }, [options.topics, selectedChapterId, selectedCurriculumId]);
+
+  const handleCurriculumChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = Number(event.target.value);
+      const curriculum = options.curricula.find((option) => option.id === id);
+      if (!curriculum) {
+        return;
+      }
+
+      setData((current) => {
+        const next = clearFields(current, CHAPTER_FIELD_KEYS);
+        next.curriculum_id = curriculum.id;
+        next.curriculum_name = curriculum.name;
+        if (curriculum.code) {
+          next.curriculum_code = curriculum.code;
+        } else {
+          delete next.curriculum_code;
+        }
+        return next;
+      });
+    },
+    [options.curricula, setData]
+  );
+
+  const handleChapterChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = Number(event.target.value);
+      const chapter = chaptersForCurriculum.find((option) => option.id === id);
+      if (!chapter) {
+        return;
+      }
+
+      setData((current) => {
+        const next = clearFields(current, TOPIC_FIELD_KEYS);
+        next.chapter_id = chapter.id;
+        next.chapter_name = chapter.name;
+        next.chapter_topic_count = chapter.topicCount;
+        next.subject_id = chapter.subjectId;
+        next.subject_name = chapter.subjectName;
+        if (chapter.code) {
+          next.chapter_code = chapter.code;
+        } else {
+          delete next.chapter_code;
+        }
+        return next;
+      });
+    },
+    [chaptersForCurriculum, setData]
+  );
+
+  const handleTopicChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      if (!event.target.value) {
+        setData((current) => clearFields(current, TOPIC_FIELD_KEYS));
+        return;
+      }
+
+      const id = Number(event.target.value);
+      const topic = topicsForChapter.find((option) => option.id === id);
+      if (!topic) {
+        return;
+      }
+
+      setData((current) => {
+        const next = clearFields(current, TOPIC_FIELD_KEYS);
+        next.topic_id = topic.id;
+        next.topic_name = topic.name;
+        if (topic.code) {
+          next.topic_code = topic.code;
+        }
+        return next;
+      });
+    },
+    [setData, topicsForChapter]
+  );
+
+  return (
+    <>
+      <CurriculumField
+        disabled={disabled}
+        error={error}
+        loading={loading}
+        options={options.curricula}
+        selectedCurriculumId={selectedCurriculumId}
+        selectedCurriculumName={selectedCurriculumName}
+        onChange={handleCurriculumChange}
+      />
+      {selectedCurriculumId !== null && (
+        <ChapterField
+          chapters={chaptersForCurriculum}
+          disabled={disabled}
+          loading={loading}
+          selectedChapterId={selectedChapterId}
+          selectedChapterName={selectedChapterName}
+          selectedSubjectName={selectedSubjectName}
+          onChange={handleChapterChange}
+        />
+      )}
+      {selectedCurriculumId !== null && selectedChapterId !== null && (
+        <TopicField
+          disabled={disabled}
+          loading={loading}
+          selectedTopicId={selectedTopicId}
+          selectedTopicName={selectedTopicName}
+          topics={topicsForChapter}
+          onChange={handleTopicChange}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/visits/ClassroomObservationForm.test.tsx
+++ b/src/components/visits/ClassroomObservationForm.test.tsx
@@ -133,6 +133,17 @@ function withTeacherAndGrade(extra: Record<string, unknown> = {}): Record<string
   };
 }
 
+async function waitForCurriculumSelectOptions() {
+  await waitFor(() => {
+    expect(screen.getByTestId("curriculum-select")).toBeInTheDocument();
+  });
+
+  await waitFor(() => {
+    const select = screen.getByTestId("curriculum-select") as HTMLSelectElement;
+    expect(select.options).toHaveLength(4);
+  });
+}
+
 describe("ClassroomObservationForm", () => {
   beforeEach(() => {
     mockFetchTeachers();
@@ -441,14 +452,7 @@ describe("ClassroomObservationForm", () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("curriculum-select")).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        const select = screen.getByTestId("curriculum-select") as HTMLSelectElement;
-        expect(select.options).toHaveLength(4);
-      });
+      await waitForCurriculumSelectOptions();
 
       await user.selectOptions(screen.getByTestId("curriculum-select"), "1");
       expect(latestData).toMatchObject({
@@ -521,14 +525,7 @@ describe("ClassroomObservationForm", () => {
 
       render(<Harness initialData={withTeacherAndGrade({ grade: "11" })} />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId("curriculum-select")).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        const select = screen.getByTestId("curriculum-select") as HTMLSelectElement;
-        expect(select.options).toHaveLength(4);
-      });
+      await waitForCurriculumSelectOptions();
 
       await user.selectOptions(screen.getByTestId("curriculum-select"), "2");
       await user.selectOptions(screen.getByTestId("chapter-select"), "45");

--- a/src/components/visits/ClassroomObservationForm.test.tsx
+++ b/src/components/visits/ClassroomObservationForm.test.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useState } from "react";
+import { StrictMode, useEffect, useState } from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,12 +12,73 @@ const MOCK_TEACHERS = [
   { id: 3, email: "noname@school.com", full_name: null },
 ];
 
-function mockFetchTeachers(teachers = MOCK_TEACHERS) {
+const MOCK_CURRICULUM_OPTIONS = {
+  curricula: [
+    { id: 1, name: "JEE Mains", code: "JMNS" },
+    { id: 2, name: "NEET", code: "NEET" },
+    { id: 9, name: "JEE Advanced", code: "JADV" },
+  ],
+  chapters: [
+    {
+      id: 44,
+      code: "11P1",
+      name: "Units and Measurement",
+      grade: 11,
+      subjectId: 4,
+      subjectName: "Physics",
+      curriculumId: 1,
+      topicCount: 2,
+    },
+    {
+      id: 45,
+      code: "11C1",
+      name: "Some Basic Concepts of Chemistry",
+      grade: 11,
+      subjectId: 2,
+      subjectName: "Chemistry",
+      curriculumId: 2,
+      topicCount: 0,
+    },
+  ],
+  topics: [
+    {
+      id: 101,
+      code: "11P1.1",
+      name: "Physical Quantities",
+      chapterId: 44,
+      curriculumId: 1,
+    },
+    {
+      id: 102,
+      code: "11P1.2",
+      name: "Errors",
+      chapterId: 44,
+      curriculumId: 1,
+    },
+  ],
+};
+
+function mockFetchTeachers(teachers = MOCK_TEACHERS, curriculumOptions = MOCK_CURRICULUM_OPTIONS) {
   vi.stubGlobal(
     "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ teachers }),
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/pm/teachers")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ teachers }),
+        });
+      }
+      if (url.startsWith("/api/pm/classroom-observation-options")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(curriculumOptions),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: "Unexpected URL" }),
+      });
     })
   );
 }
@@ -36,10 +97,20 @@ interface HarnessProps {
   disabled?: boolean;
   initialData?: Record<string, unknown>;
   schoolCode?: string;
+  onDataChange?: (data: Record<string, unknown>) => void;
 }
 
-function Harness({ disabled = false, initialData = {}, schoolCode = "SCH001" }: HarnessProps) {
+function Harness({
+  disabled = false,
+  initialData = {},
+  schoolCode = "SCH001",
+  onDataChange,
+}: HarnessProps) {
   const [data, setData] = useState<Record<string, unknown>>(initialData);
+
+  useEffect(() => {
+    onDataChange?.(data);
+  }, [data, onDataChange]);
 
   return (
     <ClassroomObservationForm
@@ -353,6 +424,118 @@ describe("ClassroomObservationForm", () => {
       await user.selectOptions(screen.getByTestId("grade-select"), "10");
       expect(screen.getByTestId("rubric-score-summary")).toBeInTheDocument();
       expect(screen.getAllByTestId(/rubric-param-/)).toHaveLength(19);
+    });
+  });
+
+  describe("curriculum, chapter, and topic dropdowns", () => {
+    it("loads CMS options after grade selection and stores selected context", async () => {
+      const user = userEvent.setup();
+      let latestData: Record<string, unknown> = {};
+
+      render(
+        <Harness
+          initialData={withTeacherAndGrade({ grade: "11" })}
+          onDataChange={(nextData) => {
+            latestData = nextData;
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("curriculum-select")).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        const select = screen.getByTestId("curriculum-select") as HTMLSelectElement;
+        expect(select.options).toHaveLength(4);
+      });
+
+      await user.selectOptions(screen.getByTestId("curriculum-select"), "1");
+      expect(latestData).toMatchObject({
+        curriculum_id: 1,
+        curriculum_name: "JEE Mains",
+        curriculum_code: "JMNS",
+      });
+
+      const chapterSelect = await screen.findByTestId("chapter-select");
+      expect(chapterSelect).toHaveTextContent("Physics - Units and Measurement (11P1)");
+
+      await user.selectOptions(chapterSelect, "44");
+      expect(latestData).toMatchObject({
+        chapter_id: 44,
+        chapter_name: "Units and Measurement",
+        chapter_code: "11P1",
+        chapter_topic_count: 2,
+        subject_id: 4,
+        subject_name: "Physics",
+      });
+
+      const topicSelect = await screen.findByTestId("topic-select");
+      expect(topicSelect).toHaveTextContent("Physical Quantities (11P1.1)");
+
+      await user.selectOptions(topicSelect, "101");
+      expect(latestData).toMatchObject({
+        topic_id: 101,
+        topic_name: "Physical Quantities",
+        topic_code: "11P1.1",
+      });
+    });
+
+    it("clears curriculum context when grade changes", async () => {
+      const user = userEvent.setup();
+      let latestData: Record<string, unknown> = {};
+
+      render(
+        <Harness
+          initialData={withTeacherAndGrade({
+            grade: "11",
+            curriculum_id: 1,
+            curriculum_name: "JEE Mains",
+            chapter_id: 44,
+            chapter_name: "Units and Measurement",
+            subject_id: 4,
+            subject_name: "Physics",
+            topic_id: 101,
+            topic_name: "Physical Quantities",
+          })}
+          onDataChange={(nextData) => {
+            latestData = nextData;
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("grade-select")).toBeInTheDocument();
+      });
+
+      await user.selectOptions(screen.getByTestId("grade-select"), "12");
+
+      expect(latestData).toMatchObject({ grade: "12" });
+      expect(latestData).not.toHaveProperty("curriculum_id");
+      expect(latestData).not.toHaveProperty("chapter_id");
+      expect(latestData).not.toHaveProperty("topic_id");
+    });
+
+    it("shows an empty topic dropdown when the selected chapter has no active topics", async () => {
+      const user = userEvent.setup();
+
+      render(<Harness initialData={withTeacherAndGrade({ grade: "11" })} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("curriculum-select")).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        const select = screen.getByTestId("curriculum-select") as HTMLSelectElement;
+        expect(select.options).toHaveLength(4);
+      });
+
+      await user.selectOptions(screen.getByTestId("curriculum-select"), "2");
+      await user.selectOptions(screen.getByTestId("chapter-select"), "45");
+
+      const topicSelect = await screen.findByTestId("topic-select");
+      expect(topicSelect).toBeDisabled();
+      expect(topicSelect).toHaveTextContent("No topics found");
     });
   });
 

--- a/src/components/visits/ClassroomObservationForm.tsx
+++ b/src/components/visits/ClassroomObservationForm.tsx
@@ -12,6 +12,7 @@ import {
 import { getTeacherDisplayName, type Teacher } from "@/lib/teacher-utils";
 import { isPlainObject } from "@/lib/visit-form-utils";
 import { FormSection, Select, StickyProgressBar } from "@/components/ui";
+import ClassroomObservationContextFields from "./ClassroomObservationContextFields";
 
 interface ClassroomObservationFormProps {
   data: Record<string, unknown>;
@@ -20,8 +21,34 @@ interface ClassroomObservationFormProps {
   schoolCode: string;
 }
 
+const CURRICULUM_FIELD_KEYS = [
+  "curriculum_id",
+  "curriculum_name",
+  "curriculum_code",
+  "chapter_id",
+  "chapter_name",
+  "chapter_code",
+  "chapter_topic_count",
+  "subject_id",
+  "subject_name",
+  "topic_id",
+  "topic_name",
+  "topic_code",
+] as const;
+
 function readString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function clearFields(
+  data: Record<string, unknown>,
+  keys: readonly string[]
+): Record<string, unknown> {
+  const next = { ...data };
+  for (const key of keys) {
+    delete next[key];
+  }
+  return next;
 }
 
 function getParams(data: Record<string, unknown>): Record<string, ParamData> {
@@ -126,7 +153,7 @@ export default function ClassroomObservationForm({
     (event: React.ChangeEvent<HTMLSelectElement>) => {
       const grade = event.target.value;
       setData((current) => ({
-        ...current,
+        ...clearFields(current, CURRICULUM_FIELD_KEYS),
         grade,
       }));
     },
@@ -156,6 +183,7 @@ export default function ClassroomObservationForm({
   const hasTeacher = selectedTeacherId !== null;
   const hasGrade = selectedGrade !== null && (VALID_GRADES as readonly string[]).includes(selectedGrade);
   const showRubric = hasTeacher && hasGrade;
+  const showCurriculumFields = hasTeacher && hasGrade;
 
   return (
     <div className="space-y-4" data-testid="classroom-observation-form">
@@ -224,6 +252,16 @@ export default function ClassroomObservationForm({
             </Select>
           )}
         </FormSection>
+      )}
+
+      {showCurriculumFields && selectedGrade && (
+        <ClassroomObservationContextFields
+          data={data}
+          setData={setData}
+          disabled={disabled}
+          schoolCode={schoolCode}
+          selectedGrade={selectedGrade}
+        />
       )}
 
       {/* Gating messages */}

--- a/src/components/visits/VisitSummaryFilterBar.test.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.test.tsx
@@ -105,7 +105,7 @@ describe("VisitSummaryFilterBar", () => {
       { scroll: false }
     );
 
-    fireEvent.change(screen.getByLabelText("Action Completion"), { target: { value: "partial" } });
+    fireEvent.change(screen.getByLabelText("Required Completion"), { target: { value: "partial" } });
     vi.advanceTimersByTime(300);
     expect(mockReplace).toHaveBeenLastCalledWith(
       "/school-visit-summary?page=1&bucket=partial",

--- a/src/components/visits/VisitSummaryFilterBar.tsx
+++ b/src/components/visits/VisitSummaryFilterBar.tsx
@@ -224,7 +224,7 @@ export default function VisitSummaryFilterBar({
 
         <div>
           <label htmlFor="visit-summary-bucket" className="text-xs font-bold uppercase tracking-wide text-text-muted">
-            Action Completion
+            Required Completion
           </label>
           <select
             id="visit-summary-bucket"
@@ -235,11 +235,11 @@ export default function VisitSummaryFilterBar({
             }}
             className="mt-2 w-full border border-border bg-bg-card px-3 py-2 text-sm text-text-primary"
           >
-            <option value="">Any completion</option>
-            <option value="none">No actions</option>
+            <option value="">Any required completion</option>
+            <option value="none">No required actions</option>
             <option value="partial">Partially started</option>
-            <option value="all_present">All types present but incomplete</option>
-            <option value="all_complete">All 7 complete</option>
+            <option value="all_present">All required present but incomplete</option>
+            <option value="all_complete">All required complete</option>
           </select>
         </div>
 

--- a/src/lib/af-team-interaction.ts
+++ b/src/lib/af-team-interaction.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -23,6 +27,7 @@ export interface AFTeamInteractionConfig {
 export interface AFTeamInteractionData {
   teachers: Array<{ id: number; name: string }>;
   questions: Record<string, { answer: boolean | null; remark?: string }>;
+  additional_notes?: string;
 }
 
 const sections: SectionConfig[] = [
@@ -62,7 +67,11 @@ export const AF_TEAM_INTERACTION_CONFIG: AFTeamInteractionConfig = {
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(["teachers", "questions"]);
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "teachers",
+  "questions",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   AF_TEAM_INTERACTION_CONFIG.allQuestionKeys.map((key) => {
@@ -182,6 +191,7 @@ export function validateAFTeamInteractionSave(data: unknown): ValidationResult {
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if ("teachers" in payload) {
     errors.push(...validateTeachers(payload.teachers));
@@ -208,6 +218,7 @@ export function validateAFTeamInteractionComplete(data: unknown): ValidationResu
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if (!("teachers" in payload) || !Array.isArray(payload.teachers) || payload.teachers.length === 0) {
     errors.push("At least one teacher must be selected");

--- a/src/lib/classroom-observation-curriculum.test.ts
+++ b/src/lib/classroom-observation-curriculum.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./db", () => ({ query: vi.fn() }));
+
+import { query } from "./db";
+import {
+  CLASSROOM_OBSERVATION_CURRICULUM_IDS,
+  getClassroomObservationCurriculumOptions,
+  isClassroomObservationGrade,
+} from "./classroom-observation-curriculum";
+
+const mockQuery = vi.mocked(query);
+
+describe("classroom-observation-curriculum", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("uses only the supported classroom observation curricula", () => {
+    expect(CLASSROOM_OBSERVATION_CURRICULUM_IDS).toEqual([1, 2, 9]);
+  });
+
+  it("accepts only grades 10, 11, and 12", () => {
+    expect(isClassroomObservationGrade(10)).toBe(true);
+    expect(isClassroomObservationGrade(11)).toBe(true);
+    expect(isClassroomObservationGrade(12)).toBe(true);
+    expect(isClassroomObservationGrade(9)).toBe(false);
+  });
+
+  it("maps curricula, active chapters, and active topics", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        { id: "1", name: "JEE Mains", code: "JMNS" },
+        { id: "2", name: "NEET", code: "NEET" },
+      ] as never)
+      .mockResolvedValueOnce([
+        {
+          chapter_id: "44",
+          chapter_code: "11P1",
+          chapter_name: [{ lang_code: "en", chapter: "Units and Measurement" }],
+          grade: "11",
+          subject_id: "4",
+          subject_name: [{ lang_code: "en", subject: "Physics" }],
+          curriculum_id: "1",
+          topic_count: "2",
+        },
+        {
+          chapter_id: "45",
+          chapter_code: "11M1",
+          chapter_name: [{ lang_code: "en", chapter: "Sets" }],
+          grade: "11",
+          subject_id: "1",
+          subject_name: [{ lang_code: "en", subject: "Mathematics" }],
+          curriculum_id: "9",
+          topic_count: "0",
+        },
+      ] as never)
+      .mockResolvedValueOnce([
+        {
+          topic_id: "101",
+          topic_code: "11P1.1",
+          topic_name: [{ lang_code: "en", topic: "Physical Quantities" }],
+          chapter_id: "44",
+          curriculum_id: "1",
+        },
+      ] as never);
+
+    const result = await getClassroomObservationCurriculumOptions({ grade: 11 });
+
+    expect(result.curricula).toEqual([
+      { id: 1, name: "JEE Mains", code: "JMNS" },
+      { id: 2, name: "NEET", code: "NEET" },
+    ]);
+    expect(result.chapters).toEqual([
+      {
+        id: 44,
+        code: "11P1",
+        name: "Units and Measurement",
+        grade: 11,
+        subjectId: 4,
+        subjectName: "Physics",
+        curriculumId: 1,
+        topicCount: 2,
+      },
+      {
+        id: 45,
+        code: "11M1",
+        name: "Sets",
+        grade: 11,
+        subjectId: 1,
+        subjectName: "Maths",
+        curriculumId: 9,
+        topicCount: 0,
+      },
+    ]);
+    expect(result.topics).toEqual([
+      {
+        id: 101,
+        code: "11P1.1",
+        name: "Physical Quantities",
+        chapterId: 44,
+        curriculumId: 1,
+      },
+    ]);
+  });
+
+  it("filters archived CMS chapters and topics in SQL", async () => {
+    mockQuery
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never);
+
+    await getClassroomObservationCurriculumOptions({ grade: 12 });
+
+    const chapterSql = mockQuery.mock.calls[1]?.[0] as string;
+    const topicSql = mockQuery.mock.calls[2]?.[0] as string;
+
+    expect(chapterSql).toContain("ch.cms_status_id IS NULL");
+    expect(chapterSql).toContain("t.cms_status_id IS NULL");
+    expect(topicSql).toContain("ch.cms_status_id IS NULL");
+    expect(topicSql).toContain("t.cms_status_id IS NULL");
+  });
+});

--- a/src/lib/classroom-observation-curriculum.test.ts
+++ b/src/lib/classroom-observation-curriculum.test.ts
@@ -104,6 +104,54 @@ describe("classroom-observation-curriculum", () => {
     ]);
   });
 
+  it("sorts chapters and topics by code using natural numeric order", async () => {
+    mockQuery
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        {
+          chapter_id: "10",
+          chapter_code: "11P10",
+          chapter_name: [{ lang_code: "en", chapter: "Tenth" }],
+          grade: "11",
+          subject_id: "4",
+          subject_name: [{ lang_code: "en", subject: "Physics" }],
+          curriculum_id: "1",
+          topic_count: "0",
+        },
+        {
+          chapter_id: "2",
+          chapter_code: "11P2",
+          chapter_name: [{ lang_code: "en", chapter: "Second" }],
+          grade: "11",
+          subject_id: "4",
+          subject_name: [{ lang_code: "en", subject: "Physics" }],
+          curriculum_id: "1",
+          topic_count: "0",
+        },
+      ] as never)
+      .mockResolvedValueOnce([
+        {
+          topic_id: "910",
+          topic_code: "11P2.10",
+          topic_name: [{ lang_code: "en", topic: "Topic Ten" }],
+          chapter_id: "2",
+          curriculum_id: "1",
+        },
+        {
+          topic_id: "92",
+          topic_code: "11P2.2",
+          topic_name: [{ lang_code: "en", topic: "Topic Two" }],
+          chapter_id: "2",
+          curriculum_id: "1",
+        },
+      ] as never);
+
+    const result = await getClassroomObservationCurriculumOptions({ grade: 11 });
+
+    expect(result.chapters.map((chapter) => chapter.code)).toEqual(["11P2", "11P10"]);
+    expect(result.topics.map((topic) => topic.code)).toEqual(["11P2.2", "11P2.10"]);
+  });
+
   it("filters archived CMS chapters and topics in SQL", async () => {
     mockQuery
       .mockResolvedValueOnce([] as never)

--- a/src/lib/classroom-observation-curriculum.ts
+++ b/src/lib/classroom-observation-curriculum.ts
@@ -1,3 +1,4 @@
+import { compareCurriculumCodes } from "./curriculum-code-sort";
 import { query } from "./db";
 
 export const CLASSROOM_OBSERVATION_CURRICULUM_IDS = [1, 2, 9] as const;
@@ -203,9 +204,21 @@ export async function getClassroomObservationCurriculumOptions(params: {
     [CLASSROOM_OBSERVATION_CURRICULUM_IDS, params.grade]
   );
 
+  const mappedChapters = chapters.map(mapChapter).sort((a, b) => {
+    if (a.curriculumId !== b.curriculumId) return a.curriculumId - b.curriculumId;
+    if (a.subjectId !== b.subjectId) return a.subjectId - b.subjectId;
+    return compareCurriculumCodes(a.code, b.code);
+  });
+
+  const mappedTopics = topics.map(mapTopic).sort((a, b) => {
+    if (a.curriculumId !== b.curriculumId) return a.curriculumId - b.curriculumId;
+    if (a.chapterId !== b.chapterId) return a.chapterId - b.chapterId;
+    return compareCurriculumCodes(a.code, b.code);
+  });
+
   return {
     curricula: curricula.map(mapCurriculum),
-    chapters: chapters.map(mapChapter),
-    topics: topics.map(mapTopic),
+    chapters: mappedChapters,
+    topics: mappedTopics,
   };
 }

--- a/src/lib/classroom-observation-curriculum.ts
+++ b/src/lib/classroom-observation-curriculum.ts
@@ -1,0 +1,211 @@
+import { query } from "./db";
+
+export const CLASSROOM_OBSERVATION_CURRICULUM_IDS = [1, 2, 9] as const;
+
+export interface ClassroomObservationCurriculumOption {
+  id: number;
+  name: string;
+  code: string | null;
+}
+
+export interface ClassroomObservationChapterOption {
+  id: number;
+  code: string | null;
+  name: string;
+  grade: number;
+  subjectId: number;
+  subjectName: string;
+  curriculumId: number;
+  topicCount: number;
+}
+
+export interface ClassroomObservationTopicOption {
+  id: number;
+  code: string | null;
+  name: string;
+  chapterId: number;
+  curriculumId: number;
+}
+
+export interface ClassroomObservationCurriculumOptions {
+  curricula: ClassroomObservationCurriculumOption[];
+  chapters: ClassroomObservationChapterOption[];
+  topics: ClassroomObservationTopicOption[];
+}
+
+interface CurriculumRow {
+  id: number | string;
+  name: string | null;
+  code: string | null;
+}
+
+interface ChapterRow {
+  chapter_id: number | string;
+  chapter_code: string | null;
+  chapter_name: unknown;
+  grade: number | string;
+  subject_id: number | string;
+  subject_name: unknown;
+  curriculum_id: number | string;
+  topic_count: number | string | null;
+}
+
+interface TopicRow {
+  topic_id: number | string;
+  topic_code: string | null;
+  topic_name: unknown;
+  chapter_id: number | string;
+  curriculum_id: number | string;
+}
+
+function extractEnglishName(value: unknown, field: string, fallback: string): string {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return extractEnglishName(parsed, field, fallback);
+    } catch {
+      return value.trim() || fallback;
+    }
+  }
+
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+
+  const english = value.find(
+    (item): item is Record<string, unknown> =>
+      item !== null &&
+      typeof item === "object" &&
+      !Array.isArray(item) &&
+      item.lang_code === "en"
+  );
+  const label = english?.[field];
+  return typeof label === "string" && label.trim() ? label.trim() : fallback;
+}
+
+function normalizeSubjectName(value: unknown): string {
+  const subject = extractEnglishName(value, "subject", "Unknown subject");
+  return subject === "Mathematics" ? "Maths" : subject;
+}
+
+function numberFromDb(value: number | string | null): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function mapCurriculum(row: CurriculumRow): ClassroomObservationCurriculumOption {
+  return {
+    id: numberFromDb(row.id),
+    name: row.name?.trim() || "Unknown curriculum",
+    code: row.code?.trim() || null,
+  };
+}
+
+function mapChapter(row: ChapterRow): ClassroomObservationChapterOption {
+  const code = row.chapter_code?.trim() || null;
+  return {
+    id: numberFromDb(row.chapter_id),
+    code,
+    name: extractEnglishName(row.chapter_name, "chapter", code ?? "Unknown chapter"),
+    grade: numberFromDb(row.grade),
+    subjectId: numberFromDb(row.subject_id),
+    subjectName: normalizeSubjectName(row.subject_name),
+    curriculumId: numberFromDb(row.curriculum_id),
+    topicCount: numberFromDb(row.topic_count),
+  };
+}
+
+function mapTopic(row: TopicRow): ClassroomObservationTopicOption {
+  const code = row.topic_code?.trim() || null;
+  return {
+    id: numberFromDb(row.topic_id),
+    code,
+    name: extractEnglishName(row.topic_name, "topic", code ?? "Unknown topic"),
+    chapterId: numberFromDb(row.chapter_id),
+    curriculumId: numberFromDb(row.curriculum_id),
+  };
+}
+
+export function isClassroomObservationGrade(value: number): boolean {
+  return value === 10 || value === 11 || value === 12;
+}
+
+export async function getClassroomObservationCurriculumOptions(params: {
+  grade: number;
+}): Promise<ClassroomObservationCurriculumOptions> {
+  const curricula = await query<CurriculumRow>(
+    `SELECT id, name, code
+     FROM curriculum
+     WHERE id = ANY($1::int[])
+     ORDER BY CASE id
+       WHEN 1 THEN 1
+       WHEN 2 THEN 2
+       WHEN 9 THEN 3
+       ELSE 99
+     END`,
+    [CLASSROOM_OBSERVATION_CURRICULUM_IDS]
+  );
+
+  if (!isClassroomObservationGrade(params.grade)) {
+    return {
+      curricula: curricula.map(mapCurriculum),
+      chapters: [],
+      topics: [],
+    };
+  }
+
+  const chapters = await query<ChapterRow>(
+    `SELECT
+       ch.id AS chapter_id,
+       ch.code AS chapter_code,
+       ch.name AS chapter_name,
+       g.number AS grade,
+       s.id AS subject_id,
+       s.name AS subject_name,
+       cc.curriculum_id,
+       COUNT(DISTINCT tc.topic_id)::int AS topic_count
+     FROM chapter_curriculum cc
+     JOIN chapter ch ON ch.id = cc.chapter_id
+     JOIN grade g ON g.id = ch.grade_id
+     JOIN subject s ON s.id = ch.subject_id
+     LEFT JOIN topic t
+       ON t.chapter_id = ch.id
+      AND t.cms_status_id IS NULL
+     LEFT JOIN topic_curriculum tc
+       ON tc.topic_id = t.id
+      AND tc.curriculum_id = cc.curriculum_id
+     WHERE cc.curriculum_id = ANY($1::int[])
+       AND g.number = $2
+       AND ch.cms_status_id IS NULL
+     GROUP BY ch.id, ch.code, ch.name, g.number, s.id, s.name, cc.curriculum_id
+     ORDER BY cc.curriculum_id ASC, s.id ASC, ch.code ASC`,
+    [CLASSROOM_OBSERVATION_CURRICULUM_IDS, params.grade]
+  );
+
+  const topics = await query<TopicRow>(
+    `SELECT DISTINCT
+       t.id AS topic_id,
+       t.code AS topic_code,
+       t.name AS topic_name,
+       t.chapter_id,
+       tc.curriculum_id
+     FROM topic_curriculum tc
+     JOIN topic t
+       ON t.id = tc.topic_id
+      AND t.cms_status_id IS NULL
+     JOIN chapter ch
+       ON ch.id = t.chapter_id
+      AND ch.cms_status_id IS NULL
+     JOIN grade g ON g.id = ch.grade_id
+     WHERE tc.curriculum_id = ANY($1::int[])
+       AND g.number = $2
+     ORDER BY tc.curriculum_id ASC, t.chapter_id ASC, t.code ASC, t.id ASC`,
+    [CLASSROOM_OBSERVATION_CURRICULUM_IDS, params.grade]
+  );
+
+  return {
+    curricula: curricula.map(mapCurriculum),
+    chapters: chapters.map(mapChapter),
+    topics: topics.map(mapTopic),
+  };
+}

--- a/src/lib/classroom-observation-rubric.test.ts
+++ b/src/lib/classroom-observation-rubric.test.ts
@@ -19,6 +19,23 @@ function buildCompleteParams(): Record<string, { score: number }> {
   return params;
 }
 
+function buildCurriculumContext() {
+  return {
+    curriculum_id: 1,
+    curriculum_name: "JEE Mains",
+    curriculum_code: "JMNS",
+    chapter_id: 44,
+    chapter_name: "Units and Measurement",
+    chapter_code: "11P1",
+    chapter_topic_count: 2,
+    subject_id: 4,
+    subject_name: "Physics",
+    topic_id: 101,
+    topic_name: "Physical Quantities",
+    topic_code: "11P1.1",
+  };
+}
+
 describe("classroom-observation-rubric config", () => {
   it("defines rubric v1 with 19 parameters and max score 45", () => {
     expect(CURRENT_RUBRIC_VERSION).toBe("1.0");
@@ -66,12 +83,16 @@ describe("classroom observation summary extractors", () => {
         text: "Needs tighter closure",
       },
     ]);
-    expect(computeInlineStats(data)).toEqual({
-      totalScore: 6,
-      maxScore: 45,
-      remarkCount: 1,
-    });
-  });
+	    expect(computeInlineStats(data)).toEqual({
+	      totalScore: 6,
+	      maxScore: 45,
+	      remarkCount: 1,
+	      curriculumName: null,
+	      chapterName: null,
+	      subjectName: null,
+	      topicName: null,
+	    });
+	  });
 
   it("handles missing params and null data gracefully", () => {
     expect(extractRemarks({
@@ -110,17 +131,18 @@ describe("computeTotalScore", () => {
 describe("validateClassroomObservationSave", () => {
   it("accepts empty payload and partial payloads", () => {
     expect(validateClassroomObservationSave({})).toEqual({ valid: true, errors: [] });
-    expect(
-      validateClassroomObservationSave({
-        params: {
-          teacher_on_time: { score: 1 },
-          recall_test: { score: 2, remarks: "interactive" },
-        },
-        observer_summary_strengths: "strong structure",
-        additional_notes: "Teacher requested chapter-level support",
-      })
-    ).toEqual({ valid: true, errors: [] });
-  });
+	    expect(
+	      validateClassroomObservationSave({
+	        params: {
+	          teacher_on_time: { score: 1 },
+	          recall_test: { score: 2, remarks: "interactive" },
+	        },
+	        observer_summary_strengths: "strong structure",
+	        ...buildCurriculumContext(),
+	        additional_notes: "Teacher requested chapter-level support",
+	      })
+	    ).toEqual({ valid: true, errors: [] });
+	  });
 
   it("rejects invalid score values", () => {
     const outOfRange = validateClassroomObservationSave({
@@ -151,8 +173,32 @@ describe("validateClassroomObservationSave", () => {
     const result = validateClassroomObservationSave({
       additional_notes: 42,
     });
+
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("additional_notes must be a string");
+  });
+
+  it("rejects invalid curriculum context field types", () => {
+    const result = validateClassroomObservationSave({
+      curriculum_id: "1",
+      curriculum_name: 123,
+      chapter_id: 0,
+      chapter_topic_count: -1,
+      subject_id: 4.5,
+      topic_id: false,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "curriculum_id must be a positive integer",
+        "curriculum_name must be a string",
+        "chapter_id must be a positive integer",
+        "chapter_topic_count must be a non-negative integer",
+        "subject_id must be a positive integer",
+        "topic_id must be a positive integer",
+      ])
+    );
   });
 
   it("rejects unknown rubric versions when provided", () => {
@@ -200,6 +246,7 @@ describe("validateClassroomObservationComplete", () => {
       teacher_id: 42,
       teacher_name: "Jane Doe",
       grade: "11",
+      ...buildCurriculumContext(),
     });
     expect(result).toEqual({ valid: true, errors: [] });
   });
@@ -209,10 +256,82 @@ describe("validateClassroomObservationComplete", () => {
       rubric_version: CURRENT_RUBRIC_VERSION,
       params: buildCompleteParams(),
     });
+
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("teacher_id is required");
     expect(result.errors).toContain("teacher_name is required");
     expect(result.errors).toContain("grade is required");
+  });
+
+  it("requires curriculum and chapter context for grades 11 and 12", () => {
+    const result = validateClassroomObservationComplete({
+      rubric_version: CURRENT_RUBRIC_VERSION,
+      params: buildCompleteParams(),
+      teacher_id: 1,
+      teacher_name: "Teacher",
+      grade: "12",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "curriculum_id is required",
+        "curriculum_name is required",
+        "chapter_id is required",
+        "chapter_name is required",
+        "chapter_topic_count is required",
+        "subject_id is required",
+        "subject_name is required",
+      ])
+    );
+  });
+
+  it("requires topic context when the selected chapter has active topics", () => {
+    const result = validateClassroomObservationComplete({
+      rubric_version: CURRENT_RUBRIC_VERSION,
+      params: buildCompleteParams(),
+      teacher_id: 1,
+      teacher_name: "Teacher",
+      grade: "11",
+      ...buildCurriculumContext(),
+      topic_id: undefined,
+      topic_name: undefined,
+      topic_code: undefined,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining(["topic_id is required", "topic_name is required"])
+    );
+  });
+
+  it("allows topic context to be empty when the selected chapter has no active topics", () => {
+    const result = validateClassroomObservationComplete({
+      rubric_version: CURRENT_RUBRIC_VERSION,
+      params: buildCompleteParams(),
+      teacher_id: 1,
+      teacher_name: "Teacher",
+      grade: "11",
+      ...buildCurriculumContext(),
+      chapter_topic_count: 0,
+      topic_id: undefined,
+      topic_name: undefined,
+      topic_code: undefined,
+    });
+
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it("does not require curriculum context for grade 10", () => {
+    const result = validateClassroomObservationComplete({
+      rubric_version: CURRENT_RUBRIC_VERSION,
+      params: buildCompleteParams(),
+      teacher_id: 1,
+      teacher_name: "Teacher",
+      grade: "10",
+    });
+
+    expect(result).toEqual({ valid: true, errors: [] });
   });
 
   it("rejects empty teacher_name", () => {
@@ -222,6 +341,7 @@ describe("validateClassroomObservationComplete", () => {
       teacher_id: 1,
       teacher_name: "",
       grade: "10",
+      ...buildCurriculumContext(),
     });
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("teacher_name is required");

--- a/src/lib/classroom-observation-rubric.test.ts
+++ b/src/lib/classroom-observation-rubric.test.ts
@@ -117,6 +117,7 @@ describe("validateClassroomObservationSave", () => {
           recall_test: { score: 2, remarks: "interactive" },
         },
         observer_summary_strengths: "strong structure",
+        additional_notes: "Teacher requested chapter-level support",
       })
     ).toEqual({ valid: true, errors: [] });
   });
@@ -144,6 +145,14 @@ describe("validateClassroomObservationSave", () => {
     });
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Unknown top-level field: legacy_key");
+  });
+
+  it("rejects non-string action-level additional notes", () => {
+    const result = validateClassroomObservationSave({
+      additional_notes: 42,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("additional_notes must be a string");
   });
 
   it("rejects unknown rubric versions when provided", () => {

--- a/src/lib/classroom-observation-rubric.ts
+++ b/src/lib/classroom-observation-rubric.ts
@@ -35,17 +35,6 @@ export interface ParamData {
   remarks?: string;
 }
 
-export interface ClassroomObservationData {
-  rubric_version: string;
-  params: Record<string, ParamData>;
-  observer_summary_strengths?: string;
-  observer_summary_improvements?: string;
-  teacher_id?: number;
-  teacher_name?: string;
-  grade?: string;
-  additional_notes?: string;
-}
-
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -310,6 +299,18 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
   "teacher_id",
   "teacher_name",
   "grade",
+  "curriculum_id",
+  "curriculum_name",
+  "curriculum_code",
+  "chapter_id",
+  "chapter_name",
+  "chapter_code",
+  "chapter_topic_count",
+  "subject_id",
+  "subject_name",
+  "topic_id",
+  "topic_name",
+  "topic_code",
   ACTION_ADDITIONAL_NOTES_KEY,
 ]);
 
@@ -319,6 +320,54 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function getAllowedScoresLabel(parameter: RubricParameter): string {
   return parameter.options.map((option) => option.score).join(", ");
+}
+
+function validateOptionalStringField(
+  payload: Record<string, unknown>,
+  key: string,
+  label = key
+): string[] {
+  if (!(key in payload) || payload[key] === undefined) {
+    return [];
+  }
+
+  return typeof payload[key] === "string" ? [] : [`${label} must be a string`];
+}
+
+function validateOptionalPositiveIntegerField(
+  payload: Record<string, unknown>,
+  key: string,
+  label = key
+): string[] {
+  if (!(key in payload) || payload[key] === undefined) {
+    return [];
+  }
+
+  const value = payload[key];
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value > 0 &&
+    Number.isInteger(value)
+    ? []
+    : [`${label} must be a positive integer`];
+}
+
+function validateOptionalNonNegativeIntegerField(
+  payload: Record<string, unknown>,
+  key: string,
+  label = key
+): string[] {
+  if (!(key in payload) || payload[key] === undefined) {
+    return [];
+  }
+
+  const value = payload[key];
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    Number.isInteger(value)
+    ? []
+    : [`${label} must be a non-negative integer`];
 }
 
 function validateTopLevelShape(data: unknown): {
@@ -368,11 +417,7 @@ function validateTopLevelShape(data: unknown): {
     }
   }
 
-  if ("teacher_name" in payload && payload.teacher_name !== undefined) {
-    if (typeof payload.teacher_name !== "string") {
-      errors.push("teacher_name must be a string");
-    }
-  }
+  errors.push(...validateOptionalStringField(payload, "teacher_name"));
 
   if ("grade" in payload && payload.grade !== undefined) {
     if (
@@ -382,6 +427,19 @@ function validateTopLevelShape(data: unknown): {
       errors.push("grade must be one of: 10, 11, 12");
     }
   }
+
+  errors.push(...validateOptionalPositiveIntegerField(payload, "curriculum_id"));
+  errors.push(...validateOptionalStringField(payload, "curriculum_name"));
+  errors.push(...validateOptionalStringField(payload, "curriculum_code"));
+  errors.push(...validateOptionalPositiveIntegerField(payload, "chapter_id"));
+  errors.push(...validateOptionalStringField(payload, "chapter_name"));
+  errors.push(...validateOptionalStringField(payload, "chapter_code"));
+  errors.push(...validateOptionalNonNegativeIntegerField(payload, "chapter_topic_count"));
+  errors.push(...validateOptionalPositiveIntegerField(payload, "subject_id"));
+  errors.push(...validateOptionalStringField(payload, "subject_name"));
+  errors.push(...validateOptionalPositiveIntegerField(payload, "topic_id"));
+  errors.push(...validateOptionalStringField(payload, "topic_name"));
+  errors.push(...validateOptionalStringField(payload, "topic_code"));
 
   return { errors, payload };
 }
@@ -566,6 +624,41 @@ export function validateClassroomObservationComplete(data: unknown): ValidationR
     errors.push("grade is required");
   }
 
+  if (payload.grade === "11" || payload.grade === "12") {
+    if (payload.curriculum_id === undefined) {
+      errors.push("curriculum_id is required");
+    }
+    if (payload.curriculum_name === undefined || payload.curriculum_name === "") {
+      errors.push("curriculum_name is required");
+    }
+    if (payload.chapter_id === undefined) {
+      errors.push("chapter_id is required");
+    }
+    if (payload.chapter_name === undefined || payload.chapter_name === "") {
+      errors.push("chapter_name is required");
+    }
+    if (payload.chapter_topic_count === undefined) {
+      errors.push("chapter_topic_count is required");
+    }
+    if (payload.subject_id === undefined) {
+      errors.push("subject_id is required");
+    }
+    if (payload.subject_name === undefined || payload.subject_name === "") {
+      errors.push("subject_name is required");
+    }
+    if (
+      typeof payload.chapter_topic_count === "number" &&
+      payload.chapter_topic_count > 0
+    ) {
+      if (payload.topic_id === undefined) {
+        errors.push("topic_id is required");
+      }
+      if (payload.topic_name === undefined || payload.topic_name === "") {
+        errors.push("topic_name is required");
+      }
+    }
+  }
+
   errors.push(...validateParams(payload.params, rubric, true));
 
   return { valid: errors.length === 0, errors };
@@ -618,6 +711,10 @@ export function computeInlineStats(data: unknown): {
   totalScore: number;
   maxScore: number;
   remarkCount: number;
+  curriculumName: string | null;
+  chapterName: string | null;
+  subjectName: string | null;
+  topicName: string | null;
 } | null {
   if (!isPlainObject(data) || !isPlainObject(data.params)) {
     return null;
@@ -635,5 +732,9 @@ export function computeInlineStats(data: unknown): {
     totalScore: computeTotalScore(data.params as Record<string, ParamData | undefined>),
     maxScore: CLASSROOM_OBSERVATION_RUBRIC.maxScore,
     remarkCount,
+    curriculumName: nonEmptyString(data.curriculum_name),
+    chapterName: nonEmptyString(data.chapter_name),
+    subjectName: nonEmptyString(data.subject_name),
+    topicName: nonEmptyString(data.topic_name),
   };
 }

--- a/src/lib/classroom-observation-rubric.ts
+++ b/src/lib/classroom-observation-rubric.ts
@@ -314,6 +314,30 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
   ACTION_ADDITIONAL_NOTES_KEY,
 ]);
 
+const OPTIONAL_STRING_FIELD_KEYS = [
+  "teacher_name",
+  "curriculum_name",
+  "curriculum_code",
+  "chapter_name",
+  "chapter_code",
+  "subject_name",
+  "topic_name",
+  "topic_code",
+] as const;
+
+const OPTIONAL_POSITIVE_INTEGER_FIELD_KEYS = [
+  "teacher_id",
+  "curriculum_id",
+  "chapter_id",
+  "subject_id",
+  "topic_id",
+] as const;
+
+const REQUIRED_COMPLETION_CONTEXT = {
+  integerKeys: ["curriculum_id", "chapter_id", "subject_id"] as const,
+  stringKeys: ["curriculum_name", "chapter_name", "subject_name"] as const,
+};
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -332,6 +356,13 @@ function validateOptionalStringField(
   }
 
   return typeof payload[key] === "string" ? [] : [`${label} must be a string`];
+}
+
+function validateOptionalStringFields(
+  payload: Record<string, unknown>,
+  keys: readonly string[]
+): string[] {
+  return keys.flatMap((key) => validateOptionalStringField(payload, key));
 }
 
 function validateOptionalIntegerField(
@@ -362,12 +393,30 @@ function validateOptionalPositiveIntegerField(
   return validateOptionalIntegerField(payload, key, 1, "positive integer", label);
 }
 
+function validateOptionalPositiveIntegerFields(
+  payload: Record<string, unknown>,
+  keys: readonly string[]
+): string[] {
+  return keys.flatMap((key) => validateOptionalPositiveIntegerField(payload, key));
+}
+
 function validateOptionalNonNegativeIntegerField(
   payload: Record<string, unknown>,
   key: string,
   label = key
 ): string[] {
   return validateOptionalIntegerField(payload, key, 0, "non-negative integer", label);
+}
+
+function validateOptionalGrade(payload: Record<string, unknown>): string[] {
+  if (!("grade" in payload) || payload.grade === undefined) {
+    return [];
+  }
+
+  return typeof payload.grade === "string" &&
+    (VALID_GRADES as readonly string[]).includes(payload.grade)
+    ? []
+    : ["grade must be one of: 10, 11, 12"];
 }
 
 function validateTopLevelShape(data: unknown): {
@@ -389,57 +438,16 @@ function validateTopLevelShape(data: unknown): {
     errors.push(`Unknown top-level field: ${key}`);
   }
   errors.push(...validateActionAdditionalNotes(payload));
-
-  if (
-    "observer_summary_strengths" in payload &&
-    payload.observer_summary_strengths !== undefined &&
-    typeof payload.observer_summary_strengths !== "string"
-  ) {
-    errors.push("observer_summary_strengths must be a string");
-  }
-
-  if (
-    "observer_summary_improvements" in payload &&
-    payload.observer_summary_improvements !== undefined &&
-    typeof payload.observer_summary_improvements !== "string"
-  ) {
-    errors.push("observer_summary_improvements must be a string");
-  }
-
-  if ("teacher_id" in payload && payload.teacher_id !== undefined) {
-    if (
-      typeof payload.teacher_id !== "number" ||
-      !Number.isFinite(payload.teacher_id) ||
-      payload.teacher_id <= 0 ||
-      !Number.isInteger(payload.teacher_id)
-    ) {
-      errors.push("teacher_id must be a positive integer");
-    }
-  }
-
-  errors.push(...validateOptionalStringField(payload, "teacher_name"));
-
-  if ("grade" in payload && payload.grade !== undefined) {
-    if (
-      typeof payload.grade !== "string" ||
-      !(VALID_GRADES as readonly string[]).includes(payload.grade)
-    ) {
-      errors.push("grade must be one of: 10, 11, 12");
-    }
-  }
-
-  errors.push(...validateOptionalPositiveIntegerField(payload, "curriculum_id"));
-  errors.push(...validateOptionalStringField(payload, "curriculum_name"));
-  errors.push(...validateOptionalStringField(payload, "curriculum_code"));
-  errors.push(...validateOptionalPositiveIntegerField(payload, "chapter_id"));
-  errors.push(...validateOptionalStringField(payload, "chapter_name"));
-  errors.push(...validateOptionalStringField(payload, "chapter_code"));
+  errors.push(
+    ...validateOptionalStringFields(payload, [
+      "observer_summary_strengths",
+      "observer_summary_improvements",
+      ...OPTIONAL_STRING_FIELD_KEYS,
+    ])
+  );
+  errors.push(...validateOptionalPositiveIntegerFields(payload, OPTIONAL_POSITIVE_INTEGER_FIELD_KEYS));
+  errors.push(...validateOptionalGrade(payload));
   errors.push(...validateOptionalNonNegativeIntegerField(payload, "chapter_topic_count"));
-  errors.push(...validateOptionalPositiveIntegerField(payload, "subject_id"));
-  errors.push(...validateOptionalStringField(payload, "subject_name"));
-  errors.push(...validateOptionalPositiveIntegerField(payload, "topic_id"));
-  errors.push(...validateOptionalStringField(payload, "topic_name"));
-  errors.push(...validateOptionalStringField(payload, "topic_code"));
 
   return { errors, payload };
 }
@@ -589,76 +597,98 @@ export function validateClassroomObservationSave(data: unknown): ValidationResul
   return { valid: errors.length === 0, errors };
 }
 
+function resolveRequiredRubric(
+  payload: Record<string, unknown>,
+  errors: string[]
+): RubricConfig | null {
+  const rubricVersion = payload.rubric_version;
+  if (rubricVersion === undefined) {
+    errors.push("rubric_version is required");
+    return null;
+  }
+
+  if (typeof rubricVersion !== "string") {
+    errors.push("rubric_version must be a string");
+    return null;
+  }
+
+  const rubric = getRubricConfig(rubricVersion);
+  if (!rubric) {
+    errors.push(`Unsupported classroom observation rubric_version: ${rubricVersion}`);
+    return null;
+  }
+
+  return rubric;
+}
+
+function validateRequiredField(
+  payload: Record<string, unknown>,
+  key: string,
+  isPresent: (value: unknown) => boolean
+): string[] {
+  return isPresent(payload[key]) ? [] : [`${key} is required`];
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value !== "";
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined;
+}
+
+function requiresCurriculumContext(grade: unknown): boolean {
+  return grade === "11" || grade === "12";
+}
+
+function chapterHasActiveTopics(payload: Record<string, unknown>): boolean {
+  return typeof payload.chapter_topic_count === "number" && payload.chapter_topic_count > 0;
+}
+
+function validateRequiredCurriculumContext(payload: Record<string, unknown>): string[] {
+  if (!requiresCurriculumContext(payload.grade)) {
+    return [];
+  }
+
+  const errors = [
+    ...REQUIRED_COMPLETION_CONTEXT.integerKeys.flatMap((key) =>
+      validateRequiredField(payload, key, hasValue)
+    ),
+    ...REQUIRED_COMPLETION_CONTEXT.stringKeys.flatMap((key) =>
+      validateRequiredField(payload, key, hasNonEmptyString)
+    ),
+    ...validateRequiredField(payload, "chapter_topic_count", hasValue),
+  ];
+
+  if (chapterHasActiveTopics(payload)) {
+    errors.push(...validateRequiredField(payload, "topic_id", hasValue));
+    errors.push(...validateRequiredField(payload, "topic_name", hasNonEmptyString));
+  }
+
+  return errors;
+}
+
+function validateRequiredCompletionContext(payload: Record<string, unknown>): string[] {
+  return [
+    ...validateRequiredField(payload, "teacher_id", hasValue),
+    ...validateRequiredField(payload, "teacher_name", hasNonEmptyString),
+    ...validateRequiredField(payload, "grade", hasValue),
+    ...validateRequiredCurriculumContext(payload),
+  ];
+}
+
 export function validateClassroomObservationComplete(data: unknown): ValidationResult {
   const { errors, payload } = validateTopLevelShape(data);
   if (!payload) {
     return { valid: false, errors };
   }
 
-  const rubricVersion = payload.rubric_version;
-  if (rubricVersion === undefined) {
-    errors.push("rubric_version is required");
-    return { valid: false, errors };
-  }
-
-  if (typeof rubricVersion !== "string") {
-    errors.push("rubric_version must be a string");
-    return { valid: false, errors };
-  }
-
-  const rubric = getRubricConfig(rubricVersion);
+  const rubric = resolveRequiredRubric(payload, errors);
   if (!rubric) {
-    errors.push(`Unsupported classroom observation rubric_version: ${rubricVersion}`);
     return { valid: false, errors };
   }
 
-  if (payload.teacher_id === undefined) {
-    errors.push("teacher_id is required");
-  }
-
-  if (payload.teacher_name === undefined || payload.teacher_name === "") {
-    errors.push("teacher_name is required");
-  }
-
-  if (payload.grade === undefined) {
-    errors.push("grade is required");
-  }
-
-  if (payload.grade === "11" || payload.grade === "12") {
-    if (payload.curriculum_id === undefined) {
-      errors.push("curriculum_id is required");
-    }
-    if (payload.curriculum_name === undefined || payload.curriculum_name === "") {
-      errors.push("curriculum_name is required");
-    }
-    if (payload.chapter_id === undefined) {
-      errors.push("chapter_id is required");
-    }
-    if (payload.chapter_name === undefined || payload.chapter_name === "") {
-      errors.push("chapter_name is required");
-    }
-    if (payload.chapter_topic_count === undefined) {
-      errors.push("chapter_topic_count is required");
-    }
-    if (payload.subject_id === undefined) {
-      errors.push("subject_id is required");
-    }
-    if (payload.subject_name === undefined || payload.subject_name === "") {
-      errors.push("subject_name is required");
-    }
-    if (
-      typeof payload.chapter_topic_count === "number" &&
-      payload.chapter_topic_count > 0
-    ) {
-      if (payload.topic_id === undefined) {
-        errors.push("topic_id is required");
-      }
-      if (payload.topic_name === undefined || payload.topic_name === "") {
-        errors.push("topic_name is required");
-      }
-    }
-  }
-
+  errors.push(...validateRequiredCompletionContext(payload));
   errors.push(...validateParams(payload.params, rubric, true));
 
   return { valid: errors.length === 0, errors };

--- a/src/lib/classroom-observation-rubric.ts
+++ b/src/lib/classroom-observation-rubric.ts
@@ -334,9 +334,11 @@ function validateOptionalStringField(
   return typeof payload[key] === "string" ? [] : [`${label} must be a string`];
 }
 
-function validateOptionalPositiveIntegerField(
+function validateOptionalIntegerField(
   payload: Record<string, unknown>,
   key: string,
+  minimum: number,
+  description: string,
   label = key
 ): string[] {
   if (!(key in payload) || payload[key] === undefined) {
@@ -346,10 +348,18 @@ function validateOptionalPositiveIntegerField(
   const value = payload[key];
   return typeof value === "number" &&
     Number.isFinite(value) &&
-    value > 0 &&
+    value >= minimum &&
     Number.isInteger(value)
     ? []
-    : [`${label} must be a positive integer`];
+    : [`${label} must be a ${description}`];
+}
+
+function validateOptionalPositiveIntegerField(
+  payload: Record<string, unknown>,
+  key: string,
+  label = key
+): string[] {
+  return validateOptionalIntegerField(payload, key, 1, "positive integer", label);
 }
 
 function validateOptionalNonNegativeIntegerField(
@@ -357,17 +367,7 @@ function validateOptionalNonNegativeIntegerField(
   key: string,
   label = key
 ): string[] {
-  if (!(key in payload) || payload[key] === undefined) {
-    return [];
-  }
-
-  const value = payload[key];
-  return typeof value === "number" &&
-    Number.isFinite(value) &&
-    value >= 0 &&
-    Number.isInteger(value)
-    ? []
-    : [`${label} must be a non-negative integer`];
+  return validateOptionalIntegerField(payload, key, 0, "non-negative integer", label);
 }
 
 function validateTopLevelShape(data: unknown): {

--- a/src/lib/classroom-observation-rubric.ts
+++ b/src/lib/classroom-observation-rubric.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface RubricOption {
   label: string;
@@ -39,6 +43,7 @@ export interface ClassroomObservationData {
   teacher_id?: number;
   teacher_name?: string;
   grade?: string;
+  additional_notes?: string;
 }
 
 export interface ValidationResult {
@@ -305,6 +310,7 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
   "teacher_id",
   "teacher_name",
   "grade",
+  ACTION_ADDITIONAL_NOTES_KEY,
 ]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -333,6 +339,7 @@ function validateTopLevelShape(data: unknown): {
   for (const key of unknownTopLevel) {
     errors.push(`Unknown top-level field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if (
     "observer_summary_strengths" in payload &&

--- a/src/lib/curriculum-code-sort.ts
+++ b/src/lib/curriculum-code-sort.ts
@@ -1,0 +1,15 @@
+const CURRICULUM_CODE_COLLATOR = new Intl.Collator("en", {
+  numeric: true,
+  sensitivity: "base",
+});
+
+/**
+ * Compares two curriculum codes (chapter/topic codes) with natural numeric
+ * ordering, so "2" sorts before "10". Null/empty codes sort last.
+ */
+export function compareCurriculumCodes(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return CURRICULUM_CODE_COLLATOR.compare(a, b);
+}

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -1,3 +1,4 @@
+import { compareCurriculumCodes } from "./curriculum-code-sort";
 import { query } from "./db";
 import {
   PROGRAM_IDS,
@@ -22,11 +23,6 @@ const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
   jee_advanced: 9,
   neet: 2,
 };
-const CURRICULUM_CODE_COLLATOR = new Intl.Collator("en", {
-  numeric: true,
-  sensitivity: "base",
-});
-
 interface SchoolScopeRow {
   code: string;
   region: string | null;
@@ -118,10 +114,6 @@ export function isSubjectName(value: string): value is SubjectName {
 
 export function curriculumIdForExamTrack(examTrack: ExamTrack): number {
   return EXAM_TRACK_CURRICULUM_IDS[examTrack];
-}
-
-function compareCurriculumCodes(a: string, b: string): number {
-  return CURRICULUM_CODE_COLLATOR.compare(a, b);
 }
 
 function sortByCurriculumOrder<T extends { examTrack: ExamTrack; grade: number; subject: SubjectName }>(

--- a/src/lib/group-student-discussion.ts
+++ b/src/lib/group-student-discussion.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -23,6 +27,7 @@ export interface GroupStudentDiscussionConfig {
 export interface GroupStudentDiscussionData {
   grade: number;
   questions: Record<string, { answer: boolean | null; remark?: string }>;
+  additional_notes?: string;
 }
 
 export const VALID_GRADES = [11, 12] as const;
@@ -60,7 +65,11 @@ export const GROUP_STUDENT_DISCUSSION_CONFIG: GroupStudentDiscussionConfig = {
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(["grade", "questions"]);
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "grade",
+  "questions",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   GROUP_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.map((key) => {
@@ -149,6 +158,7 @@ export function validateGroupStudentDiscussionSave(data: unknown): ValidationRes
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if ("grade" in payload && payload.grade !== undefined) {
     if (!isValidGrade(payload.grade)) {
@@ -177,6 +187,7 @@ export function validateGroupStudentDiscussionComplete(data: unknown): Validatio
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if (!isValidGrade(payload.grade)) {
     errors.push("grade is required and must be 11 or 12");

--- a/src/lib/individual-af-teacher-interaction.ts
+++ b/src/lib/individual-af-teacher-interaction.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -32,6 +36,7 @@ export interface IndividualTeacherEntry {
 
 export interface IndividualAFTeacherInteractionData {
   teachers: IndividualTeacherEntry[];
+  additional_notes?: string;
 }
 
 const sections: SectionConfig[] = [
@@ -80,7 +85,10 @@ export const INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG: IndividualAFTeacherIntera
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(["teachers"]);
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "teachers",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG.allQuestionKeys.map((key) => {
@@ -231,6 +239,7 @@ export function validateIndividualTeacherSave(data: unknown): ValidationResult {
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if ("teachers" in payload) {
     errors.push(...validateTeacherEntries(payload.teachers, false));
@@ -253,6 +262,7 @@ export function validateIndividualTeacherComplete(data: unknown): ValidationResu
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if (!("teachers" in payload) || !Array.isArray(payload.teachers) || payload.teachers.length === 0) {
     errors.push("At least one teacher must be recorded");

--- a/src/lib/individual-student-discussion.ts
+++ b/src/lib/individual-student-discussion.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -42,6 +46,7 @@ export interface IndividualStudentDiscussionEntry {
 
 export interface IndividualStudentDiscussionData {
   entries: IndividualStudentDiscussionEntry[];
+  additional_notes?: string;
 }
 
 const sections: SectionConfig[] = [
@@ -59,7 +64,10 @@ export const INDIVIDUAL_STUDENT_DISCUSSION_CONFIG: IndividualStudentDiscussionCo
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-export const ALLOWED_TOP_LEVEL_KEYS = new Set(["entries"]);
+export const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "entries",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   INDIVIDUAL_STUDENT_DISCUSSION_CONFIG.allQuestionKeys.map((key) => {
@@ -267,6 +275,7 @@ export function validateIndividualStudentDiscussionSave(data: unknown): Validati
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   const canonical = getEntriesForValidation(payload);
   errors.push(...canonical.errors);
@@ -292,6 +301,7 @@ export function validateIndividualStudentDiscussionComplete(data: unknown): Vali
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   const canonical = getEntriesForValidation(payload);
   errors.push(...canonical.errors);

--- a/src/lib/principal-interaction.test.ts
+++ b/src/lib/principal-interaction.test.ts
@@ -97,10 +97,24 @@ describe("validatePrincipalInteractionSave (lenient)", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("accepts optional action-level additional notes", () => {
+    const result = validatePrincipalInteractionSave({
+      ...buildCompletePayload(),
+      additional_notes: "Principal asked for extra monthly context",
+    });
+    expect(result.valid).toBe(true);
+  });
+
   it("rejects unknown top-level keys", () => {
     const result = validatePrincipalInteractionSave({ foo: "bar" });
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Unknown field: foo");
+  });
+
+  it("rejects non-string action-level additional notes", () => {
+    const result = validatePrincipalInteractionSave({ additional_notes: 42 });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("additional_notes must be a string");
   });
 
   it("rejects teachers top-level key (not allowed for principal interaction)", () => {
@@ -209,6 +223,14 @@ describe("validatePrincipalInteractionComplete (strict)", () => {
     const result = validatePrincipalInteractionComplete(buildCompletePayload());
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  it("accepts optional action-level additional notes when complete", () => {
+    const result = validatePrincipalInteractionComplete({
+      ...buildCompletePayload(),
+      additional_notes: "Principal asked for extra monthly context",
+    });
+    expect(result.valid).toBe(true);
   });
 
   it("ignores unknown question keys alongside requiring all known keys", () => {

--- a/src/lib/principal-interaction.ts
+++ b/src/lib/principal-interaction.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -22,6 +26,7 @@ export interface PrincipalInteractionConfig {
 
 export interface PrincipalInteractionData {
   questions: Record<string, { answer: boolean | null; remark?: string }>;
+  additional_notes?: string;
 }
 
 const sections: SectionConfig[] = [
@@ -91,7 +96,10 @@ export const PRINCIPAL_INTERACTION_CONFIG: PrincipalInteractionConfig = {
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(["questions"]);
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "questions",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   PRINCIPAL_INTERACTION_CONFIG.allQuestionKeys.map((key) => {
@@ -176,6 +184,7 @@ export function validatePrincipalInteractionSave(data: unknown): ValidationResul
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if ("questions" in payload) {
     errors.push(...validateQuestions(payload.questions, false));
@@ -198,6 +207,7 @@ export function validatePrincipalInteractionComplete(data: unknown): ValidationR
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   errors.push(...validateQuestions(payload.questions, true));
 

--- a/src/lib/school-staff-interaction.ts
+++ b/src/lib/school-staff-interaction.ts
@@ -1,4 +1,8 @@
 import type { RemarkEntry } from "./visit-summary";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 export interface ValidationResult {
   valid: boolean;
@@ -22,6 +26,7 @@ export interface SchoolStaffInteractionConfig {
 
 export interface SchoolStaffInteractionData {
   questions: Record<string, { answer: boolean | null; remark?: string }>;
+  additional_notes?: string;
 }
 
 const sections: SectionConfig[] = [
@@ -47,7 +52,10 @@ export const SCHOOL_STAFF_INTERACTION_CONFIG: SchoolStaffInteractionConfig = {
   allQuestionKeys: sections.flatMap((s) => s.questions.map((q) => q.key)),
 };
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(["questions"]);
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "questions",
+  ACTION_ADDITIONAL_NOTES_KEY,
+]);
 
 const questionKeyToLabel = new Map<string, string>(
   SCHOOL_STAFF_INTERACTION_CONFIG.allQuestionKeys.map((key) => {
@@ -132,6 +140,7 @@ export function validateSchoolStaffInteractionSave(data: unknown): ValidationRes
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   if ("questions" in payload) {
     errors.push(...validateQuestions(payload.questions, false));
@@ -154,6 +163,7 @@ export function validateSchoolStaffInteractionComplete(data: unknown): Validatio
   for (const key of unknownKeys) {
     errors.push(`Unknown field: ${key}`);
   }
+  errors.push(...validateActionAdditionalNotes(payload));
 
   errors.push(...validateQuestions(payload.questions, true));
 

--- a/src/lib/visit-actions.test.ts
+++ b/src/lib/visit-actions.test.ts
@@ -4,8 +4,11 @@ import {
   ACTION_STATUS_VALUES,
   ACTION_TYPES,
   ACTION_TYPE_VALUES,
+  OPTIONAL_ACTION_TYPE_VALUES,
+  REQUIRED_ACTION_TYPE_VALUES,
   getActionTypeLabel,
   isActionType,
+  isOptionalActionType,
   statusBadgeClass,
   type ActionType,
 } from "./visit-actions";
@@ -34,6 +37,14 @@ describe("visit-actions", () => {
     expect(getActionTypeLabel("school_staff_interaction")).toBe(
       "School Staff Interaction"
     );
+  });
+
+  it("marks school staff interaction as optional while keeping the other action types required", () => {
+    expect(OPTIONAL_ACTION_TYPE_VALUES).toEqual(["school_staff_interaction"]);
+    expect(REQUIRED_ACTION_TYPE_VALUES).toHaveLength(6);
+    expect(REQUIRED_ACTION_TYPE_VALUES).not.toContain("school_staff_interaction");
+    expect(isOptionalActionType("school_staff_interaction")).toBe(true);
+    expect(isOptionalActionType("principal_interaction")).toBe(false);
   });
 
   it("defines allowed action statuses", () => {

--- a/src/lib/visit-actions.ts
+++ b/src/lib/visit-actions.ts
@@ -11,6 +11,10 @@ export const ACTION_TYPES = {
 export type ActionType = keyof typeof ACTION_TYPES;
 
 export const ACTION_TYPE_VALUES = Object.keys(ACTION_TYPES) as ActionType[];
+export const OPTIONAL_ACTION_TYPE_VALUES: ActionType[] = ["school_staff_interaction"];
+export const REQUIRED_ACTION_TYPE_VALUES = ACTION_TYPE_VALUES.filter(
+  (actionType) => !OPTIONAL_ACTION_TYPE_VALUES.includes(actionType)
+);
 
 export const ACTION_STATUS_VALUES = ["pending", "in_progress", "completed"] as const;
 export type ActionStatus = (typeof ACTION_STATUS_VALUES)[number];
@@ -21,6 +25,10 @@ export function isActionType(value: string): value is ActionType {
 
 export function getActionTypeLabel(actionType: ActionType): string {
   return ACTION_TYPES[actionType];
+}
+
+export function isOptionalActionType(actionType: ActionType): boolean {
+  return OPTIONAL_ACTION_TYPE_VALUES.includes(actionType);
 }
 
 export function statusBadgeClass(status: string): string {

--- a/src/lib/visit-form-utils.test.ts
+++ b/src/lib/visit-form-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { isPlainObject } from "./visit-form-utils";
+import {
+  ACTION_ADDITIONAL_NOTES_KEY,
+  appendActionAdditionalNotes,
+  isPlainObject,
+  readActionAdditionalNotes,
+  validateActionAdditionalNotes,
+} from "./visit-form-utils";
 
 describe("isPlainObject", () => {
   it("returns true for plain objects", () => {
@@ -21,5 +27,28 @@ describe("isPlainObject", () => {
     expect(isPlainObject(42)).toBe(false);
     expect(isPlainObject(true)).toBe(false);
     expect(isPlainObject(undefined)).toBe(false);
+  });
+});
+
+describe("action additional notes helpers", () => {
+  it("reads and appends action-level notes", () => {
+    const target: Record<string, unknown> = {};
+
+    expect(readActionAdditionalNotes(null)).toBe("");
+    expect(readActionAdditionalNotes({ [ACTION_ADDITIONAL_NOTES_KEY]: 123 })).toBe("");
+    expect(readActionAdditionalNotes({ [ACTION_ADDITIONAL_NOTES_KEY]: "Follow up" })).toBe(
+      "Follow up"
+    );
+
+    appendActionAdditionalNotes(target, { [ACTION_ADDITIONAL_NOTES_KEY]: "Follow up" });
+    expect(target).toEqual({ [ACTION_ADDITIONAL_NOTES_KEY]: "Follow up" });
+  });
+
+  it("allows missing or string notes and rejects non-string notes", () => {
+    expect(validateActionAdditionalNotes({})).toEqual([]);
+    expect(validateActionAdditionalNotes({ [ACTION_ADDITIONAL_NOTES_KEY]: "" })).toEqual([]);
+    expect(validateActionAdditionalNotes({ [ACTION_ADDITIONAL_NOTES_KEY]: 42 })).toEqual([
+      "additional_notes must be a string",
+    ]);
   });
 });

--- a/src/lib/visit-form-utils.ts
+++ b/src/lib/visit-form-utils.ts
@@ -3,3 +3,36 @@ export function isPlainObject(
 ): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+
+export const ACTION_ADDITIONAL_NOTES_KEY = "additional_notes";
+export const ACTION_ADDITIONAL_NOTES_LABEL = "Additional Notes or Concerns";
+
+export function readActionAdditionalNotes(data: unknown): string {
+  if (!isPlainObject(data)) {
+    return "";
+  }
+
+  const value = data[ACTION_ADDITIONAL_NOTES_KEY];
+  return typeof value === "string" ? value : "";
+}
+
+export function appendActionAdditionalNotes(
+  target: Record<string, unknown>,
+  source: unknown
+): void {
+  const notes = readActionAdditionalNotes(source);
+  if (notes.length > 0) {
+    target[ACTION_ADDITIONAL_NOTES_KEY] = notes;
+  }
+}
+
+export function validateActionAdditionalNotes(
+  payload: Record<string, unknown>
+): string[] {
+  const value = payload[ACTION_ADDITIONAL_NOTES_KEY];
+  if (value !== undefined && typeof value !== "string") {
+    return [`${ACTION_ADDITIONAL_NOTES_KEY} must be a string`];
+  }
+
+  return [];
+}

--- a/src/lib/visit-summary.test.ts
+++ b/src/lib/visit-summary.test.ts
@@ -143,6 +143,7 @@ describe("summary action dispatch", () => {
   it("delegates known action types and handles unknown types gracefully", () => {
     expect(
       dispatchExtractRemarks("principal_interaction", {
+        additional_notes: "Bring district schedule next visit",
         questions: {
           oh_program_feedback: { answer: true, remark: "Principal wants monthly updates" },
         },
@@ -151,6 +152,10 @@ describe("summary action dispatch", () => {
       {
         label: "Does the Principal have any feedback or concerns on the program implementation?",
         text: "Principal wants monthly updates",
+      },
+      {
+        label: "Additional Notes or Concerns",
+        text: "Bring district schedule next visit",
       },
     ]);
 
@@ -164,6 +169,14 @@ describe("summary action dispatch", () => {
     ).toEqual({ answeredCount: 1, totalQuestions: 7 });
 
     expect(dispatchExtractRemarks("unknown_action", {})).toEqual([]);
+    expect(dispatchExtractRemarks("unknown_action", {
+      additional_notes: "Unclassified follow-up",
+    })).toEqual([
+      {
+        label: "Additional Notes or Concerns",
+        text: "Unclassified follow-up",
+      },
+    ]);
     expect(dispatchComputeInlineStats("unknown_action", {})).toBeNull();
   });
 

--- a/src/lib/visit-summary.test.ts
+++ b/src/lib/visit-summary.test.ts
@@ -64,7 +64,6 @@ describe("classifyActionCompletion", () => {
       individual_af_teacher_interaction: "completed",
       principal_interaction: "completed",
       group_student_discussion: "completed",
-      individual_student_discussion: "completed",
     }))).toBe("partial");
 
     expect(classifyActionCompletion(makeRollup({
@@ -73,7 +72,7 @@ describe("classifyActionCompletion", () => {
       individual_af_teacher_interaction: "completed",
       principal_interaction: "completed",
       group_student_discussion: "completed",
-      individual_student_discussion: "completed",
+      individual_student_discussion: "pending",
       school_staff_interaction: "pending",
     }))).toBe("all_present");
 
@@ -84,7 +83,6 @@ describe("classifyActionCompletion", () => {
       principal_interaction: "completed",
       group_student_discussion: "completed",
       individual_student_discussion: "completed",
-      school_staff_interaction: "completed",
     }))).toBe("all_complete");
   });
 });
@@ -93,8 +91,8 @@ describe("computeAverageCompletion", () => {
   it("returns null for zero visits, zero for no completions, and percentages otherwise", () => {
     expect(computeAverageCompletion(0, 0)).toBeNull();
     expect(computeAverageCompletion(0, 3)).toBe(0);
-    expect(computeAverageCompletion(7, 1)).toBe(100);
-    expect(computeAverageCompletion(7, 2)).toBe(50);
+    expect(computeAverageCompletion(6, 1)).toBe(100);
+    expect(computeAverageCompletion(6, 2)).toBe(50);
   });
 });
 

--- a/src/lib/visit-summary.ts
+++ b/src/lib/visit-summary.ts
@@ -1,4 +1,9 @@
-import { ACTION_TYPE_VALUES, isActionType, type ActionType } from "./visit-actions";
+import {
+  ACTION_TYPE_VALUES,
+  REQUIRED_ACTION_TYPE_VALUES,
+  isActionType,
+  type ActionType,
+} from "./visit-actions";
 import {
   ACTION_ADDITIONAL_NOTES_LABEL,
   readActionAdditionalNotes,
@@ -80,20 +85,20 @@ export function rollupActionTypes(
 export function classifyActionCompletion(
   rollup: Record<ActionType, ActionTypeRollupStatus>
 ): ActionCompletionBucket {
-  const touchedCount = ACTION_TYPE_VALUES.filter(
+  const touchedCount = REQUIRED_ACTION_TYPE_VALUES.filter(
     (actionType) => rollup[actionType] !== "not_started"
   ).length;
-  const completedCount = ACTION_TYPE_VALUES.filter(
+  const completedCount = REQUIRED_ACTION_TYPE_VALUES.filter(
     (actionType) => rollup[actionType] === "completed"
   ).length;
 
-  if (completedCount === ACTION_TYPE_VALUES.length) {
+  if (completedCount === REQUIRED_ACTION_TYPE_VALUES.length) {
     return "all_complete";
   }
   if (touchedCount === 0) {
     return "none";
   }
-  if (touchedCount === ACTION_TYPE_VALUES.length) {
+  if (touchedCount === REQUIRED_ACTION_TYPE_VALUES.length) {
     return "all_present";
   }
   return "partial";
@@ -102,7 +107,7 @@ export function classifyActionCompletion(
 export function computeAverageCompletion(
   completedTypeCountSum: number,
   visitCount: number,
-  knownTypeCount = ACTION_TYPE_VALUES.length
+  knownTypeCount = REQUIRED_ACTION_TYPE_VALUES.length
 ): number | null {
   if (visitCount === 0) {
     return null;

--- a/src/lib/visit-summary.ts
+++ b/src/lib/visit-summary.ts
@@ -1,5 +1,9 @@
 import { ACTION_TYPE_VALUES, isActionType, type ActionType } from "./visit-actions";
 import {
+  ACTION_ADDITIONAL_NOTES_LABEL,
+  readActionAdditionalNotes,
+} from "./visit-form-utils";
+import {
   computeInlineStats as computeAFTeamInlineStats,
   extractRemarks as extractAFTeamRemarks,
 } from "./af-team-interaction";
@@ -121,23 +125,28 @@ export function resolvePresetDateRange(
 }
 
 export function dispatchExtractRemarks(actionType: string, data: unknown): RemarkEntry[] {
+  const additionalNotes = readActionAdditionalNotes(data).trim();
+  const actionNotes = additionalNotes
+    ? [{ label: ACTION_ADDITIONAL_NOTES_LABEL, text: additionalNotes }]
+    : [];
+
   switch (actionType) {
     case "classroom_observation":
-      return extractClassroomRemarks(data);
+      return [...extractClassroomRemarks(data), ...actionNotes];
     case "af_team_interaction":
-      return extractAFTeamRemarks(data);
+      return [...extractAFTeamRemarks(data), ...actionNotes];
     case "individual_af_teacher_interaction":
-      return extractIndividualTeacherRemarks(data);
+      return [...extractIndividualTeacherRemarks(data), ...actionNotes];
     case "principal_interaction":
-      return extractPrincipalRemarks(data);
+      return [...extractPrincipalRemarks(data), ...actionNotes];
     case "group_student_discussion":
-      return extractGroupStudentRemarks(data);
+      return [...extractGroupStudentRemarks(data), ...actionNotes];
     case "individual_student_discussion":
-      return extractIndividualStudentRemarks(data);
+      return [...extractIndividualStudentRemarks(data), ...actionNotes];
     case "school_staff_interaction":
-      return extractSchoolStaffRemarks(data);
+      return [...extractSchoolStaffRemarks(data), ...actionNotes];
     default:
-      return [];
+      return actionNotes;
   }
 }
 

--- a/src/lib/visits-policy.ts
+++ b/src/lib/visits-policy.ts
@@ -32,6 +32,11 @@ export interface ScopeResolution {
   schoolRegion?: string;
 }
 
+interface SchoolRegionLookup {
+  exists: boolean;
+  schoolRegion: string | null;
+}
+
 export interface VisitScopePredicate {
   clause: string;
   params: unknown[];
@@ -45,6 +50,10 @@ type VisitsAccessResult =
 
 type JsonBodyResult =
   | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: NextResponse<ApiErrorBody> };
+
+type SchoolRegionAccessResult =
+  | { ok: true; schoolRegion: string | null }
   | { ok: false; response: NextResponse<ApiErrorBody> };
 
 function normalizeEmail(email: string): string {
@@ -85,6 +94,19 @@ export function buildVisitsActor(email: string, permission: UserPermission): Vis
   };
 }
 
+async function findSchoolRegion(schoolCode: string): Promise<SchoolRegionLookup> {
+  const schools = await query<{ region: string | null }>(
+    `SELECT region FROM school WHERE code = $1`,
+    [schoolCode]
+  );
+
+  if (schools.length === 0) {
+    return { exists: false, schoolRegion: null };
+  }
+
+  return { exists: true, schoolRegion: schools[0].region ?? null };
+}
+
 export async function requireVisitsAccess(
   session: Session | null,
   mode: AccessMode
@@ -123,19 +145,27 @@ export async function resolveSchoolRegionForScope(
     return { exists: true };
   }
 
-  const schools = await query<{ region: string | null }>(
-    `SELECT region FROM school WHERE code = $1`,
-    [schoolCode]
-  );
-
-  if (schools.length === 0) {
+  const school = await findSchoolRegion(schoolCode);
+  if (!school.exists) {
     return { exists: false };
   }
 
   return {
     exists: true,
-    schoolRegion: schools[0].region ?? undefined,
+    schoolRegion: school.schoolRegion ?? undefined,
   };
+}
+
+export async function resolveAccessibleVisitSchoolRegion(
+  actor: VisitsActor,
+  schoolCode: string
+): Promise<SchoolRegionAccessResult> {
+  const school = await findSchoolRegion(schoolCode);
+  if (!canAccessVisitSchoolScope(actor, schoolCode, school.schoolRegion)) {
+    return { ok: false, response: apiError(403, "Forbidden") };
+  }
+
+  return { ok: true, schoolRegion: school.schoolRegion };
 }
 
 export function buildVisitScopePredicate(


### PR DESCRIPTION
## Summary
- Add a shared optional `additional_notes` field for every visit action point
- Make School Staff Interaction optional for visit completion
- Add Classroom Observation curriculum/chapter/topic dropdowns for JEE Mains, NEET, and JEE Advanced
- Store selected classroom context in action data, filter archived CMS chapters/topics, and surface context on visit action cards and summary details

## Tests
- `npm run lint`
- `npm test -- --run src/lib/classroom-observation-curriculum.test.ts src/lib/classroom-observation-rubric.test.ts src/components/visits/ClassroomObservationForm.test.tsx src/app/api/pm/classroom-observation-options/route.test.ts`
- `npm test`
- Browser check on local visit #63/action #155: selected teacher/grade/curriculum/chapter/topic, saved, verified DB persistence, visit action card, and admin summary display

Refs #126