### PR TITLE
fix(centres): dashboard cards count the centre cohort, not the host school

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -949,6 +949,12 @@ describe("DashboardPage (server component)", () => {
     expect(sql).toContain("er.academic_year = $2");
     expect(params[0]).toEqual(["s99"]);
     expect(params[1]).toBe("2026-2027");
+    // Cohort rule: JNV schools count all members, but non-JNV centre-linked
+    // schools count only students in a batch of one of the school's active-centre
+    // programs — so the card reflects the cohort, not the whole host school.
+    expect(sql).toContain("s.af_school_category = 'JNV'");
+    expect(sql).toContain("JOIN centres c ON c.school_id = s.id AND c.is_active");
+    expect(sql).toContain("c.program_id = b.program_id");
   });
 
   it("skips grade count query when no schools found", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -144,9 +144,19 @@ async function getSchools(
   return { schools, totalCount: parseInt(countResult[0]?.total || "0", 10) };
 }
 
-// Get grade-wise student counts for loaded schools (all programs).
+// Get grade-wise student counts for the loaded school cards.
 // Scoped to the current academic year so the dashboard summary cards match
 // the school roster, which is also restricted to CURRENT_ACADEMIC_YEAR.
+//
+// Cohort rule (matches the school-page roster, which attributes each student a
+// program via their batch):
+//  - JNV schools: the school *is* the cohort — count every current-year member
+//    (historical behaviour, unchanged).
+//  - Non-JNV centre-linked schools sit inside a much larger host school (e.g.
+//    RSMS Bathinda has ~341 current-year members but only ~99 CoE+Nodal cohort),
+//    so count only students enrolled in a batch of one of the school's
+//    active-centre programs. Otherwise the card over-counts the whole host
+//    school (incl. unrelated programmes like the STP Test Series group).
 async function getSchoolGradeCounts(schoolIds: string[]): Promise<Map<string, GradeCount[]>> {
   if (schoolIds.length === 0) return new Map();
 
@@ -163,6 +173,18 @@ async function getSchoolGradeCounts(schoolIds: string[]): Promise<Map<string, Gr
        AND er.academic_year = $2
      LEFT JOIN grade gr ON er.group_id = gr.id
      WHERE s.id = ANY($1) AND gr.number IS NOT NULL
+       AND (
+         s.af_school_category = 'JNV'
+         OR EXISTS (
+           SELECT 1
+           FROM group_user gu_batch
+           JOIN "group" g_batch ON gu_batch.group_id = g_batch.id AND g_batch.type = 'batch'
+           JOIN batch b ON g_batch.child_id = b.id
+           JOIN centres c ON c.school_id = s.id AND c.is_active
+             AND c.program_id = b.program_id
+           WHERE gu_batch.user_id = gu_school.user_id
+         )
+       )
      GROUP BY s.id, gr.number
      ORDER BY gr.number`,
     [schoolIds, CURRENT_ACADEMIC_YEAR]


### PR DESCRIPTION
## What

Dashboard "My Schools" cards counted every current-year member of the **host school**, so the new non-JNV centre schools showed the whole school instead of their CoE/Nodal cohort:

- RSMS Bathinda: **341** (G11:1, G12:340)
- RSMS SAS Nagar: **304** (G12:303, G13:1)

The grade chips also leaked unrelated students (the G11:1 / G13:1 noise, plus the large "STP Test Series Punjab" group).

## Fix

`getSchoolGradeCounts` now applies the same cohort attribution the school-page roster already uses:

- **JNV schools** → count all current-year members (historical behaviour, **unchanged**).
- **Non-JNV centre-linked schools** → count only students enrolled in a batch of one of the school's **active-centre programs** (`centres.program_id`).

The card total auto-corrects (it's summed from the grade counts).

## Verified on prod (`prod_af_db`)

| School | Before | After |
|---|---|---|
| RSMS Bathinda | 341 | **99** (51 CoE + 48 Nodal) |
| RSMS SAS Nagar | 304 | **54** (53 Nodal + 1 CoE) |
| EMRS Bhopal | 70 | 70 (already exact) |
| JNV (Dantewada/Dhamtari/Sukma) | 82 / 82 / 35 | unchanged |

48/48 dashboard tests pass, incl. new assertions for the cohort rule.

> Note: RSMS Bathinda has an active cruft centre tagged program 1 (id 91, from #543's by-name backfill). It has zero program-1 students today so the count is correct, but the deferred centre-cruft cleanup (dedupe 91/92/93/34) would remove the fragility.

Follow-up to #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)