### PR TITLE
feat: generate combined student reports from the school page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,11 @@ S3_DOCS_SECRET_ACCESS_KEY=
 # must be staging or production and match the environment-bound machine token.
 HOLISTIC_PROFILE_ETL_URL=
 HOLISTIC_PROFILE_ETL_TOKEN=
+
+# =============================================================================
+# REPORTING ENGINE (combined student reports — reports-ui)
+# =============================================================================
+# Server-side only; the service key is never exposed to the browser.
+# Contract: reporting/docs/combined-reports-contract.md
+REPORTING_SERVICE_URL=
+REPORTING_SERVICE_API_KEY=

--- a/amplify.yml
+++ b/amplify.yml
@@ -41,6 +41,8 @@ frontend:
           echo "QUIZ_AF_API_KEY=$QUIZ_AF_API_KEY" >> .env.production
           echo "AF_SHORTENER_URL=$AF_SHORTENER_URL" >> .env.production
           echo "AF_SHORTENER_AUTH_TOKEN=$AF_SHORTENER_AUTH_TOKEN" >> .env.production
+          echo "REPORTING_SERVICE_URL=$REPORTING_SERVICE_URL" >> .env.production
+          echo "REPORTING_SERVICE_API_KEY=$REPORTING_SERVICE_API_KEY" >> .env.production
     build:
       commands:
         - npm run build

--- a/src/app/api/quiz-analytics/[udise]/combined-reports/[jobId]/retry/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/[jobId]/retry/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import {
+  getCombinedReportJob,
+  retryCombinedReportJob,
+  ReportingServiceError,
+} from "@/lib/reporting-service";
+
+// POST /api/quiz-analytics/[udise]/combined-reports/[jobId]/retry
+// Re-enqueue an errored job.
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ udise: string; jobId: string }> },
+) {
+  const { udise, jobId } = await params;
+  const auth = await authorizeSchoolAccess(udise);
+  if (!auth.authorized) return auth.response;
+
+  try {
+    // Confirm the job belongs to this school before retrying.
+    const existing = await getCombinedReportJob(jobId);
+    if (existing.school_code !== auth.school.code) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const job = await retryCombinedReportJob(jobId);
+    return NextResponse.json(job);
+  } catch (error) {
+    if (error instanceof ReportingServiceError) {
+      if (error.status === 404) {
+        return NextResponse.json({ error: "Job not found" }, { status: 404 });
+      }
+      if (error.status === 409) {
+        return NextResponse.json(
+          { error: "Only errored jobs can be retried" },
+          { status: 409 },
+        );
+      }
+    }
+    console.error("Combined-report retry error:", error);
+    return NextResponse.json(
+      { error: "Failed to retry job" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/quiz-analytics/[udise]/combined-reports/[jobId]/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/[jobId]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import {
+  getCombinedReportJob,
+  ReportingServiceError,
+} from "@/lib/reporting-service";
+
+// GET /api/quiz-analytics/[udise]/combined-reports/[jobId]
+// Poll a single job's status (+ presigned download_url when done).
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ udise: string; jobId: string }> },
+) {
+  const { udise, jobId } = await params;
+  const auth = await authorizeSchoolAccess(udise);
+  if (!auth.authorized) return auth.response;
+
+  try {
+    const job = await getCombinedReportJob(jobId);
+    // Defence-in-depth: a job_id is opaque, but make sure it belongs to the
+    // school the caller is authorized for.
+    if (job.school_code !== auth.school.code) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(job);
+  } catch (error) {
+    if (error instanceof ReportingServiceError && error.status === 404) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+    console.error("Combined-report status error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch job status" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import {
+  getSchoolRoster,
+  filterActiveRosterStudents,
+} from "@/lib/school-students";
+import {
+  submitCombinedReport,
+  listCombinedReportJobs,
+  ReportingServiceError,
+} from "@/lib/reporting-service";
+
+// GET /api/quiz-analytics/[udise]/combined-reports?session_id=...
+// List the combined-report jobs for this school + test (the Performance-tab view).
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ udise: string }> },
+) {
+  const { udise } = await params;
+  const auth = await authorizeSchoolAccess(udise);
+  if (!auth.authorized) return auth.response;
+
+  const sessionId = new URL(request.url).searchParams.get("session_id");
+  if (!sessionId) {
+    return NextResponse.json({ error: "session_id is required" }, { status: 400 });
+  }
+
+  try {
+    const jobs = await listCombinedReportJobs(sessionId, auth.school.code);
+    return NextResponse.json({ jobs });
+  } catch (error) {
+    if (error instanceof ReportingServiceError) {
+      console.error("Combined-report list error:", error.status, error.body);
+    } else {
+      console.error("Combined-report list error:", error);
+    }
+    return NextResponse.json(
+      { error: "Failed to list report jobs" },
+      { status: 502 },
+    );
+  }
+}
+
+// POST /api/quiz-analytics/[udise]/combined-reports
+// Body: { session_id, test_name?, grade?, program?, stream? }
+// Builds the school roster (optionally narrowed to the test's grade/program/
+// stream) and submits a combined-report job to the reporting engine.
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ udise: string }> },
+) {
+  const { udise } = await params;
+  const auth = await authorizeSchoolAccess(udise);
+  if (!auth.authorized) return auth.response;
+
+  let body: {
+    session_id?: string;
+    test_name?: string;
+    grade?: number;
+    program?: string;
+    stream?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body.session_id) {
+    return NextResponse.json({ error: "session_id is required" }, { status: 400 });
+  }
+
+  try {
+    const { students: roster } = await getSchoolRoster(auth.school.id);
+    // Narrow to the cohort the test belongs to (and drop dropouts), so the
+    // combined report matches what the teacher sees for this test.
+    const students = filterActiveRosterStudents(roster, {
+      grade: body.grade,
+      program: body.program,
+      stream: body.stream,
+    }).map((s) => ({
+      user_id: s.user_id != null ? String(s.user_id) : null,
+      student_id: s.student_id != null ? String(s.student_id) : null,
+      apaar_id: s.apaar_id != null ? String(s.apaar_id) : null,
+    }));
+
+    if (students.length === 0) {
+      return NextResponse.json(
+        { error: "No active students found for this school/cohort" },
+        { status: 400 },
+      );
+    }
+
+    const session = await getServerSession(authOptions);
+    const result = await submitCombinedReport({
+      sessionId: body.session_id,
+      testName: body.test_name ?? null,
+      school: {
+        udise,
+        code: auth.school.code,
+        name: auth.school.name,
+      },
+      students,
+      requestedBy: session?.user?.email ?? null,
+    });
+    return NextResponse.json(result, { status: 202 });
+  } catch (error) {
+    if (error instanceof ReportingServiceError) {
+      console.error("Combined-report submit error:", error.status, error.body);
+    } else {
+      console.error("Combined-report submit error:", error);
+    }
+    return NextResponse.json(
+      { error: "Failed to submit report job" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -6,6 +6,7 @@ import { Select } from "@/components/ui/Select";
 import BatchOverview from "./performance/BatchOverview";
 import TestDeepDive from "./performance/TestDeepDive";
 import CumulativeALTable from "./performance/CumulativeALTable";
+import CombinedReportPanel from "./performance/CombinedReportPanel";
 
 interface Props {
   schoolUdise: string;
@@ -463,16 +464,26 @@ export default function PerformanceTab({ schoolUdise }: Props) {
           <p className="text-sm text-text-muted">Select a grade to view performance data.</p>
         </div>
       ) : deepDiveSession ? (
-        <TestDeepDive
-          schoolUdise={schoolUdise}
-          grade={selectedGrade}
-          sessionId={deepDiveSession.sessionId}
-          testName={deepDiveSession.testName}
-          program={selectedProgram || undefined}
-          stream={selectedStream || undefined}
-          onBack={handleBack}
-          onDataLoaded={handleDeepDiveData}
-        />
+        <div className="space-y-6">
+          <CombinedReportPanel
+            schoolUdise={schoolUdise}
+            sessionId={deepDiveSession.sessionId}
+            testName={deepDiveSession.testName}
+            grade={selectedGrade}
+            program={selectedProgram || undefined}
+            stream={selectedStream || undefined}
+          />
+          <TestDeepDive
+            schoolUdise={schoolUdise}
+            grade={selectedGrade}
+            sessionId={deepDiveSession.sessionId}
+            testName={deepDiveSession.testName}
+            program={selectedProgram || undefined}
+            stream={selectedStream || undefined}
+            onBack={handleBack}
+            onDataLoaded={handleDeepDiveData}
+          />
+        </div>
       ) : testCategory === "full" && fullTestView === "cumulative" ? (
         <CumulativeALTable
           schoolUdise={schoolUdise}

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Props {
+  schoolUdise: string;
+  sessionId: string;
+  testName: string;
+  grade: number;
+  program?: string;
+  stream?: string;
+}
+
+type JobStatus = "queued" | "started" | "processing" | "done" | "errored";
+
+interface Job {
+  job_id: string;
+  status: JobStatus;
+  student_count: number | null;
+  matched_count: number | null;
+  missing_count: number | null;
+  error: string | null;
+  download_url: string | null;
+  created_at: string;
+  updated_at: string;
+  retry_count: number;
+}
+
+const ACTIVE: JobStatus[] = ["queued", "started", "processing"];
+const POLL_MS = 4000;
+
+const STATUS_STYLE: Record<JobStatus, string> = {
+  queued: "bg-bg-card-alt text-text-muted border-border",
+  started: "bg-accent/10 text-accent border-accent/30",
+  processing: "bg-accent/10 text-accent border-accent/30",
+  done: "bg-success-bg text-success border-success",
+  errored: "bg-danger-bg text-danger border-danger",
+};
+
+const STATUS_LABEL: Record<JobStatus, string> = {
+  queued: "Queued",
+  started: "Started",
+  processing: "Processing",
+  done: "Ready",
+  errored: "Failed",
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+export default function CombinedReportPanel({
+  schoolUdise,
+  sessionId,
+  testName,
+  grade,
+  program,
+  stream,
+}: Props) {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const base = `/api/quiz-analytics/${schoolUdise}/combined-reports`;
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `${base}?session_id=${encodeURIComponent(sessionId)}`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) throw new Error("Failed to load reports");
+      const data = await res.json();
+      setJobs(data.jobs ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load reports");
+    } finally {
+      setLoading(false);
+    }
+  }, [base, sessionId]);
+
+  // Initial load + reload when the selected test changes.
+  useEffect(() => {
+    setLoading(true);
+    refresh();
+  }, [refresh]);
+
+  // Poll while any job is still in flight.
+  useEffect(() => {
+    const hasActive = jobs.some((j) => ACTIVE.includes(j.status));
+    if (hasActive && !pollRef.current) {
+      pollRef.current = setInterval(refresh, POLL_MS);
+    } else if (!hasActive && pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [jobs, refresh]);
+
+  const generate = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(base, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sessionId,
+          test_name: testName || null,
+          grade,
+          program,
+          stream,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to start report");
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to start report");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const retry = async (jobId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`${base}/${jobId}/retry`, { method: "POST" });
+      if (!res.ok) throw new Error("Failed to retry");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to retry");
+    }
+  };
+
+  return (
+    <div className="bg-bg-card-alt border border-border rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h3 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+            Combined student reports
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            Generate one printable PDF of every student&apos;s report for this test.
+          </p>
+        </div>
+        <button
+          onClick={generate}
+          disabled={submitting}
+          className="px-4 py-2 min-h-[44px] text-xs md:text-sm font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent shadow-sm transition-colors hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting
+            ? "Starting…"
+            : jobs.some((j) => j.status === "done")
+              ? "Regenerate"
+              : "Generate combined report"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="p-2 bg-danger-bg border border-danger text-danger rounded text-xs">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-xs text-text-muted">Loading…</p>
+      ) : jobs.length === 0 ? (
+        <p className="text-xs text-text-muted">
+          No reports generated yet for this test.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {jobs.map((job) => (
+            <li
+              key={job.job_id}
+              className="py-2 flex items-center justify-between gap-3 flex-wrap"
+            >
+              <div className="flex items-center gap-2 flex-wrap">
+                <span
+                  className={`px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide rounded border ${STATUS_STYLE[job.status]}`}
+                >
+                  {STATUS_LABEL[job.status]}
+                </span>
+                <span className="text-xs text-text-muted">
+                  {formatTime(job.created_at)}
+                </span>
+                {job.status === "done" && job.matched_count != null && (
+                  <span className="text-xs text-text-muted">
+                    {job.matched_count} of {job.student_count} students
+                    {job.missing_count ? ` · ${job.missing_count} missing` : ""}
+                  </span>
+                )}
+                {job.status === "errored" && job.error && (
+                  <span className="text-xs text-danger">{job.error}</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {job.status === "done" && job.download_url && (
+                  <a
+                    href={job.download_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-3 py-1.5 min-h-[36px] text-xs font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent hover:opacity-90"
+                  >
+                    Download
+                  </a>
+                )}
+                {job.status === "errored" && (
+                  <button
+                    onClick={() => retry(job.job_id)}
+                    className="px-3 py-1.5 min-h-[36px] text-xs font-bold uppercase tracking-wide rounded-lg bg-bg-card-alt text-text-primary border border-border hover:border-accent/50"
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/reporting-service.ts
+++ b/src/lib/reporting-service.ts
@@ -1,0 +1,135 @@
+// Server-side client for the Reporting engine's combined-report job API.
+// Mirrors the db-service-documents.ts pattern: a shared service key in an env
+// var, never exposed to the browser. The user is authorized for the school by
+// the calling API route (authorizeSchoolAccess); reporting trusts this key.
+// Wire contract: reporting/docs/combined-reports-contract.md.
+
+export interface ReportStudentRef {
+  user_id?: string | null;
+  student_id?: string | null;
+  apaar_id?: string | null;
+}
+
+export interface SchoolRef {
+  udise?: string | null;
+  code?: string | null;
+  name?: string | null;
+}
+
+export interface CombinedReportJob {
+  job_id: string;
+  session_id: string;
+  school_code: string;
+  test_name: string | null;
+  status: "queued" | "started" | "processing" | "done" | "errored";
+  student_count: number | null;
+  matched_count: number | null;
+  missing_count: number | null;
+  error: string | null;
+  download_url: string | null;
+  created_at: string;
+  updated_at: string;
+  retry_count: number;
+}
+
+export class ReportingServiceError extends Error {
+  readonly status: number;
+  readonly body: string;
+  constructor(message: string, status: number, body: string) {
+    super(message);
+    this.name = "ReportingServiceError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function reportingUrl(): string {
+  const url = process.env.REPORTING_SERVICE_URL;
+  if (!url) throw new Error("REPORTING_SERVICE_URL is not set");
+  return url.replace(/\/$/, "");
+}
+
+function serviceKey(): string {
+  const key = process.env.REPORTING_SERVICE_API_KEY;
+  if (!key) throw new Error("REPORTING_SERVICE_API_KEY is not set");
+  return key;
+}
+
+function headers(): HeadersInit {
+  return {
+    "X-Api-Key": serviceKey(),
+    "Content-Type": "application/json",
+    accept: "application/json",
+  };
+}
+
+async function parseOrThrow(res: Response, action: string) {
+  if (!res.ok) {
+    const body = await res.text();
+    throw new ReportingServiceError(
+      `Reporting service ${action} failed (${res.status})`,
+      res.status,
+      body,
+    );
+  }
+  return res.json();
+}
+
+export async function submitCombinedReport(input: {
+  sessionId: string;
+  school: SchoolRef;
+  students: ReportStudentRef[];
+  testName?: string | null;
+  requestedBy?: string | null;
+}): Promise<{ job_id: string; status: string }> {
+  const res = await fetch(`${reportingUrl()}/reports/combined`, {
+    method: "POST",
+    headers: headers(),
+    cache: "no-store",
+    body: JSON.stringify({
+      session_id: input.sessionId,
+      school: input.school,
+      students: input.students,
+      test_name: input.testName ?? null,
+      requested_by: input.requestedBy ?? null,
+    }),
+  });
+  return parseOrThrow(res, "submit");
+}
+
+export async function getCombinedReportJob(
+  jobId: string,
+): Promise<CombinedReportJob> {
+  const res = await fetch(
+    `${reportingUrl()}/reports/combined/${encodeURIComponent(jobId)}`,
+    { method: "GET", headers: headers(), cache: "no-store" },
+  );
+  return parseOrThrow(res, "status");
+}
+
+export async function listCombinedReportJobs(
+  sessionId: string,
+  schoolCode: string,
+): Promise<CombinedReportJob[]> {
+  const url =
+    `${reportingUrl()}/reports/combined` +
+    `?session_id=${encodeURIComponent(sessionId)}` +
+    `&school_code=${encodeURIComponent(schoolCode)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: headers(),
+    cache: "no-store",
+  });
+  const data = await parseOrThrow(res, "list");
+  return data.jobs ?? [];
+}
+
+export async function retryCombinedReportJob(
+  jobId: string,
+): Promise<CombinedReportJob> {
+  const res = await fetch(
+    `${reportingUrl()}/reports/combined/${encodeURIComponent(jobId)}/retry`,
+    { method: "POST", headers: headers(), cache: "no-store" },
+  );
+  return parseOrThrow(res, "retry");
+}


### PR DESCRIPTION
## What

Adds a **Combined student reports** panel to the Performance tab (school page): a teacher/PM opens a test's deep-dive, clicks **Generate combined report**, and gets one merged PDF of every student's report for that school — watching live status and downloading when ready. Companion backend PR: avantifellows/reporting#82.

Scoped to physical-centre size (~50–60 students); bulk by-session is a separate future use case.

## How it fits

- **Auth reuse** — no new login. NextAuth already authenticates the user and `authorizeSchoolAccess(udise)` already gates the school; the server calls reporting with a service key (`X-Api-Key`, never exposed to the browser). This is why we dropped the originally-planned standalone Google-OAuth layer.
- **Roster** — submit builds the school roster from `getSchoolRoster` + `filterActiveRosterStudents` (grade/program/stream) and sends `{user_id, student_id, apaar_id}` triples; reporting 3-way-matches them against the test's `student_quiz_reports_v2` docs.
- **Routes** — `combined-reports` submit + list, `[jobId]` status + retry; each re-checks school ownership of the job.
- **UI** — `CombinedReportPanel` (status chips, polling, download, retry, "Regenerate" once a report exists), mounted above the deep-dive.

## Env (set, global on the Amplify app — all branches)
`REPORTING_SERVICE_URL` (→ `https://reports.avantifellows.org`) + `REPORTING_SERVICE_API_KEY`; surfaced to runtime via `amplify.yml`.

## Verification
Exercised end-to-end on localhost against the running reporting service + live prod data (real session `AIET-01-G12-PCM`, JNV Palghar) — generate → status → download all working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
