### PR TITLE
fix(performance): question numbering + per-subject question counts (#128 items 1 & 4)

### DIFF
--- a/src/components/performance/ChapterAnalysisSection.test.tsx
+++ b/src/components/performance/ChapterAnalysisSection.test.tsx
@@ -32,7 +32,8 @@ const QUESTIONS: TestQuestionLevelRow[] = [
     chapter_name: "Kinematics",
     chapter_id: "chap-kin",
     question_id: "q1",
-    position_index: 1,
+    // position_index is the 0-based source index; it renders as Q{index + 1}.
+    position_index: 0,
     total_students: 10,
     attempted: 8,
     correct: 6,
@@ -46,7 +47,7 @@ const QUESTIONS: TestQuestionLevelRow[] = [
     chapter_name: "Kinematics",
     chapter_id: "chap-kin",
     question_id: "q2",
-    position_index: 2,
+    position_index: 1,
     total_students: 10,
     attempted: 5,
     correct: 1,
@@ -60,7 +61,7 @@ const QUESTIONS: TestQuestionLevelRow[] = [
     chapter_name: "Dynamics",
     chapter_id: "chap-dyn",
     question_id: "q3",
-    position_index: 3,
+    position_index: 2,
     total_students: 10,
     attempted: 9,
     correct: 8,
@@ -210,7 +211,7 @@ describe("ChapterAnalysisSection", () => {
         chapter_name: "Periodic Table",
         chapter_id: "chap-periodic",
         question_id: "qX",
-        position_index: 7,
+        position_index: 6,
         total_students: 24,
         attempted: 9,
         correct: 0,
@@ -238,6 +239,47 @@ describe("ChapterAnalysisSection", () => {
     expect(
       screen.queryByText("No question-level data for this chapter.")
     ).not.toBeInTheDocument();
+  });
+
+  it("displays a 0-based position_index as a 1-based question number (Q0 -> Q1)", async () => {
+    const zeroIndexed: TestQuestionLevelRow[] = [
+      { ...QUESTIONS[0], question_id: "qZero", position_index: 0 },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ questions: zeroIndexed }),
+        })
+      )
+    );
+    render(<ChapterAnalysisSection {...defaultProps} />);
+    fireEvent.click(screen.getByText("Kinematics"));
+    // The off-by-one fix: index 0 must render as "Q1", never "Q0".
+    await screen.findByText("Q1");
+    expect(screen.queryByText("Q0")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the 1-based row position when position_index is null", async () => {
+    const nullIndexed: TestQuestionLevelRow[] = [
+      { ...QUESTIONS[0], question_id: "qNull", position_index: null },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ questions: nullIndexed }),
+        })
+      )
+    );
+    render(<ChapterAnalysisSection {...defaultProps} />);
+    fireEvent.click(screen.getByText("Kinematics"));
+    // Single question, row index 0 -> idx + 1 -> "Q1".
+    await screen.findByText("Q1");
   });
 
   it("renders 'No chapter-level data' when chapters array is empty", () => {

--- a/src/components/performance/ChapterAnalysisSection.tsx
+++ b/src/components/performance/ChapterAnalysisSection.tsx
@@ -288,7 +288,7 @@ function QuestionBreakdown({
           {questions.map((q, idx) => (
             <tr key={q.question_id} className="border-b border-border/15">
               <td className="px-3 py-2 text-sm font-mono text-text-primary">
-                Q{q.position_index ?? idx + 1}
+                Q{q.position_index == null ? idx + 1 : q.position_index + 1}
               </td>
               <td className="px-3 py-2 text-sm font-mono text-text-primary">{q.attempt_rate}%</td>
               <td className="px-3 py-2 text-sm font-mono text-text-primary">{q.accuracy}%</td>

--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -449,6 +449,44 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
       });
     });
 
+    it("derives per-subject total_questions + attempt_rate from chapters, not subject_performance's test-wide totals (#128 item 4)", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([
+        makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1" }),
+      ]);
+      mocks.mockSend.mockResolvedValueOnce({
+        Items: [
+          makeV2Doc({
+            student_id: "s1",
+            user_id: "u1",
+            // subject_performance stamps the WHOLE-TEST totals onto every
+            // subject row (75 questions, 25 skipped) — the bug being fixed.
+            subject_performance: [
+              { subject: "Physics", percentage: 50, accuracy: 60, total_questions: 75, num_skipped: 25 },
+              { subject: "Chemistry", percentage: 40, accuracy: 50, total_questions: 75, num_skipped: 25 },
+            ],
+            // chapter_performance carries the true per-chapter counts.
+            chapter_performance: [
+              { chapter_name: "Kinematics", chapter_id: "c-kin", subject: "Physics", marks_scored: 4, max_marks_possible: 4, accuracy: 100, total_questions: 20, num_correct: 15, num_wrong: 0, num_skipped: 5 },
+              { chapter_name: "Optics", chapter_id: "c-opt", subject: "Physics", marks_scored: 0, max_marks_possible: 4, accuracy: 0, total_questions: 5, num_correct: 0, num_wrong: 0, num_skipped: 5 },
+              { chapter_name: "Mole Concept", chapter_id: "c-mole", subject: "Chemistry", marks_scored: 4, max_marks_possible: 4, accuracy: 100, total_questions: 25, num_correct: 25, num_wrong: 0, num_skipped: 0 },
+            ],
+          }),
+        ],
+      });
+
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo("school-1", "JNV Test", 10, "sess-1");
+      const phys = result!.subjects.find((s) => s.subject === "Physics")!;
+      const chem = result!.subjects.find((s) => s.subject === "Chemistry")!;
+      // 20 + 5 = 25 per subject, NOT the test-wide 75.
+      expect(phys.total_questions).toBe(25);
+      expect(chem.total_questions).toBe(25);
+      // Physics attempt rate = (25 - 10 skipped) / 25 = 60%, not the
+      // test-wide (75 - 25) / 75 = 66.7% that every subject would have shared.
+      expect(phys.avg_attempt_rate).toBe(60);
+      expect(chem.avg_attempt_rate).toBe(100);
+    });
+
     it("groups chapter aggregates by chapter_id and surfaces it on the result", async () => {
       mocks.mockQuery.mockResolvedValueOnce([
         makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1" }),

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -313,8 +313,13 @@ export async function getTestDeepDiveFromDynamo(
       const sectionDisplay = si.subject || "";
       const sectionKey = sectionDisplay.toLowerCase();
 
-      const total = toNum(si.total_questions);
-      const skipped = toNum(si.num_skipped);
+      // subject_performance stamps TEST-WIDE totals onto every subject row
+      // (e.g. total_questions=75 and num_skipped=25 repeated across all three
+      // subjects of a 75-question JEE test), so the per-subject question count
+      // and attempt rate must be derived from this subject's chapters instead.
+      const subjectChapters = chaptersBySubject.get(sectionKey) || [];
+      const total = subjectChapters.reduce((sum, c) => sum + toNum(c.total_questions), 0);
+      const skipped = subjectChapters.reduce((sum, c) => sum + toNum(c.num_skipped), 0);
       const attemptRate = total > 0 ? ((total - skipped) / total) * 100 : 0;
 
       // Subject analysis aggregates across the class.
@@ -334,7 +339,6 @@ export async function getTestDeepDiveFromDynamo(
       subjectAggMap.set(sectionKey, existing);
 
       // Per-student chapter rows for this subject.
-      const subjectChapters = chaptersBySubject.get(sectionKey) || [];
       const chapters: StudentChapterScore[] = subjectChapters.map((c) => {
         const chTotal = toNum(c.total_questions);
         const chMax = toNum(c.max_marks_possible);


### PR DESCRIPTION
Addresses two of the four items in #128 (Updates requested in Performance). Items #2 (chapter priority tag) and #3 (student question-level drill-down) are tracked separately — #2 is blocked on an etl-next prod `--full-refresh`.

## Item #1 — question numbering off-by-one
Question-level reports rendered the first question as `Q0`. `question_position_index` is **0-based** in BigQuery (verified against prod), so the display now uses `position_index + 1`, keeping the row-position fallback when the index is null.

## Item #4 — subject-level question count (75 → 25)
The Subject Analysis table showed **75 questions per subject** (should be 25 for JEE; 45/45/90 for NEET). Verified against a real prod DynamoDB record that `subject_performance` **stamps the whole-test totals onto every subject row** (`total_questions=75` and `num_skipped=25` identical across Physics/Chemistry/Maths). `chapter_performance` is correct per-chapter and sums to exactly 25 per subject (cross-checked against BigQuery's distinct-question-per-subject count).

Fix: derive each subject's `total_questions`, `num_skipped`, and attempt rate from its `chapter_performance` sums. This also corrects the per-subject **attempt rate**, which was computed off the inflated total and was identical across subjects (`(75−25)/75 = 66.7%`). Percentage/accuracy still read from `subject_performance` (genuinely per-subject).

## Tests
- `ChapterAnalysisSection.test.tsx`: fixtures moved to 0-based `position_index`; added explicit `Q0→Q1` and null-fallback tests.
- `dynamodb.test.ts`: added a regression test asserting chapter-derived per-subject `total_questions=25` (not 75) and per-subject attempt rates (60%/100%, not the shared 66.7%).
- Full unit suite green (2410 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)