### PR TITLE
feat(centres): surface non-JNV centre-linked schools + their programs (Punjab CoE + EMRS)

### DIFF
--- a/src/app/api/students/search/route.test.ts
+++ b/src/app/api/students/search/route.test.ts
@@ -62,9 +62,13 @@ describe("GET /api/students/search", () => {
       expect.stringContaining("af_school_category = 'JNV'"),
       ["%john%", CURRENT_ACADEMIC_YEAR],
     );
+    // Visibility scope mirrors the dashboard/school-page: JNV OR active-centre-
+    // linked, so students at the non-JNV centre schools (Punjab CoE / EMRS) are
+    // searchable too — not silently filtered by a JNV-only WHERE.
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("FROM centres c WHERE c.school_id = sch.id AND c.is_active");
     // Current-cohort rule shared with the canonical roster: results are
     // restricted to students enrolled for the current academic year.
-    const sql = mockQuery.mock.calls[0][0] as string;
     expect(sql).toContain("er.academic_year = $2");
     expect(sql).not.toContain("s.grade_id");
   });
@@ -83,5 +87,8 @@ describe("GET /api/students/search", () => {
     );
     const sql = mockQuery.mock.calls[0][0] as string;
     expect(sql).toContain("er.academic_year = $3");
+    // Scoped branch carries the same JNV-OR-active-centre visibility scope, so a
+    // user seated at a centre school can search its students within their codes.
+    expect(sql).toContain("FROM centres c WHERE c.school_id = sch.id AND c.is_active");
   });
 });

--- a/src/app/api/students/search/route.ts
+++ b/src/app/api/students/search/route.ts
@@ -40,6 +40,16 @@ export async function GET(request: NextRequest) {
 
   const searchPattern = `%${searchQuery}%`;
 
+  // School visibility scope: the historical JNV set PLUS any school linked to an
+  // active centre. Mirrors the dashboard `schoolScope` / school-page predicate so
+  // the non-JNV centre schools (Punjab CoE / EMRS) those pages now surface are
+  // also searchable here — otherwise their students are silently filtered out.
+  // (One shared const across all call sites is the better home — deferred.)
+  const schoolScope = `(
+        sch.af_school_category = 'JNV'
+        OR EXISTS (SELECT 1 FROM centres c WHERE c.school_id = sch.id AND c.is_active)
+      )`;
+
   let results: StudentSearchResult[];
 
   if (schoolCodes === "all") {
@@ -69,7 +79,7 @@ export async function GET(request: NextRequest) {
         AND er.is_current = true
         AND er.academic_year = $2
       LEFT JOIN grade gr ON er.group_id = gr.id
-      WHERE sch.af_school_category = 'JNV'
+      WHERE ${schoolScope}
         AND (
           u.first_name ILIKE $1
           OR u.last_name ILIKE $1
@@ -106,7 +116,7 @@ export async function GET(request: NextRequest) {
         AND er.academic_year = $3
       LEFT JOIN grade gr ON er.group_id = gr.id
       WHERE sch.code = ANY($1)
-        AND sch.af_school_category = 'JNV'
+        AND ${schoolScope}
         AND (
           u.first_name ILIKE $2
           OR u.last_name ILIKE $2

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -60,15 +60,24 @@ async function getSchools(
       )
     )`;
 
+  // School visibility scope: the historical JNV set PLUS any school linked to an
+  // active centre. Centre-linked covers the non-JNV centre rollout (Punjab CoE
+  // meritorious / EMRS) without disturbing JNV. Centre-driven, not a category
+  // allowlist — new centre types light up by linking a centre, no code change.
+  const schoolScope = `(
+    s.af_school_category = 'JNV'
+    OR EXISTS (SELECT 1 FROM centres c WHERE c.school_id = s.id AND c.is_active)
+  )`;
+
   const baseQuery = `
     SELECT s.id, s.code, s.name, s.district, s.state, s.region
     FROM school s
-    WHERE s.af_school_category = 'JNV'${excludeDupPlaceholders}`;
+    WHERE ${schoolScope}${excludeDupPlaceholders}`;
 
   const countBaseQuery = `
     SELECT COUNT(DISTINCT s.id) as total
     FROM school s
-    WHERE s.af_school_category = 'JNV'${excludeDupPlaceholders}`;
+    WHERE ${schoolScope}${excludeDupPlaceholders}`;
 
   if (codes === "all") {
     if (searchPattern) {

--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -1162,7 +1162,10 @@ describe("SchoolPage (server component)", () => {
 
     // First query is getSchoolByCode
     const firstCall = mockQuery.mock.calls[0];
-    expect(firstCall[0]).toContain("udise_code = $1 OR code = $1");
+    expect(firstCall[0]).toContain("s.udise_code = $1 OR s.code = $1");
+    // Visible schools = JNV OR linked to an active centre (centre rollout).
+    expect(firstCall[0]).toContain("af_school_category = 'JNV'");
+    expect(firstCall[0]).toContain("FROM centres c WHERE c.school_id = s.id AND c.is_active");
     expect(firstCall[1]).toEqual(["12345678901"]);
   });
 

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -36,11 +36,17 @@ interface School {
 }
 
 async function getSchoolByCode(code: string): Promise<School | null> {
+  // Visible schools = the historical JNV set PLUS any school linked to an active
+  // centre (the non-JNV centre rollout: Punjab CoE meritorious / EMRS). Mirrors
+  // the dashboard `schoolScope` predicate so a school listed there also opens.
   const schools = await query<School>(
     `SELECT id, name, code, udise_code, district, state, region
-     FROM school
-     WHERE af_school_category = 'JNV'
-       AND (udise_code = $1 OR code = $1)`,
+     FROM school s
+     WHERE (
+         s.af_school_category = 'JNV'
+         OR EXISTS (SELECT 1 FROM centres c WHERE c.school_id = s.id AND c.is_active)
+       )
+       AND (s.udise_code = $1 OR s.code = $1)`,
     [code],
   );
   return schools[0] || null;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,13 +4,20 @@ export const CURRENT_ACADEMIC_YEAR = "2026-2027";
 
 // Program IDs. Kept here (not in permissions.ts) so client components can
 // import them without pulling in the server-only DB pool.
+// NOTE (transitional): this hand-maintained list is the known debt the centre
+// rollout is chipping away at — the long-term fix is to read `program` from the
+// DB. Until then, add a program here when a non-JNV centre is onboarded.
 export const PROGRAM_IDS = {
   COE: 1,
   NODAL: 2,
   NVS: 64,
+  // Non-JNV centre programs (centre rollout — Punjab CoE meritorious schools + EMRS).
+  PUNJAB_COE: 74,
+  PUNJAB_NODAL: 94,
+  EMRS_COE: 78,
 } as const;
 
-// Canonical display order for program IDs.
+// Canonical display order for program IDs (JNV first, then non-JNV centres).
 export const PROGRAM_IDS_ORDERED: number[] = Object.values(PROGRAM_IDS);
 
 // Maps program_ids to the BigQuery `student_program` label.
@@ -19,4 +26,7 @@ export const PROGRAM_ID_TO_LABEL: Record<number, string> = {
   [PROGRAM_IDS.COE]: "JNV CoE",
   [PROGRAM_IDS.NODAL]: "JNV Nodal",
   [PROGRAM_IDS.NVS]: "JNV NVS",
+  [PROGRAM_IDS.PUNJAB_COE]: "Punjab CoE",
+  [PROGRAM_IDS.PUNJAB_NODAL]: "Punjab Nodal",
+  [PROGRAM_IDS.EMRS_COE]: "EMRS CoE",
 };


### PR DESCRIPTION
## What

First operational rollout of the *"LMS targets centres, not just JNV schools"* arc — **visibility-first**. Makes the LMS usable for non-JNV centres that are already data-clean: the **Punjab CoE meritorious-school centres** (Bathinda, Mohali) and **EMRS Bhopal**.

## Changes (program/centre-generic, not a Punjab allowlist)
- **`dashboard/page.tsx`** & **`school/[udise]/page.tsx`** — school visibility = the historical `af_school_category='JNV'` set **OR** any school linked to an active centre. New centre types light up by linking a centre, no further code.
- **`lib/constants.ts`** — `PROGRAM_IDS` / `PROGRAM_ID_TO_LABEL` learn Punjab CoE (74), Punjab Nodal (94), EMRS CoE (78), so the per-program enrollment roster recognises + labels them.
- **No roster-query change** — the roster is program-filtered in the UI, so a centre's cohort shows under its program pill, and large non-centre programs at the same school (e.g. STP Test Series, ~250/school) are naturally excluded.

## Why this shape
The roster is keyed on `centre.school_id + program_id`; Punjab CoE cohorts were confirmed **single-school** (analyst + data), so no centre↔batch link is needed. Schema foundation (`centres.program_id`, db-service #543/#545) is already merged to prod.

## Testing
- Full unit suite green: **2376 passed, 3 skipped** (file-dependent centre-import tests).
- Verified on staging (after bringing staging centre links in line with prod): RSMS Bathinda, RSMS SAS Nagar, EMRS Bhopal all resolve visible and show their CoE/Nodal cohorts.

## Notes / follow-ups (not in this PR)
- **Mohali reads as a Nodal centre** in the data (53 Punjab Nodal, 1 CoE on prod) — confirming the intended cohort with ops.
- Deferred: feature-gating so Punjab CoE/Nodal users get visits/curriculum (the `hasCoEOrNodal` gap); curriculum config for program 74; EMRS Bhopal staff login (data/onboarding); centre cruft cleanup (duplicate Punjab/EMRS centre rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)