### PR TITLE
feat(performance): student question-level drill-down (#128 item 3)

### DIFF
--- a/src/app/api/quiz-analytics/[udise]/student-questions/route.test.ts
+++ b/src/app/api/quiz-analytics/[udise]/student-questions/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeSchoolAccess: vi.fn(),
+}));
+vi.mock("@/lib/bigquery", () => ({
+  getStudentQuestionLevelData: vi.fn(),
+}));
+
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import { getStudentQuestionLevelData } from "@/lib/bigquery";
+import { GET } from "./route";
+import { routeParams } from "../../../__test-utils__/api-test-helpers";
+
+const mockAuth = vi.mocked(authorizeSchoolAccess);
+const mockGet = vi.mocked(getStudentQuestionLevelData);
+
+const SCHOOL = { id: "1", code: "70705", name: "Test School", region: "North" };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("GET /api/quiz-analytics/[udise]/student-questions", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+
+    const res = await GET(
+      new Request("http://localhost/api/quiz-analytics/1234/student-questions?grade=12&sessionId=s1"),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when grade is missing", async () => {
+    mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+
+    const res = await GET(
+      new Request("http://localhost/api/quiz-analytics/1234/student-questions?sessionId=s1"),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when sessionId is missing", async () => {
+    mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+
+    const res = await GET(
+      new Request("http://localhost/api/quiz-analytics/1234/student-questions?grade=12"),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when grade is not an integer", async () => {
+    mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+
+    const res = await GET(
+      new Request("http://localhost/api/quiz-analytics/1234/student-questions?grade=abc&sessionId=s1"),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns questions on success and passes program + lowercased stream", async () => {
+    mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+    mockGet.mockResolvedValue([
+      {
+        enrollment_user_id: "368592",
+        chapter_id: "c-kin",
+        chapter_name: "Kinematics",
+        question_id: "q1",
+        position_index: 0,
+        status: "correct",
+      },
+    ]);
+
+    const res = await GET(
+      new Request(
+        "http://localhost/api/quiz-analytics/1234/student-questions?grade=12&sessionId=s1&program=JNV+CoE&stream=PCM"
+      ),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.questions).toHaveLength(1);
+    expect(body.questions[0].status).toBe("correct");
+    expect(mockGet).toHaveBeenCalledWith("1234", 12, "s1", "JNV CoE", "pcm");
+  });
+
+  it("returns 500 when the helper throws", async () => {
+    mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+    mockGet.mockRejectedValue(new Error("BQ outage"));
+
+    const res = await GET(
+      new Request("http://localhost/api/quiz-analytics/1234/student-questions?grade=12&sessionId=s1"),
+      routeParams({ udise: "1234" })
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/quiz-analytics/[udise]/student-questions/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/student-questions/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import { getStudentQuestionLevelData } from "@/lib/bigquery";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ udise: string }> }
+) {
+  const { udise } = await params;
+  const auth = await authorizeSchoolAccess(udise);
+  if (!auth.authorized) return auth.response;
+
+  const url = new URL(request.url);
+  const gradeParam = url.searchParams.get("grade");
+  const sessionId = url.searchParams.get("sessionId");
+
+  if (!gradeParam || !sessionId) {
+    return NextResponse.json(
+      { error: "grade and sessionId are required" },
+      { status: 400 }
+    );
+  }
+  const grade = Number(gradeParam);
+  if (!Number.isInteger(grade)) {
+    return NextResponse.json({ error: "grade must be an integer" }, { status: 400 });
+  }
+
+  try {
+    const program = url.searchParams.get("program") || undefined;
+    const stream = url.searchParams.get("stream")?.toLowerCase() || undefined;
+    const questions = await getStudentQuestionLevelData(
+      udise,
+      grade,
+      sessionId,
+      program,
+      stream
+    );
+    return NextResponse.json({ questions });
+  } catch (error) {
+    console.error("Student questions error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch student question-level data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/performance/StudentResultsTable.test.tsx
+++ b/src/components/performance/StudentResultsTable.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import StudentResultsTable from "./StudentResultsTable";
+import type { StudentDeepDiveRow, StudentQuestionRow } from "@/types/quiz";
+
+const STUDENTS: StudentDeepDiveRow[] = [
+  {
+    student_name: "Asha Rao",
+    enrollment_user_id: "368592",
+    gender: "F",
+    marks_scored: 40,
+    max_marks: 100,
+    percentage: 40,
+    accuracy: 50,
+    attempt_rate: 60,
+    subject_scores: [
+      {
+        subject: "Physics",
+        percentage: 40,
+        marks_scored: 10,
+        max_marks: 25,
+        accuracy: 50,
+        attempt_rate: 60,
+        chapters: [
+          {
+            subject: "Physics",
+            chapter_name: "Kinematics",
+            chapter_id: "c-kin",
+            marks_scored: 4,
+            max_marks: 8,
+            accuracy: 50,
+            attempt_rate: 100,
+            total_questions: 2,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const QUESTIONS: StudentQuestionRow[] = [
+  { enrollment_user_id: "368592", chapter_id: "c-kin", chapter_name: "Kinematics", question_id: "q1", position_index: 0, status: "correct" },
+  { enrollment_user_id: "368592", chapter_id: "c-kin", chapter_name: "Kinematics", question_id: "q2", position_index: 1, status: "skipped" },
+];
+
+const props = {
+  students: STUDENTS,
+  schoolUdise: "1234",
+  grade: 12,
+  sessionId: "sess-1",
+};
+
+function mockFetchOk(questions: StudentQuestionRow[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ questions }),
+      })
+    )
+  );
+}
+
+beforeEach(() => {
+  mockFetchOk(QUESTIONS);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("StudentResultsTable", () => {
+  it("renders student rows without fetching question detail upfront", () => {
+    render(<StudentResultsTable {...props} />);
+    expect(screen.getByText("Asha Rao")).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches question detail once on first student expand and drills down to question level (0-based index -> Q1)", async () => {
+    render(<StudentResultsTable {...props} />);
+
+    // Expand the student -> triggers the one-time fetch.
+    fireEvent.click(screen.getByText("Asha Rao"));
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain("/api/quiz-analytics/1234/student-questions");
+    expect(url).toContain("grade=12");
+    expect(url).toContain("sessionId=sess-1");
+
+    // Drill: subject -> chapter -> questions.
+    fireEvent.click(screen.getByText("Physics"));
+    fireEvent.click(await screen.findByText("Kinematics"));
+
+    // position_index 0 renders as Q1 (off-by-one fix), 1 -> Q2.
+    await screen.findByText("Q1");
+    expect(screen.getByText("Q2")).toBeInTheDocument();
+    expect(screen.getByText("Correct")).toBeInTheDocument();
+    expect(screen.getByText("Skipped")).toBeInTheDocument();
+  });
+
+  it("does not re-fetch when the student is collapsed and re-expanded", async () => {
+    render(<StudentResultsTable {...props} />);
+
+    fireEvent.click(screen.getByText("Asha Rao"));
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText("Asha Rao")); // collapse
+    fireEvent.click(screen.getByText("Asha Rao")); // re-expand
+
+    // Still only the single initial fetch — data is cached.
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error banner when the question fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: "BQ outage" }),
+        })
+      )
+    );
+    render(<StudentResultsTable {...props} />);
+    fireEvent.click(screen.getByText("Asha Rao"));
+    await screen.findByText(/BQ outage/);
+  });
+});

--- a/src/components/performance/StudentResultsTable.tsx
+++ b/src/components/performance/StudentResultsTable.tsx
@@ -1,17 +1,139 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Card } from "@/components/ui/Card";
-import type { StudentDeepDiveRow, StudentSubjectScore } from "@/types/quiz";
+import type {
+  StudentDeepDiveRow,
+  StudentSubjectScore,
+  StudentChapterScore,
+  StudentQuestionRow,
+} from "@/types/quiz";
 
 interface Props {
   students: StudentDeepDiveRow[];
+  schoolUdise: string;
+  grade: number;
+  sessionId: string;
+  program?: string;
+  stream?: string;
 }
 
 type SortKey = "percentage" | "accuracy" | "attempt_rate" | "student_name" | "marks_scored";
 type SortDir = "asc" | "desc";
+type QStatus = "idle" | "loading" | "loaded" | "error";
 
-function SubjectWithChapters({ ss }: { ss: StudentSubjectScore }) {
+const STATUS_LABEL: Record<StudentQuestionRow["status"], string> = {
+  correct: "Correct",
+  wrong: "Wrong",
+  skipped: "Skipped",
+};
+const STATUS_CLASS: Record<StudentQuestionRow["status"], string> = {
+  correct: "text-accent",
+  wrong: "text-danger",
+  skipped: "text-text-muted",
+};
+
+// The questions for a single (student, chapter): match on chapter_id when the
+// v2 chapter row carries one, else fall back to a case-insensitive chapter_name
+// match (BQ names can lack the "11C3 - " code prefix the v2 row has).
+function questionsForChapter(
+  ch: StudentChapterScore,
+  studentQuestions: StudentQuestionRow[]
+): StudentQuestionRow[] {
+  const byId = ch.chapter_id
+    ? studentQuestions.filter((q) => q.chapter_id === ch.chapter_id)
+    : [];
+  if (byId.length > 0) return byId;
+  const chName = ch.chapter_name.toLowerCase();
+  return studentQuestions.filter((q) => {
+    const qName = q.chapter_name.toLowerCase();
+    return qName === chName || chName.endsWith(qName) || qName.endsWith(chName);
+  });
+}
+
+function ChapterRow({
+  ch,
+  studentQuestions,
+  qStatus,
+}: {
+  ch: StudentChapterScore;
+  studentQuestions: StudentQuestionRow[] | undefined;
+  qStatus: QStatus;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  // Drill-down to questions is only meaningful once the fetch has data.
+  const canDrill = qStatus === "loaded";
+  const questions = useMemo(
+    () =>
+      canDrill && studentQuestions
+        ? questionsForChapter(ch, studentQuestions).sort(
+            (a, b) => (a.position_index ?? 0) - (b.position_index ?? 0)
+          )
+        : [],
+    [canDrill, studentQuestions, ch]
+  );
+  const showCaret = canDrill && questions.length > 0;
+
+  return (
+    <>
+      <tr
+        className={`bg-bg-card-alt border-b border-border/25 ${showCaret ? "cursor-pointer hover:bg-hover-bg" : ""}`}
+        onClick={() => showCaret && setExpanded(!expanded)}
+      >
+        <td className="px-3 py-1 text-[11px] pl-8 text-text-secondary">
+          {ch.chapter_name}
+          {showCaret && (
+            <span className="ml-1 text-[10px] text-text-muted">
+              {expanded ? "▼" : "▶"}
+            </span>
+          )}
+          {qStatus === "loading" && (
+            <span className="ml-1 text-[10px] text-text-muted">loading…</span>
+          )}
+        </td>
+        <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
+          {ch.marks_scored}/{ch.max_marks}
+        </td>
+        <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
+          {ch.max_marks > 0
+            ? Math.round((ch.marks_scored / ch.max_marks) * 1000) / 10
+            : 0}
+          %
+        </td>
+        <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
+          {Math.round(ch.accuracy * 10) / 10}%
+        </td>
+        <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
+          {Math.round(ch.attempt_rate * 10) / 10}%
+        </td>
+      </tr>
+      {expanded &&
+        questions.map((q) => (
+          <tr key={q.question_id} className="bg-bg border-b border-border/15">
+            <td className="px-3 py-1 text-[11px] pl-12 font-mono text-text-secondary">
+              Q{q.position_index == null ? "?" : q.position_index + 1}
+            </td>
+            <td
+              className={`px-3 py-1 text-[11px] font-semibold ${STATUS_CLASS[q.status]}`}
+              colSpan={4}
+            >
+              {STATUS_LABEL[q.status]}
+            </td>
+          </tr>
+        ))}
+    </>
+  );
+}
+
+function SubjectWithChapters({
+  ss,
+  studentQuestions,
+  qStatus,
+}: {
+  ss: StudentSubjectScore;
+  studentQuestions: StudentQuestionRow[] | undefined;
+  qStatus: QStatus;
+}) {
   const [expanded, setExpanded] = useState(false);
   const hasChapters = ss.chapters && ss.chapters.length > 0;
 
@@ -44,29 +166,12 @@ function SubjectWithChapters({ ss }: { ss: StudentSubjectScore }) {
       </tr>
       {expanded &&
         ss.chapters!.map((ch) => (
-          <tr
-            key={`${ss.subject}-${ch.chapter_name}`}
-            className="bg-bg-card-alt border-b border-border/25"
-          >
-            <td className="px-3 py-1 text-[11px] pl-8 text-text-secondary">
-              {ch.chapter_name}
-            </td>
-            <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
-              {ch.marks_scored}/{ch.max_marks}
-            </td>
-            <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
-              {ch.max_marks > 0
-                ? Math.round((ch.marks_scored / ch.max_marks) * 1000) / 10
-                : 0}
-              %
-            </td>
-            <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
-              {Math.round(ch.accuracy * 10) / 10}%
-            </td>
-            <td className="px-3 py-1 text-[11px] font-mono text-text-secondary">
-              {Math.round(ch.attempt_rate * 10) / 10}%
-            </td>
-          </tr>
+          <ChapterRow
+            key={`${ss.subject}-${ch.chapter_id ?? ch.chapter_name}`}
+            ch={ch}
+            studentQuestions={studentQuestions}
+            qStatus={qStatus}
+          />
         ))}
     </>
   );
@@ -75,10 +180,59 @@ function SubjectWithChapters({ ss }: { ss: StudentSubjectScore }) {
 const TH = "px-4 py-3 text-left text-xs uppercase tracking-wider font-bold bg-bg-card-alt text-text-muted";
 const SORTABLE_TH = `${TH} cursor-pointer hover:text-text-primary`;
 
-export default function StudentResultsTable({ students }: Props) {
+export default function StudentResultsTable({
+  students,
+  schoolUdise,
+  grade,
+  sessionId,
+  program,
+  stream,
+}: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("percentage");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [expandedName, setExpandedName] = useState<string | null>(null);
+
+  // Per-student question rows for the whole test, fetched once on first
+  // drill-in (the table is clustered such that one all-students query is far
+  // cheaper than one query per student), then filtered client-side.
+  const [qStatus, setQStatus] = useState<QStatus>("idle");
+  const [allQuestions, setAllQuestions] = useState<StudentQuestionRow[]>([]);
+  const [qError, setQError] = useState<string | null>(null);
+
+  const fetchQuestions = () => {
+    if (qStatus !== "idle") return;
+    setQStatus("loading");
+    const programParam = program ? `&program=${encodeURIComponent(program)}` : "";
+    const streamParam = stream ? `&stream=${encodeURIComponent(stream)}` : "";
+    fetch(
+      `/api/quiz-analytics/${schoolUdise}/student-questions?grade=${grade}&sessionId=${encodeURIComponent(sessionId)}${programParam}${streamParam}`
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.error || "Failed to fetch question detail");
+        }
+        return res.json();
+      })
+      .then((d: { questions: StudentQuestionRow[] }) => {
+        setAllQuestions(d.questions || []);
+        setQStatus("loaded");
+      })
+      .catch((err) => {
+        setQError(err.message);
+        setQStatus("error");
+      });
+  };
+
+  const questionsByStudent = useMemo(() => {
+    const map = new Map<string, StudentQuestionRow[]>();
+    for (const q of allQuestions) {
+      const list = map.get(q.enrollment_user_id) || [];
+      list.push(q);
+      map.set(q.enrollment_user_id, list);
+    }
+    return map;
+  }, [allQuestions]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -102,6 +256,13 @@ export default function StudentResultsTable({ students }: Props) {
     return sortDir === "asc" ? " ↑" : " ↓";
   };
 
+  const toggleStudent = (name: string) => {
+    const next = expandedName === name ? null : name;
+    setExpandedName(next);
+    // First drill-in triggers the one-time question fetch.
+    if (next) fetchQuestions();
+  };
+
   return (
     <Card elevation="sm" className="overflow-hidden">
       <div className="px-4 md:px-6 py-3 md:py-4 flex items-center justify-between border-b-2 border-border-accent">
@@ -112,6 +273,12 @@ export default function StudentResultsTable({ students }: Props) {
           {students.length} students
         </span>
       </div>
+
+      {qStatus === "error" && qError && (
+        <div className="px-4 md:px-6 py-2 text-xs text-danger bg-danger-bg border-b border-danger">
+          Couldn&apos;t load question detail: {qError}
+        </div>
+      )}
 
       <div className="overflow-x-auto">
         <table className="w-full">
@@ -143,7 +310,7 @@ export default function StudentResultsTable({ students }: Props) {
                 <Fragment key={s.student_name}>
                   <tr
                     className="border-b border-border/25 cursor-pointer transition-colors hover:bg-hover-bg"
-                    onClick={() => setExpandedName(isExpanded ? null : s.student_name)}
+                    onClick={() => toggleStudent(s.student_name)}
                   >
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-bold text-accent">
                       {String(idx + 1).padStart(2, "0")}
@@ -198,7 +365,16 @@ export default function StudentResultsTable({ students }: Props) {
                             </thead>
                             <tbody>
                               {s.subject_scores.map((ss) => (
-                                <SubjectWithChapters key={ss.subject} ss={ss} />
+                                <SubjectWithChapters
+                                  key={ss.subject}
+                                  ss={ss}
+                                  studentQuestions={
+                                    s.enrollment_user_id
+                                      ? questionsByStudent.get(s.enrollment_user_id)
+                                      : undefined
+                                  }
+                                  qStatus={qStatus}
+                                />
                               ))}
                             </tbody>
                           </table>

--- a/src/components/performance/TestDeepDive.tsx
+++ b/src/components/performance/TestDeepDive.tsx
@@ -112,7 +112,14 @@ export default function TestDeepDive({
             program={program}
             stream={stream}
           />
-          <StudentResultsTable students={data.students} />
+          <StudentResultsTable
+            students={data.students}
+            schoolUdise={schoolUdise}
+            grade={grade}
+            sessionId={sessionId}
+            program={program}
+            stream={stream}
+          />
         </>
       )}
     </div>

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -369,6 +369,64 @@ describe("getTestQuestionLevelData", () => {
   });
 });
 
+describe("getStudentQuestionLevelData", () => {
+  it("maps is_answered/is_correct to correct/wrong/skipped status", async () => {
+    const rows = [
+      // answered + correct -> correct
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q1", position_index: 0, is_answered: 1, is_correct: 1 },
+      // answered + incorrect -> wrong
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q2", position_index: 1, is_answered: 1, is_correct: 0 },
+      // not answered -> skipped (is_correct irrelevant)
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Optics", chapter_id: "c-opt", question_id: "q3", position_index: 2, is_answered: 0, is_correct: 0 },
+    ];
+    mocks.mockQueryFn.mockResolvedValueOnce([rows]);
+
+    const { getStudentQuestionLevelData } = await import("./bigquery");
+    const result = await getStudentQuestionLevelData("11223344", 12, "sess-1");
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      enrollment_user_id: "368592", // stringified for client-side matching
+      chapter_id: "c-kin",
+      question_id: "q1",
+      position_index: 0,
+      status: "correct",
+    });
+    expect(result[1].status).toBe("wrong");
+    expect(result[2].status).toBe("skipped");
+  });
+
+  it("groups by enrollment_user_id and binds filter params", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]);
+
+    const { getStudentQuestionLevelData } = await import("./bigquery");
+    await getStudentQuestionLevelData("11223344", 12, "sess-1", "JNV", "pcm");
+
+    const call = mocks.mockQueryFn.mock.calls[0][0];
+    expect(call.query).toContain("fact_student_test_results_question_level");
+    expect(call.query).toContain("GROUP BY enrollment_user_id");
+    expect(call.query).toContain("enrollment_user_id IS NOT NULL");
+    expect(call.query).toContain("student_program = @program");
+    expect(call.query).toContain("LOWER(student_stream) = @stream");
+    expect(call.params).toMatchObject({
+      udise: "11223344",
+      grade: 12,
+      sessionId: "sess-1",
+      program: "JNV",
+      stream: "pcm",
+    });
+  });
+
+  it("propagates BQ errors to the caller", async () => {
+    mocks.mockQueryFn.mockRejectedValueOnce(new Error("BQ down"));
+
+    const { getStudentQuestionLevelData } = await import("./bigquery");
+    await expect(
+      getStudentQuestionLevelData("11223344", 12, "sess-1")
+    ).rejects.toThrow("BQ down");
+  });
+});
+
 describe("canonicalStream / streamDisplayLabel", () => {
   it("lowercases and trims stream values", async () => {
     const { canonicalStream } = await import("./bigquery");

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -6,6 +6,7 @@ import type {
   ProgressionTest,
   ProgressionEntry,
   TestQuestionLevelRow,
+  StudentQuestionRow,
 } from "@/types/quiz";
 import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
 
@@ -517,6 +518,90 @@ export async function getTestQuestionLevelData(
       attempt_rate: total > 0 ? Math.round((attempted / total) * 100) : 0,
       accuracy:
         attempted > 0 ? Math.round((correct / attempted) * 100) : 0,
+    };
+  });
+}
+
+/**
+ * Per-(student, question) results for a single test — the grain behind the
+ * Student Results → chapter → question drill-down. Returns ALL students in one
+ * query (the table is clustered by session_id/enrollment_user_id, but a
+ * single-student scan costs ~the same as the whole-session scan, so one
+ * all-students query is far cheaper than one query per drilled-in student).
+ * The caller fetches this once on first drill-in and filters client-side.
+ */
+export async function getStudentQuestionLevelData(
+  udise: string,
+  grade: number,
+  sessionId: string,
+  program?: string,
+  stream?: string
+): Promise<StudentQuestionRow[]> {
+  const client = getBigQueryClient();
+  const programFilter = program ? `AND student_program = @program` : "";
+  const streamFilter = stream ? `AND LOWER(student_stream) = @stream` : "";
+
+  const params: Record<string, string | number> = { udise, grade, sessionId };
+  if (program) params.program = program;
+  if (stream) params.stream = stream;
+
+  const sql = `
+    SELECT
+      enrollment_user_id,
+      section AS subject,
+      chapter_name,
+      chapter_id,
+      question_id,
+      ANY_VALUE(question_position_index) AS position_index,
+      MAX(CAST(is_answered AS INT64)) AS is_answered,
+      MAX(is_correct) AS is_correct
+    FROM ${FACT_QUESTION_LEVEL_TABLE}
+    WHERE student_school_udise_code = @udise
+      AND student_grade = @grade
+      AND session_id = @sessionId
+      AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
+      AND question_id IS NOT NULL
+      AND enrollment_user_id IS NOT NULL
+      ${programFilter}
+      ${streamFilter}
+    GROUP BY enrollment_user_id, section, chapter_name, chapter_id, question_id
+    ORDER BY enrollment_user_id, section, chapter_name, position_index
+  `;
+
+  interface RawRow {
+    enrollment_user_id: number | string | null;
+    subject: string | null;
+    chapter_name: string | null;
+    chapter_id: string | null;
+    question_id: string;
+    position_index: number | string | null;
+    is_answered: number | string | null;
+    is_correct: number | string | null;
+  }
+
+  const toInt = (v: number | string | null | undefined): number => {
+    if (v == null) return 0;
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+
+  const [rows] = await client.query({ query: sql, params });
+  return (rows as RawRow[]).map((r) => {
+    const answered = toInt(r.is_answered) > 0;
+    const correct = toInt(r.is_correct) === 1;
+    const status: StudentQuestionRow["status"] = !answered
+      ? "skipped"
+      : correct
+        ? "correct"
+        : "wrong";
+    return {
+      enrollment_user_id: String(r.enrollment_user_id ?? ""),
+      chapter_id: r.chapter_id || null,
+      chapter_name: r.chapter_name || "",
+      question_id: r.question_id,
+      position_index:
+        r.position_index == null ? null : toInt(r.position_index),
+      status,
     };
   });
 }

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -369,6 +369,7 @@ export async function getTestDeepDiveFromDynamo(
         return {
           subject: sectionDisplay,
           chapter_name: c.chapter_name || "",
+          chapter_id: c.chapter_id || null,
           marks_scored: chMarks,
           max_marks: chMax,
           accuracy: toNum(c.accuracy),
@@ -394,6 +395,8 @@ export async function getTestDeepDiveFromDynamo(
 
     studentRows.push({
       student_name: studentName,
+      // doc.user_id is the enrollment_user_id (the BQ question-level join key).
+      enrollment_user_id: doc.user_id != null ? String(doc.user_id) : null,
       gender: student.gender,
       marks_scored: toNum(overall.marks_scored),
       max_marks: toNum(overall.max_marks_possible),

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -105,6 +105,10 @@ export interface ChapterAnalysisRow {
 export interface StudentChapterScore {
   subject: string;
   chapter_name: string;
+  // Stable join key to the per-student question rows (BQ chapter_id). Null when
+  // the v2 chapter row had no chapter_id; the question drill-down then falls
+  // back to matching on chapter_name.
+  chapter_id: string | null;
   marks_scored: number;
   max_marks: number;
   accuracy: number;
@@ -124,6 +128,11 @@ export interface StudentSubjectScore {
 
 export interface StudentDeepDiveRow {
   student_name: string;
+  // The v2 doc's user_id, which equals fact_student_test_results_question_level's
+  // enrollment_user_id — the join key for the per-student question drill-down.
+  // Null if the matched roster student had no usable id. Stringified for stable
+  // client-side matching against the (INT64) BQ value.
+  enrollment_user_id: string | null;
   gender: string | null;
   marks_scored: number;
   max_marks: number;
@@ -160,4 +169,20 @@ export interface TestQuestionLevelRow {
 
 export interface TestQuestionLevelData {
   questions: TestQuestionLevelRow[];
+}
+
+// One row per (student, question) for a given test — the grain behind the
+// Student Results → chapter → question drill-down. Sourced from BQ
+// fact_student_test_results_question_level grouped by enrollment_user_id.
+export interface StudentQuestionRow {
+  enrollment_user_id: string;
+  chapter_id: string | null;
+  chapter_name: string;
+  question_id: string;
+  position_index: number | null;
+  status: "correct" | "wrong" | "skipped";
+}
+
+export interface StudentQuestionLevelData {
+  questions: StudentQuestionRow[];
 }


### PR DESCRIPTION
Item #3 of #128 — extends the Student Results drill-down a 4th level: **Student → Subject → Chapter → individual questions**, showing each question's number and **Correct / Wrong / Skipped** status for that student.

> **Stacked on #136** (base = `feat/lms-perf-tab`). #3's `dynamodb.ts` changes build on #4's. Retarget to `main` once #136 merges.

## Approach
DynamoDB only holds chapter/subject aggregates, so per-question grain comes from BigQuery `fact_student_test_results_question_level` via a new `getStudentQuestionLevelData` query grouped by `enrollment_user_id`.

**Why one all-students query, fetched once + cached** (not lazy-per-student): the table is range-partitioned by `hashed_session_id` and clustered by `session_id, enrollment_user_id, question_id`, but measured bytes show a single-student scan costs ≈ the same as the all-students scan (~500 MB) — clustering doesn't prune within one session. So lazy-per-student would be ~500 MB × every student expanded, vs ~500 MB once. The fetch fires on first drill-in (nothing scanned if no one drills in) and every subsequent expand is a client-side filter.

## Changes
- `bigquery.ts`: `getStudentQuestionLevelData` (`is_answered`/`is_correct` → status).
- New route `/api/quiz-analytics/[udise]/student-questions`.
- `types/quiz.ts`: `enrollment_user_id` on `StudentDeepDiveRow` (= v2 doc `user_id` = BQ `enrollment_user_id`), `chapter_id` on `StudentChapterScore`, new `StudentQuestionRow`.
- `dynamodb.ts`: populate `enrollment_user_id` + `chapter_id`.
- `StudentResultsTable.tsx`: chapter → questions drill, fetch-once + cache + client-side filter; question number reuses the `position_index + 1` off-by-one fix from item #1.

## Tests (+13)
3 BQ (status mapping, param binding, error), 6 route (auth/validation/success/error), 4 component (no upfront fetch, drill-down + `Q0→Q1`, fetch-once-cached, error banner). Full unit suite green (2423 passed); tsc clean on source; lint clean.

> ⚠️ CI `npm run build` will fail on a **pre-existing** type error unrelated to this PR — `src/app/school-visit-summary/[id]/page.tsx:209` (already on `main`, from the codex/issue-126 merge). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)