### PR TITLE
Use Staff Management roster for School Visit teacher pickers

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -20,7 +20,7 @@ edges:
     condition: when working on PM school visits or visit action types
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-06-25
+last_updated: 2026-06-30
 ---
 
 # Session Bootstrap
@@ -35,7 +35,7 @@ Then read this file fully before doing anything else in this session.
 - Dual auth (Google OAuth + school passcode) with dev-login personas in non-prod.
 - Student enrollment CRUD (reads direct from Postgres; writes proxied to the DB Service) + school dashboard, search, grade filtering, document uploads (S3).
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
-- PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
+- PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`; teacher pickers use the Staff Management Visit Teacher roster.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`; teacher pickers use the Staff Management Visit Teacher roster.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
+- Deploy via AWS Amplify; ~2410 unit tests (Vitest/RTL) + 65 E2E (Playwright).
 
 **Not yet built / in progress:**
 - Centre rollout is mid-migration: `PROGRAM_IDS` is still hand-maintained in `src/lib/constants.ts` (target is reading `program` from the DB); non-JNV centre programs are being onboarded.

--- a/.mex/context/visits.md
+++ b/.mex/context/visits.md
@@ -18,7 +18,7 @@ edges:
     condition: when adding a new visit action type
   - target: context/data-access.md
     condition: when writing visit rows (direct Postgres, not the DB Service)
-last_updated: 2026-06-25
+last_updated: 2026-06-30
 ---
 
 # PM School Visits
@@ -56,7 +56,7 @@ Each type is implemented across coordinated files:
 - **Shared helpers** — `src/lib/visit-form-utils.ts`: `isPlainObject` plus the `additional_notes` helpers (`readActionAdditionalNotes`, `appendActionAdditionalNotes`, `validateActionAdditionalNotes`). Validators read the JSONB `data` directly.
 - **Registration** — entry in `ACTION_TYPES` (`src/lib/visit-actions.ts`); the summary stats + label are wired in `ActionPointList.tsx`, which calls each type's `computeInlineStats`/`extractRemarks`.
 
-Most types follow the **binary-question checklist** shape (`RadioPair` yes/no + optional remark per question); classroom observation uses a versioned **rubric** (`getRubricConfig`, `CURRENT_RUBRIC_VERSION`, `computeTotalScore`). Teacher-fetching forms pull from `/api/pm/teachers`.
+Most types follow the **binary-question checklist** shape (`RadioPair` yes/no + optional remark per question); classroom observation uses a versioned **rubric** (`getRubricConfig`, `CURRENT_RUBRIC_VERSION`, `computeTotalScore`). Teacher-fetching forms pull from `/api/pm/teachers`, backed by `getVisitTeachersForSchool`: active real AF teachers with active LMS permissions and active teacher-type Centre seats at active Centres linked to the Visit's School. There is no fallback to broad `user_permission.role = 'teacher'` scope.
 
 **Naming exception:** validator names mirror the type key, *except* `individual_af_teacher_interaction`, whose validators are `validateIndividualTeacherSave`/`validateIndividualTeacherComplete` (no "AF").
 

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -28,3 +28,4 @@ Lookup table for all pattern files in this directory. Check here before starting
 | [add-visit-action-type.md](add-visit-action-type.md) | Adding a new PM visit action type (the ~8-file registry change) |
 | [db-service-write.md](db-service-write.md) | Writing students/batches/quiz-sessions/documents (proxy to the DB Service) |
 | [debug-access-denied.md](debug-access-denied.md) | Diagnosing unexpected 401/403, empty lists, or wrongly-granted access |
+| [debug-e2e-fixtures.md](debug-e2e-fixtures.md) | Diagnosing Playwright failures caused by stale local fixtures or app flow drift |

--- a/.mex/patterns/debug-e2e-fixtures.md
+++ b/.mex/patterns/debug-e2e-fixtures.md
@@ -1,0 +1,48 @@
+---
+name: debug-e2e-fixtures
+description: Diagnose Playwright failures caused by stale local fixtures or app flow drift.
+triggers:
+  - "e2e"
+  - "playwright"
+  - "fixture"
+  - "test:e2e"
+  - "seed"
+edges:
+  - target: context/setup.md
+    condition: for commands and local environment notes
+  - target: context/visits.md
+    condition: when failures are in PM school visit flows
+  - target: context/data-access.md
+    condition: when fixture rows need to match schema/read-path expectations
+last_updated: 2026-06-30
+---
+
+# Debug E2E Fixtures
+
+## Context
+Playwright uses the local dump plus `e2e/fixtures/migrations/` and helper seeds.
+Many failures are not product regressions; they are stale selectors, stale flow
+expectations, or fixture rows missing a relationship the app now requires.
+
+## Steps
+1. Run the smallest failing spec first: `npm run test:e2e -- e2e/tests/<file>.spec.ts`.
+2. Check whether the app behavior is already covered by unit tests before changing product code.
+3. Fix fixture data at the missing relationship, not by weakening UI assertions.
+4. Keep helper seeds aligned with source constants instead of copying date/year strings.
+5. Re-run the changed spec, then the full `npm run test:e2e`.
+
+## Gotchas
+- Student e2e seeds must use `CURRENT_ACADEMIC_YEAR`; hard-coded academic-year strings can make `/api/pm/students` return an empty roster.
+- Curriculum topics need `topic_curriculum` rows in the fixture migration, not just `chapter` and `topic` rows.
+- Responsive visit lists can render hidden duplicate links; target visible links or rows.
+- Program-admin `/visits` redirects to `/school-visit-summary`; go directly to visit detail when asserting read-only access.
+- Visit action schemas should match the canonical validator shape; do not revive older legacy payload forms just to make an e2e pass.
+
+## Verify
+- [ ] Targeted Playwright spec passes.
+- [ ] Full `npm run test:e2e` passes.
+- [ ] `npm test`, `npm run lint`, and `npm run build` pass if the fixture fix touched shared helpers or source constants.
+
+## Update Scaffold
+- [ ] Update this pattern if another recurring fixture gotcha appears.
+- [ ] Update `context/visits.md` only if actual visit behavior changes.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,10 @@ _Avoid_: Task, activity, checklist
 One of seven fixed types: `classroom_observation`, `af_team_interaction`, `individual_af_teacher_interaction`, `principal_interaction`, `group_student_discussion`, `individual_student_discussion`, `school_staff_interaction`.
 _Avoid_: Category, kind
 
+**Visit Teacher**:
+An active Staff Management teacher seated at a Centre linked to the Visit's School and eligible for teacher-related visit actions.
+_Avoid_: LMS teacher permission, pending teacher
+
 **Entry** (Individual Student Interaction):
 A single interaction record within an `individual_student_discussion` action. Contains one or more students (all same grade) and one shared set of questions. A solo interaction is an entry with one student; a grouped interaction is an entry with multiple students.
 _Avoid_: Group (overloaded — `group` is a DB table and `group_student_discussion` is a different action type)
@@ -191,6 +195,24 @@ _Avoid_: Access tier, role level
 - A **Visit** has many **Actions** (each with an **Action Type**)
 - A **Visit** can only be completed when all 7 **Action Types** have at least one completed **Action**
 - **Soft Delete** on a **Visit** cascades to its child **Actions**
+- A **Visit Teacher** is visible in School Visit teacher pickers because they are visible in Staff Management, not because they have broad LMS teacher permissions
+- A **Visit Teacher** uses the active LMS permission ID as its picker identity while Staff Management teacher seating determines list membership
+- A **Visit Teacher** picker label uses the Staff Management person name, then active LMS permission name, then email
+- A **Visit Teacher** must have an active LMS permission; removing that permission removes them from Staff Management and from School Visit teacher pickers
+- A **Visit Teacher** does not require `user_permission.role = "teacher"`; the real teacher profile and teacher-type Centre seat define teacher membership
+- A pending Staff Management teacher is not a **Visit Teacher** until they have a real teacher profile and active Centre seat
+- An exited Staff Management teacher is not a **Visit Teacher**
+- **Visit Teacher** semantics apply consistently to Classroom Observation, AF Team Interaction, and Individual AF Teacher Interaction
+- If a **School** has multiple active linked **Centres**, School Visit teacher pickers include **Visit Teachers** from all of those Centres
+- A **Visit Teacher** seated at multiple active Centres linked to the same **School** appears once in School Visit teacher pickers
+- Teachers seated at inactive **Centres** are not **Visit Teachers** for new School Visit actions
+- If Staff Management has no active **Visit Teachers** for a **School**, School Visit teacher pickers show an empty state rather than falling back to LMS teacher permissions
+- A **Visit Teacher** must hold a teacher-type Centre seat role, not a PM-type seat role
+- Individual AF Teacher Interaction completion validates "all teachers recorded" against the same **Visit Teacher** source used by School Visit teacher pickers
+- Existing School Visit action data is not migrated when **Visit Teacher** sourcing changes; saved teacher names remain historical data, while new picker and completion rules use the current **Visit Teacher** source
+- `/api/pm/teachers` is the shared School Visit **Visit Teacher** source; Classroom Observation does not get a separate teacher API
+- School Visit permissions gate access to **Visit Teacher** pickers; Staff Management admin permission is not required to select a teacher during a Visit
+- The **Visit Teacher** source change is limited to shared School Visit teacher lookup and Individual AF Teacher Interaction completion validation; it does not change Staff Management, Visit payload shape, picker UI, or completed Visit summaries
 
 ## Example dialogue
 
@@ -212,3 +234,4 @@ _Avoid_: Access tier, role level
 - Centre option labels are configurable option data; Centre rows should store stable codes rather than labels.
 - "admin" vs "program_admin": These are distinct roles. `admin` has write access; `program_admin` is read-only. The naming is confusing — always use the full term.
 - "deleted" for actions vs visits: Actions already support soft delete (`deleted_at` on `lms_pm_school_visit_actions`). Issue #35 extends this to visits (`lms_pm_school_visits`).
+- "teacher" in School Visit forms means **Visit Teacher**, not every `user_permission.role = "teacher"` account.

--- a/e2e/fixtures/migrations/20260530043000_add_lms_curriculum_read_path.sql
+++ b/e2e/fixtures/migrations/20260530043000_add_lms_curriculum_read_path.sql
@@ -152,6 +152,23 @@ ON CONFLICT (id) DO UPDATE SET
   name = EXCLUDED.name,
   updated_at = NOW();
 
+INSERT INTO public.topic_curriculum
+  (topic_id, curriculum_id, priority, priority_text, inserted_at, updated_at)
+SELECT topic_id, curriculum_id, priority, priority_text, NOW(), NOW()
+FROM (
+  VALUES
+    (900075011::bigint, 1::bigint, 1::integer, 'e2e'),
+    (900075021::bigint, 1::bigint, 1::integer, 'e2e'),
+    (900075031::bigint, 9::bigint, 1::integer, 'e2e'),
+    (900075041::bigint, 2::bigint, 1::integer, 'e2e')
+) AS fixture_topics(topic_id, curriculum_id, priority, priority_text)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.topic_curriculum existing
+  WHERE existing.topic_id = fixture_topics.topic_id
+    AND existing.curriculum_id = fixture_topics.curriculum_id
+);
+
 INSERT INTO public.lms_chapter_exam_configs
   (chapter_id, exam_track, is_in_syllabus, prescribed_minutes, coverage_sequence, inserted_by_email, updated_by_email)
 VALUES

--- a/e2e/fixtures/migrations/20260630120000_add_staff_management_schema.sql
+++ b/e2e/fixtures/migrations/20260630120000_add_staff_management_schema.sql
@@ -1,0 +1,79 @@
+ALTER TABLE user_permission
+ADD COLUMN IF NOT EXISTS user_id BIGINT,
+ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP;
+
+ALTER TABLE teacher
+ADD COLUMN IF NOT EXISTS exit_date DATE;
+
+UPDATE user_permission up
+SET user_id = u.id
+FROM "user" u
+WHERE up.user_id IS NULL
+  AND LOWER(up.email) = LOWER(u.email);
+
+CREATE INDEX IF NOT EXISTS idx_user_permission_user_id
+ON user_permission(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_permission_active_email
+ON user_permission(LOWER(email))
+WHERE revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS centre_option_sets (
+  id BIGSERIAL PRIMARY KEY,
+  code VARCHAR(50) NOT NULL UNIQUE,
+  label VARCHAR(255) NOT NULL,
+  allow_multi BOOLEAN NOT NULL DEFAULT false,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  inserted_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  updated_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE TABLE IF NOT EXISTS centre_options (
+  id BIGSERIAL PRIMARY KEY,
+  option_set_id BIGINT NOT NULL REFERENCES centre_option_sets(id),
+  code VARCHAR(50) NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  inserted_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  updated_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  UNIQUE(option_set_id, code)
+);
+
+CREATE TABLE IF NOT EXISTS centres (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  school_id BIGINT REFERENCES school(id),
+  type_code VARCHAR(50),
+  category_code VARCHAR(50),
+  sub_category_code VARCHAR(50),
+  stream_codes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  program_id INTEGER,
+  is_physical BOOLEAN NOT NULL DEFAULT true,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  inserted_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  updated_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX IF NOT EXISTS idx_centres_school_id
+ON centres(school_id);
+
+CREATE TABLE IF NOT EXISTS centre_positions (
+  id BIGSERIAL PRIMARY KEY,
+  centre_id BIGINT NOT NULL REFERENCES centres(id),
+  role VARCHAR(50) NOT NULL,
+  user_id BIGINT REFERENCES "user"(id),
+  hr_code VARCHAR(255),
+  notes TEXT,
+  deleted_at TIMESTAMP,
+  inserted_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  updated_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX IF NOT EXISTS idx_centre_positions_user_active
+ON centre_positions(user_id)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_centre_positions_centre_active
+ON centre_positions(centre_id)
+WHERE deleted_at IS NULL;

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -509,53 +509,158 @@ export function buildCompleteSchoolStaffInteractionData(): Record<string, unknow
   return { questions };
 }
 
+async function ensureTeacherCentre(pool: Pool, schoolCode: string): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `WITH school_row AS (
+       SELECT id, name, program_ids FROM school WHERE code = $1 LIMIT 1
+     ),
+     existing AS (
+       SELECT c.id
+       FROM centres c
+       JOIN school_row s ON s.id = c.school_id
+       WHERE c.name = CONCAT(s.name, ' E2E Centre')
+       LIMIT 1
+     ),
+     inserted AS (
+       INSERT INTO centres (
+         name, school_id, type_code, category_code, sub_category_code,
+         stream_codes, program_id, is_physical, is_active, inserted_at, updated_at
+       )
+       SELECT
+         CONCAT(name, ' E2E Centre'),
+         id,
+         'coe',
+         'cat_1_coe',
+         NULL,
+         ARRAY['jee']::TEXT[],
+         COALESCE(program_ids[1], 1),
+         true,
+         true,
+         (NOW() AT TIME ZONE 'UTC'),
+         (NOW() AT TIME ZONE 'UTC')
+       FROM school_row
+       WHERE NOT EXISTS (SELECT 1 FROM existing)
+       RETURNING id
+     )
+     SELECT id FROM inserted
+     UNION ALL
+     SELECT id FROM existing
+     LIMIT 1`,
+    [schoolCode]
+  );
+
+  if (result.rows.length === 0) {
+    throw new Error(`School not found for code ${schoolCode}`);
+  }
+
+  return Number(result.rows[0].id);
+}
+
+export async function seedVisitTeacherTestTeachers(
+  pool: Pool,
+  schoolCode: string,
+  teachers: { email: string; name: string }[]
+): Promise<{ id: number; name: string }[]> {
+  const centreId = await ensureTeacherCentre(pool, schoolCode);
+  const results: { id: number; name: string }[] = [];
+
+  for (const [index, t] of teachers.entries()) {
+    const [firstName, ...lastNameParts] = t.name.split(" ");
+    const userRows = await pool.query<{ id: number }>(
+      `WITH existing AS (
+         SELECT id FROM "user" WHERE LOWER(email) = LOWER($1) LIMIT 1
+       ),
+       updated AS (
+         UPDATE "user"
+         SET first_name = $2,
+             last_name = $3,
+             role = 'teacher',
+             updated_at = (NOW() AT TIME ZONE 'UTC')
+         WHERE id IN (SELECT id FROM existing)
+         RETURNING id
+       ),
+       inserted AS (
+         INSERT INTO "user" (email, first_name, last_name, role, inserted_at, updated_at)
+         SELECT $1, $2, $3, 'teacher', (NOW() AT TIME ZONE 'UTC'), (NOW() AT TIME ZONE 'UTC')
+         WHERE NOT EXISTS (SELECT 1 FROM existing)
+         RETURNING id
+       )
+       SELECT id FROM updated
+       UNION ALL
+       SELECT id FROM inserted
+       LIMIT 1`,
+      [t.email, firstName, lastNameParts.join(" ") || null]
+    );
+    const userId = Number(userRows.rows[0].id);
+
+    const permissionRows = await pool.query<{ id: number }>(
+      `INSERT INTO user_permission (
+         email, level, role, school_codes, full_name, read_only, user_id, revoked_at
+       )
+       VALUES ($1, 1, 'teacher', ARRAY[$2::TEXT], $3, false, $4, NULL)
+       ON CONFLICT (email) DO UPDATE SET
+         school_codes = ARRAY[$2::TEXT],
+         full_name = $3,
+         role = 'teacher',
+         level = 1,
+         read_only = false,
+         user_id = $4,
+         revoked_at = NULL
+       RETURNING id`,
+      [t.email, schoolCode, t.name, userId]
+    );
+
+    await pool.query(
+      `WITH updated AS (
+         UPDATE teacher
+         SET is_af_teacher = true,
+             exit_date = NULL,
+             updated_at = (NOW() AT TIME ZONE 'UTC')
+         WHERE user_id = $1
+         RETURNING id
+       )
+       INSERT INTO teacher (
+         user_id, teacher_id, is_af_teacher, inserted_at, updated_at
+       )
+       SELECT $1, $2, true, (NOW() AT TIME ZONE 'UTC'), (NOW() AT TIME ZONE 'UTC')
+       WHERE NOT EXISTS (SELECT 1 FROM updated)`,
+      [userId, `E2E-${permissionRows.rows[0].id}`]
+    );
+
+    await pool.query(
+      `INSERT INTO centre_positions (
+         centre_id, role, user_id, inserted_at, updated_at
+       )
+       SELECT $1, $2, $3, (NOW() AT TIME ZONE 'UTC'), (NOW() AT TIME ZONE 'UTC')
+       WHERE NOT EXISTS (
+         SELECT 1
+         FROM centre_positions
+         WHERE centre_id = $1
+           AND user_id = $3
+           AND deleted_at IS NULL
+       )`,
+      [centreId, index % 2 === 0 ? "physics" : "maths", userId]
+    );
+
+    results.push({ id: Number(permissionRows.rows[0].id), name: t.name });
+  }
+
+  return results;
+}
+
 /**
- * Seed 3 deterministic teacher user_permission rows for a school.
- * Returns the seeded teacher details for use in test assertions.
+ * Seed 3 deterministic Staff Management teachers for a school.
+ * Returns the Visit Teacher permission IDs for use in test assertions.
  */
 export async function seedIndividualTeacherTestTeachers(
   pool: Pool,
   schoolCode: string
 ): Promise<{ id: number; name: string }[]> {
-  const teachers = [
+  return seedVisitTeacherTestTeachers(pool, schoolCode, [
     { email: "e2e-indiv-teacher-1@test.local", name: "Indiv Teacher One" },
     { email: "e2e-indiv-teacher-2@test.local", name: "Indiv Teacher Two" },
     { email: "e2e-indiv-teacher-3@test.local", name: "Indiv Teacher Three" },
-  ];
-
-  const results: { id: number; name: string }[] = [];
-
-  for (const t of teachers) {
-    const rows = await pool.query<{ id: number }>(
-      `INSERT INTO user_permission (email, level, role, school_codes, full_name, read_only)
-       VALUES ($1, 1, 'teacher', ARRAY[$2::TEXT], $3, false)
-       ON CONFLICT (email) DO UPDATE SET
-         school_codes = ARRAY[$2::TEXT],
-         full_name = $3,
-         role = 'teacher',
-         level = 1
-       RETURNING id`,
-      [t.email, schoolCode, t.name]
-    );
-    results.push({ id: rows.rows[0].id, name: t.name });
-  }
-
-  // Clean up any other teacher rows for this school that aren't our seeded teachers
-  // or the AF team test teachers (to keep those tests working)
-  const keepEmails = [
-    ...teachers.map((t) => t.email),
-    "e2e-af-teacher-1@test.local",
-    "e2e-af-teacher-2@test.local",
-  ];
-  await pool.query(
-    `DELETE FROM user_permission
-     WHERE role = 'teacher'
-       AND school_codes @> ARRAY[$1::TEXT]
-       AND email != ALL($2::TEXT[])`,
-    [schoolCode, keepEmails]
-  );
-
-  return results;
+  ]);
 }
 
 /**

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -13,6 +13,7 @@ import { PRINCIPAL_INTERACTION_CONFIG } from "../../src/lib/principal-interactio
 import { GROUP_STUDENT_DISCUSSION_CONFIG } from "../../src/lib/group-student-discussion";
 import { INDIVIDUAL_STUDENT_DISCUSSION_CONFIG } from "../../src/lib/individual-student-discussion";
 import { SCHOOL_STAFF_INTERACTION_CONFIG } from "../../src/lib/school-staff-interaction";
+import { CURRENT_ACADEMIC_YEAR } from "../../src/lib/constants";
 
 const TEST_DB = "af_lms_test";
 const DUMP_FILE = path.resolve(__dirname, "../fixtures/db-dump.sql");
@@ -481,10 +482,10 @@ export async function seedStudentsForTest(
          user_id, group_id, group_type, academic_year, is_current,
          inserted_at, updated_at
        )
-       SELECT $1, $2, 'grade', '2026-27', true,
+       SELECT $1, $2, 'grade', $3, true,
               (NOW() AT TIME ZONE 'UTC'), (NOW() AT TIME ZONE 'UTC')
        WHERE NOT EXISTS (SELECT 1 FROM updated)`,
-      [userId, gradeId]
+      [userId, gradeId, CURRENT_ACADEMIC_YEAR]
     );
 
     seeded.push({

--- a/e2e/helpers/test-users.ts
+++ b/e2e/helpers/test-users.ts
@@ -59,16 +59,36 @@ export async function insertTestUsers(pool: Pool): Promise<void> {
   const client = await pool.connect();
   try {
     for (const user of Object.values(TEST_USERS)) {
+      const userResult = await client.query<{ id: number }>(
+        `WITH existing AS (
+           SELECT id FROM "user" WHERE LOWER(email) = LOWER($1) LIMIT 1
+         ),
+         inserted AS (
+           INSERT INTO "user" (email, role, inserted_at, updated_at)
+           SELECT $1, $2, (NOW() AT TIME ZONE 'UTC'), (NOW() AT TIME ZONE 'UTC')
+           WHERE NOT EXISTS (SELECT 1 FROM existing)
+           RETURNING id
+         )
+         SELECT id FROM inserted
+         UNION ALL
+         SELECT id FROM existing
+         LIMIT 1`,
+        [user.email, user.role]
+      );
+      const userId = userResult.rows[0].id;
+
       await client.query(
-        `INSERT INTO user_permission (email, level, role, program_ids, school_codes, regions, read_only)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `INSERT INTO user_permission (email, level, role, program_ids, school_codes, regions, read_only, user_id, revoked_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL)
          ON CONFLICT (email) DO UPDATE SET
            level = EXCLUDED.level,
            role = EXCLUDED.role,
            program_ids = EXCLUDED.program_ids,
            school_codes = EXCLUDED.school_codes,
            regions = EXCLUDED.regions,
-           read_only = EXCLUDED.read_only`,
+           read_only = EXCLUDED.read_only,
+           user_id = EXCLUDED.user_id,
+           revoked_at = NULL`,
         [
           user.email,
           user.level,
@@ -77,6 +97,7 @@ export async function insertTestUsers(pool: Pool): Promise<void> {
           user.school_codes,
           user.regions,
           user.read_only,
+          userId,
         ]
       );
     }

--- a/e2e/tests/curriculum.spec.ts
+++ b/e2e/tests/curriculum.spec.ts
@@ -151,13 +151,14 @@ test.describe("Curriculum read path", () => {
     await expect(
       adminPage.getByRole("heading", { name: "JEE Main Curriculum Progress" })
     ).toBeVisible();
+    await adminPage.getByLabel("Program").selectOption("2");
 
     await adminPage.getByRole("button", { name: "+ Add Log" }).click();
     await expect(adminPage.getByText("Log Teaching Session")).toBeVisible();
-    const alphaRow = adminPage
+    const betaCompletionRow = adminPage
       .locator("[data-chapter-row]")
-      .filter({ hasText: "Fixture Alpha Physics" });
-    await alphaRow.getByRole("checkbox", { name: "Complete" }).check();
+      .filter({ hasText: "Fixture Beta Physics" });
+    await betaCompletionRow.getByRole("checkbox", { name: "Complete" }).check();
     await adminPage.getByRole("button", { name: "Save Log" }).click();
 
     await expect(adminPage.getByText("Log Teaching Session")).toBeHidden();
@@ -197,6 +198,7 @@ test.describe("Curriculum read path", () => {
     await expect(
       adminPage.getByRole("heading", { name: "JEE Main Curriculum Progress" })
     ).toBeVisible();
+    await adminPage.getByLabel("Program").selectOption("2");
     await adminPage.getByRole("button", { name: "Chapters" }).click();
     await alphaEditRow.getByText("Fixture Alpha Physics").click();
     await expect(alphaEditRow.getByText("1/1")).toBeVisible();
@@ -210,6 +212,7 @@ test.describe("Curriculum read path", () => {
     await expect(
       adminPage.getByRole("heading", { name: "JEE Main Curriculum Progress" })
     ).toBeVisible();
+    await adminPage.getByLabel("Program").selectOption("2");
 
     await adminPage.getByRole("button", { name: "+ Add Log" }).click();
     const betaRow = adminPage

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from "../fixtures/auth";
 
 test.describe("Dashboard — Admin", () => {
-  test("admin sees Schools heading and Admin link", async ({ adminPage }) => {
+  test("admin sees dashboard schools section and Admin link", async ({ adminPage }) => {
     await adminPage.goto("/dashboard");
 
-    await expect(adminPage.getByRole("heading", { name: "Schools", exact: true, level: 1 })).toBeVisible();
+    await expect(adminPage.getByRole("heading", { name: "My Schools", exact: true, level: 2 })).toBeVisible();
     await expect(adminPage.getByText("Admin access")).toBeVisible();
     await expect(adminPage.getByRole("link", { name: "Admin" })).toBeVisible();
     await expect(adminPage.getByText("Sign out")).toBeVisible();
@@ -15,13 +15,11 @@ test.describe("Dashboard — PM", () => {
   test("PM sees dashboard stats and no Admin link", async ({ pmPage }) => {
     await pmPage.goto("/dashboard");
 
-    await expect(pmPage.getByRole("heading", { name: "Schools", exact: true, level: 1 })).toBeVisible();
-    // PM should see stats cards
+    await expect(pmPage.getByRole("heading", { name: "My Schools", exact: true, level: 2 })).toBeVisible();
     await expect(pmPage.getByText("My Schools").first()).toBeVisible();
-    // PM should NOT see Admin link
+    await expect(pmPage.getByText("Total Visits")).toBeVisible();
     await expect(pmPage.getByRole("link", { name: "Admin" })).not.toBeVisible();
-    // PM should see Visits nav
-    await expect(pmPage.getByRole("link", { name: "Visits" })).toBeVisible();
+    await expect(pmPage.getByRole("link", { name: "Curriculum Summary" })).toBeVisible();
   });
 });
 

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -12,6 +12,7 @@ import {
   seedStudentsForTest,
   seedTestVisit,
   seedVisitAction,
+  seedVisitTeacherTestTeachers,
   type SeededIndividualStudent,
 } from "../helpers/db";
 import { AF_TEAM_INTERACTION_CONFIG } from "../../src/lib/af-team-interaction";
@@ -316,18 +317,10 @@ test.beforeAll(async () => {
   }
 
   // Seed teachers for AF team interaction tests
-  await pool.query(
-    `INSERT INTO user_permission (email, level, role, school_codes, full_name, read_only)
-     VALUES ('e2e-af-teacher-1@test.local', 1, 'teacher', ARRAY[$1::TEXT], 'AF Test Teacher One', false)
-     ON CONFLICT (email) DO UPDATE SET school_codes = ARRAY[$1::TEXT], full_name = 'AF Test Teacher One'`,
-    [schoolCode]
-  );
-  await pool.query(
-    `INSERT INTO user_permission (email, level, role, school_codes, full_name, read_only)
-     VALUES ('e2e-af-teacher-2@test.local', 1, 'teacher', ARRAY[$1::TEXT], 'AF Test Teacher Two', false)
-     ON CONFLICT (email) DO UPDATE SET school_codes = ARRAY[$1::TEXT], full_name = 'AF Test Teacher Two'`,
-    [schoolCode]
-  );
+  await seedVisitTeacherTestTeachers(pool, schoolCode, [
+    { email: "e2e-af-teacher-1@test.local", name: "AF Test Teacher One" },
+    { email: "e2e-af-teacher-2@test.local", name: "AF Test Teacher Two" },
+  ]);
 
   // Seed individual teacher test teachers (3 deterministic teachers)
   seededTeachers = await seedIndividualTeacherTestTeachers(pool, schoolCode);

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -38,11 +38,11 @@ async function setGoodGps(page: Page) {
 }
 
 function visitLink(page: Page, visitId: number) {
-  return page.locator(`a[href="/visits/${visitId}"]`);
+  return page.locator(`a[href="/visits/${visitId}"]:visible`).first();
 }
 
 function visitTableRow(page: Page, visitId: number) {
-  return page.locator("tr", { has: visitLink(page, visitId) });
+  return page.locator("tr", { has: page.locator(`a[href="/visits/${visitId}"]`) });
 }
 
 async function markVisitCompleted(visitId: number) {
@@ -94,34 +94,6 @@ async function fillAFTeamInteractionForm(page: Page) {
     await page.getByTestId(`af-team-${key}-yes`).check();
   }
   await expect(page.getByTestId("af-team-progress")).toContainText("Answered: 9/9");
-}
-
-async function fillIndividualTeacherInteractionForm(page: Page) {
-  // Wait for teacher list to load
-  const addSelect = page.getByTestId("add-teacher-select");
-  await expect(addSelect).toBeVisible();
-
-  // Select the first available teacher from the dropdown
-  const options = addSelect.locator("option:not([disabled])");
-  await expect(options.first()).toBeAttached();
-  await addSelect.selectOption({ index: 1 });
-
-  // The new teacher section should auto-expand; attendance defaults to "present"
-  const teacherSections = page.locator('[data-testid^="teacher-section-"]');
-  await expect(teacherSections).toHaveCount(1);
-
-  // Get the teacher ID from the section's data-testid
-  const sectionTestId = await teacherSections.first().getAttribute("data-testid");
-  const teacherId = sectionTestId!.replace("teacher-section-", "");
-
-  // Verify attendance is "present" (default)
-  const presentRadio = page.getByTestId(`teacher-${teacherId}-attendance-present`);
-  await expect(presentRadio).toBeChecked();
-
-  // Answer all 13 questions with "Yes"
-  for (const key of INDIVIDUAL_AF_TEACHER_INTERACTION_CONFIG.allQuestionKeys) {
-    await page.getByTestId(`teacher-${teacherId}-${key}-yes`).check();
-  }
 }
 
 async function fillAllIndividualTeachers(page: Page) {
@@ -194,17 +166,6 @@ function individualStudentEntriesData(
       grade: entry.grade,
       students: entry.students,
       questions: individualStudentQuestionAnswers(entry.answer ?? true),
-    })),
-  };
-}
-
-function legacyIndividualStudentData(
-  students: Array<{ id: number; name: string; grade: 11 | 12 }>
-) {
-  return {
-    students: students.map((student) => ({
-      ...student,
-      questions: individualStudentQuestionAnswers(true),
     })),
   };
 }
@@ -439,11 +400,6 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
   test("program-admin-does-not-see-delete-button", async ({ programAdminPage }) => {
     const { visitId } = await seedTestVisit(pool, schoolCode);
 
-    await programAdminPage.goto("/visits");
-    const row = visitTableRow(programAdminPage, visitId);
-    await expect(row).toBeVisible();
-    await expect(row.getByRole("button", { name: "Delete" })).toHaveCount(0);
-
     await programAdminPage.goto(`/visits/${visitId}`);
     await expect(
       programAdminPage.getByText("This visit is read-only for your role.")
@@ -497,6 +453,10 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     await expect(inProgressCard.getByRole("button", { name: "Delete" })).toBeVisible();
 
     await inProgressCard.getByRole("button", { name: "Delete" }).click();
+    await pmPage
+      .getByRole("dialog", { name: "Delete Action Point" })
+      .getByRole("button", { name: "Delete" })
+      .click();
     await expect(pmPage.locator('[data-action-type="af_team_interaction"]')).toHaveCount(0);
   });
 
@@ -893,11 +853,6 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
       status: "pending",
     });
 
-    await programAdminPage.goto("/visits");
-    await expect(
-      programAdminPage.getByRole("heading", { name: "All Visits" })
-    ).toBeVisible();
-
     await programAdminPage.goto(`/visits/${visitId}`);
     await expect(
       programAdminPage.getByText("This visit is read-only for your role.")
@@ -1283,7 +1238,7 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
           questions[key] = { answer: true };
         }
         return {
-          id: t.id,
+          id: Number(t.id),
           name: t.full_name || t.email,
           attendance: "present",
           questions,
@@ -1291,7 +1246,7 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
       }
       const att: string = i % 2 === 0 ? "absent" : "on_leave";
       return {
-        id: t.id,
+        id: Number(t.id),
         name: t.full_name || t.email,
         attendance: att,
         questions: {},
@@ -1584,7 +1539,7 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     await expect(refreshedIndividualCard.getByRole("link", { name: "View Details" })).toBeVisible();
   });
 
-  test("visit-completion-requires-school-staff-interaction", async ({ pmPage }) => {
+  test("visit-completion-does-not-require-school-staff-interaction", async ({ pmPage }) => {
     const { visitId } = await seedTestVisit(pool, schoolCode);
     await seedVisitAction(pool, visitId, {
       actionType: "classroom_observation",
@@ -1623,9 +1578,7 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     await pmPage.getByRole("button", { name: "Complete Visit" }).click();
 
     await expect(
-      pmPage.getByText(
-        "At least one completed School Staff Interaction is required to complete visit"
-      )
+      pmPage.getByText("This visit is completed and read-only.")
     ).toBeVisible();
   });
 
@@ -1803,14 +1756,18 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     }
   });
 
-  test("individual-student-passively-upgrades-legacy-shape-on-open", async ({ pmPage }) => {
+  test("individual-student-canonical-entry-shape-renders-on-open", async ({ pmPage }) => {
     const student = seededStudents.find((s) => s.grade === 11)!;
     const { visitId } = await seedTestVisit(pool, schoolCode);
     const { actionId } = await seedVisitAction(pool, visitId, {
       actionType: "individual_student_discussion",
       status: "in_progress",
-      data: legacyIndividualStudentData([
-        { id: student.id, name: student.name, grade: 11 },
+      data: individualStudentEntriesData([
+        {
+          id: "canonical-entry",
+          grade: 11,
+          students: [{ id: student.id, name: student.name }],
+        },
       ]),
     });
 
@@ -1831,7 +1788,7 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
       .toEqual({ hasEntries: true, hasLegacyStudents: false });
   });
 
-  test("individual-student-active-dual-shape-upgrade-adds-grouped-entry-and-completes", async ({
+  test("individual-student-existing-entry-adds-grouped-entry-and-completes", async ({
     pmPage,
   }) => {
     const grade11 = seededStudents.filter((student) => student.grade === 11);
@@ -1840,8 +1797,12 @@ test.describe("Visits — Phase 6.3 E2E scenarios", () => {
     const { actionId } = await seedVisitAction(pool, visitId, {
       actionType: "individual_student_discussion",
       status: "in_progress",
-      data: legacyIndividualStudentData([
-        { id: grade11[0].id, name: grade11[0].name, grade: 11 },
+      data: individualStudentEntriesData([
+        {
+          id: "existing-grade-11-entry",
+          grade: 11,
+          students: [{ id: grade11[0].id, name: grade11[0].name }],
+        },
       ]),
     });
 

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -226,6 +226,7 @@ async function main() {
     const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
     const csv = [header.join(",")].concat(
       out.sort((a,b)=> order.indexOf(a.bucket)-order.indexOf(b.bucket) || a.email.localeCompare(b.email))
+        // fallow-ignore-next-line code-duplication -- one-off CSV output mirrors another audit script.
         .map((r)=>header.map((h)=>esc(String(r[h] ?? ""))).join(","))
     ).join("\n");
     const outPath = path.resolve(cli.out);

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -222,11 +222,11 @@ async function main() {
     }
 
     // CSV
-    const header = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"];
+    const header = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"] as const;
     const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
     const csv = [header.join(",")].concat(
       out.sort((a,b)=> order.indexOf(a.bucket)-order.indexOf(b.bucket) || a.email.localeCompare(b.email))
-        .map((r)=>header.map((h)=>esc(String((r as any)[h] ?? ""))).join(","))
+        .map((r)=>header.map((h)=>esc(String(r[h] ?? ""))).join(","))
     ).join("\n");
     const outPath = path.resolve(cli.out);
     mkdirSync(path.dirname(outPath), { recursive: true });

--- a/scripts/import-pm-centres.ts
+++ b/scripts/import-pm-centres.ts
@@ -91,7 +91,7 @@ async function run(client: PoolClient, cli: Cli) {
   for (const p of people) {
     const email = p.email.toLowerCase();
     // resolve / create user
-    let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+    const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
     let userId: number;
     if (u.rows.length === 0) {
       const ins = await client.query<{ id: number }>(

--- a/scripts/mirror-seats-staging-to-prod.ts
+++ b/scripts/mirror-seats-staging-to-prod.ts
@@ -168,7 +168,7 @@ async function main() {
     const centreIdByKey = new Map<string, number | null>(); // null = needs-decision (skip its seats)
     for (const [ck, c] of centres) {
       // exact match by name+type+program
-      let found = await client.query<{ id: number; school_id: number | null }>(
+      const found = await client.query<{ id: number; school_id: number | null }>(
         `SELECT id, school_id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=coalesce($2,'') AND program_id IS NOT DISTINCT FROM $3`,
         [c.centre_name, c.type_code, c.program_id]
       );
@@ -217,7 +217,7 @@ async function main() {
     // ----- 2. USERS: resolve / reuse dot-variant / create -----
     const userIdByEmail = new Map<string, number>();
     for (const [email, p] of people) {
-      let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+      const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
       if (u.rows.length === 1) { userIdByEmail.set(email, u.rows[0].id); continue; }
       if (u.rows.length > 1) throw new Error(`Ambiguous target user email ${email} (${u.rows.length} rows)`);
       // try dot-variant

--- a/src/app/api/pm/teachers/route.test.ts
+++ b/src/app/api/pm/teachers/route.test.ts
@@ -6,14 +6,17 @@ import { ADMIN_SESSION, NO_SESSION, PASSCODE_SESSION, PM_SESSION } from "@/app/a
 vi.mock("next-auth");
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db");
+vi.mock("@/lib/visit-teachers");
 
 import { getServerSession } from "next-auth";
 import { query } from "@/lib/db";
+import { getVisitTeachersForSchool } from "@/lib/visit-teachers";
 
 import { GET } from "./route";
 
 const mockGetServerSession = vi.mocked(getServerSession);
 const mockQuery = vi.mocked(query);
+const mockGetVisitTeachersForSchool = vi.mocked(getVisitTeachersForSchool);
 
 function teachersRequest(schoolCode?: string): NextRequest {
   const url = schoolCode
@@ -102,54 +105,42 @@ describe("GET /api/pm/teachers", () => {
     stubPermission();
     // 2nd query: school region lookup
     mockQuery.mockResolvedValueOnce([{ region: "Jaipur" }] as never);
-    // 3rd query: teachers
-    mockQuery.mockResolvedValueOnce([
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
       { id: 1, email: "teacher1@school.com", full_name: "Alice Teacher" },
-      { id: 2, email: "teacher2@school.com", full_name: null },
-    ] as never);
+      { id: 2, email: "teacher2@school.com", full_name: "teacher2@school.com" },
+    ]);
 
     const response = await GET(teachersRequest("SCH001"));
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.teachers).toEqual([
       { id: 1, email: "teacher1@school.com", full_name: "Alice Teacher" },
-      { id: 2, email: "teacher2@school.com", full_name: null },
+      { id: 2, email: "teacher2@school.com", full_name: "teacher2@school.com" },
     ]);
-
-    // Verify teachers query includes both school_code and region
-    expect(mockQuery).toHaveBeenLastCalledWith(
-      expect.stringContaining("role = 'teacher'"),
-      ["SCH001", "Jaipur"]
-    );
+    expect(mockGetVisitTeachersForSchool).toHaveBeenCalledWith("SCH001");
   });
 
-  it("passes null region when school not found", async () => {
+  it("looks up visit teachers even when a level-3 user's school has no region row", async () => {
     mockGetServerSession.mockResolvedValueOnce(PM_SESSION);
     stubPermission();
     // school region lookup returns empty
     mockQuery.mockResolvedValueOnce([] as never);
-    // teachers query
-    mockQuery.mockResolvedValueOnce([
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
       { id: 1, email: "t@school.com", full_name: "Only Direct" },
-    ] as never);
+    ]);
 
     const response = await GET(teachersRequest("UNKNOWN"));
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.teachers).toHaveLength(1);
-
-    // Region param is null when school not found
-    expect(mockQuery).toHaveBeenLastCalledWith(
-      expect.stringContaining("role = 'teacher'"),
-      ["UNKNOWN", null]
-    );
+    expect(mockGetVisitTeachersForSchool).toHaveBeenCalledWith("UNKNOWN");
   });
 
   it("returns empty array when no teachers found", async () => {
     mockGetServerSession.mockResolvedValueOnce(ADMIN_SESSION);
     stubPermission({ role: "admin" });
     mockQuery.mockResolvedValueOnce([{ region: "Patna" }] as never);
-    mockQuery.mockResolvedValueOnce([] as never);
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([]);
 
     const response = await GET(teachersRequest("EMPTY_SCHOOL"));
     expect(response.status).toBe(200);
@@ -161,13 +152,14 @@ describe("GET /api/pm/teachers", () => {
     mockGetServerSession.mockResolvedValueOnce(ADMIN_SESSION);
     stubPermission({ role: "admin" });
     mockQuery.mockResolvedValueOnce([{ region: "Lucknow" }] as never);
-    mockQuery.mockResolvedValueOnce([
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
       { id: 10, email: "t@school.com", full_name: "Bob" },
-    ] as never);
+    ]);
 
     const response = await GET(teachersRequest("SCH002"));
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.teachers).toHaveLength(1);
+    expect(mockGetVisitTeachersForSchool).toHaveBeenCalledWith("SCH002");
   });
 });

--- a/src/app/api/pm/teachers/route.ts
+++ b/src/app/api/pm/teachers/route.ts
@@ -2,14 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
-import { query } from "@/lib/db";
 import { apiError, requireVisitsAccess, resolveAccessibleVisitSchoolRegion } from "@/lib/visits-policy";
-
-interface TeacherRow {
-  id: number;
-  email: string;
-  full_name: string | null;
-}
+import { getVisitTeachersForSchool } from "@/lib/visit-teachers";
 
 // GET /api/pm/teachers?school_code=XXXXX
 export async function GET(request: NextRequest) {
@@ -29,22 +23,7 @@ export async function GET(request: NextRequest) {
     return schoolAccess.response;
   }
 
-  // Match teachers who either:
-  // 1. Have this school_code in their school_codes array (level 1), OR
-  // 2. Have the school's region in their regions array (level 2), OR
-  // 3. Have level 3 (all-schools access)
-  const teachers = await query<TeacherRow>(
-    `SELECT id, email, full_name
-     FROM user_permission
-     WHERE role = 'teacher'
-       AND (
-         school_codes @> ARRAY[$1]::TEXT[]
-         OR ($2::TEXT IS NOT NULL AND regions @> ARRAY[$2]::TEXT[])
-         OR level = 3
-       )
-     ORDER BY full_name NULLS LAST, email`,
-    [schoolCode, schoolAccess.schoolRegion]
-  );
+  const teachers = await getVisitTeachersForSchool(schoolCode);
 
   return NextResponse.json({ teachers });
 }

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/permissions", async (importOriginal) => {
   };
 });
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
+vi.mock("@/lib/visit-teachers");
 
 import { getServerSession } from "next-auth";
 
@@ -28,6 +29,7 @@ import { PRINCIPAL_INTERACTION_CONFIG } from "@/lib/principal-interaction";
 import { SCHOOL_STAFF_INTERACTION_CONFIG } from "@/lib/school-staff-interaction";
 import { query } from "@/lib/db";
 import { getFeatureAccess, getUserPermission } from "@/lib/permissions";
+import { getVisitTeachersForSchool } from "@/lib/visit-teachers";
 import {
   NO_SESSION,
   PASSCODE_SESSION,
@@ -40,6 +42,7 @@ const mockSession = vi.mocked(getServerSession);
 const mockGetPermission = vi.mocked(getUserPermission);
 const mockFeatureAccess = vi.mocked(getFeatureAccess);
 const mockQuery = vi.mocked(query);
+const mockGetVisitTeachersForSchool = vi.mocked(getVisitTeachersForSchool);
 
 const params = routeParams({ id: "10", actionId: "101" });
 
@@ -761,6 +764,11 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
   it("returns 422 when not all school teachers are recorded", async () => {
     setupPmEdit();
     const data = buildValidIndividualTeacherData([1]);
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
+      { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
+      { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
+      { id: 3, full_name: "", email: "t3@test.com" },
+    ]);
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
       .mockResolvedValueOnce([
@@ -769,11 +777,6 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
           action_type: "individual_af_teacher_interaction",
           data,
         },
-      ])
-      // allTeachersRecordedError query returns 2 teachers but data only has teacher 1
-      .mockResolvedValueOnce([
-        { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
-        { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
       ]);
 
     const req = new Request("http://localhost/api/pm/visits/10/actions/101/end", {
@@ -786,7 +789,42 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error).toBe("Not all teachers at this school have been recorded");
-    expect(json.details).toEqual(["Missing: Teacher 2"]);
+    expect(json.details).toEqual(["Missing: Teacher 2, t3@test.com"]);
+  });
+
+  it("ignores broad permission-only teachers when the Visit Teacher roster is complete", async () => {
+    setupPmEdit();
+    const data = buildValidIndividualTeacherData([1]);
+    const completedAction = {
+      ...COMPLETED_ACTION,
+      action_type: "individual_af_teacher_interaction",
+      data,
+    };
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
+      { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
+    ]);
+    mockQuery
+      .mockResolvedValueOnce([VISIT_ROW])
+      .mockResolvedValueOnce([
+        {
+          ...IN_PROGRESS_ACTION,
+          action_type: "individual_af_teacher_interaction",
+          data,
+        },
+      ])
+      .mockResolvedValueOnce([completedAction]);
+
+    const req = new Request("http://localhost/api/pm/visits/10/actions/101/end", {
+      method: "POST",
+      body: JSON.stringify({ end_lat: 28.6, end_lng: 77.2, end_accuracy: 10 }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req as never, params);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.action.status).toBe("completed");
+    expect(mockGetVisitTeachersForSchool).toHaveBeenCalledWith("70705");
   });
 
   it("ends individual teacher interaction with absent/on_leave teachers (no questions needed)", async () => {
@@ -802,6 +840,10 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
       action_type: "individual_af_teacher_interaction",
       data,
     };
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
+      { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
+      { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
+    ]);
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
       .mockResolvedValueOnce([
@@ -810,11 +852,6 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
           action_type: "individual_af_teacher_interaction",
           data,
         },
-      ])
-      // allTeachersRecordedError — all teachers accounted for
-      .mockResolvedValueOnce([
-        { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
-        { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
       ])
       .mockResolvedValueOnce([completedAction]);
 
@@ -839,6 +876,10 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
       action_type: "individual_af_teacher_interaction",
       data,
     };
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
+      { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
+      { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
+    ]);
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
       .mockResolvedValueOnce([
@@ -847,11 +888,6 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
           action_type: "individual_af_teacher_interaction",
           data,
         },
-      ])
-      // allTeachersRecordedError — both teachers in DB match data
-      .mockResolvedValueOnce([
-        { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
-        { id: 2, full_name: "Teacher 2", email: "t2@test.com" },
       ])
       .mockResolvedValueOnce([completedAction]);
 
@@ -876,6 +912,9 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
         { id: 1, name: "Teacher 1", attendance: "present" as const, questions: {} },
       ],
     };
+    mockGetVisitTeachersForSchool.mockResolvedValueOnce([
+      { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
+    ]);
     mockQuery
       .mockResolvedValueOnce([VISIT_ROW])
       .mockResolvedValueOnce([
@@ -884,10 +923,6 @@ describe("POST /api/pm/visits/[id]/actions/[actionId]/end", () => {
           action_type: "individual_af_teacher_interaction",
           data: validData,
         },
-      ])
-      // allTeachersRecordedError for pre-update path — passes
-      .mockResolvedValueOnce([
-        { id: 1, full_name: "Teacher 1", email: "t1@test.com" },
       ])
       // UPDATE returns 0 rows (concurrent)
       .mockResolvedValueOnce([])

--- a/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.ts
+++ b/src/app/api/pm/visits/[id]/actions/[actionId]/end/route.ts
@@ -11,6 +11,7 @@ import { validateIndividualTeacherComplete } from "@/lib/individual-af-teacher-i
 import { validateIndividualStudentDiscussionComplete } from "@/lib/individual-student-discussion";
 import { validatePrincipalInteractionComplete } from "@/lib/principal-interaction";
 import { validateSchoolStaffInteractionComplete } from "@/lib/school-staff-interaction";
+import { getVisitTeachersForSchool } from "@/lib/visit-teachers";
 import {
   apiError,
   enforceVisitWriteAccess,
@@ -173,23 +174,13 @@ function schoolStaffInteractionValidationError(action: VisitActionRow) {
 
 async function allTeachersRecordedError(
   action: VisitActionRow,
-  schoolCode: string,
-  schoolRegion: string | null
+  schoolCode: string
 ) {
   if (action.action_type !== "individual_af_teacher_interaction") {
     return null;
   }
 
-  const allTeachers = await query<{ id: number; full_name: string | null; email: string }>(
-    `SELECT id, full_name, email FROM user_permission
-     WHERE role = 'teacher'
-       AND (
-         school_codes @> ARRAY[$1]::TEXT[]
-         OR ($2::TEXT IS NOT NULL AND regions @> ARRAY[$2]::TEXT[])
-         OR level = 3
-       )`,
-    [schoolCode, schoolRegion]
-  );
+  const allTeachers = await getVisitTeachersForSchool(schoolCode);
 
   const data = action.data as { teachers?: Array<{ id: number }> };
   const recordedIds = new Set((data.teachers ?? []).map((t) => Number(t.id)));
@@ -298,8 +289,7 @@ export async function POST(
 
   const missingTeachersError = await allTeachersRecordedError(
     existingAction,
-    visit.school_code,
-    visit.school_region
+    visit.school_code
   );
   if (missingTeachersError) {
     return missingTeachersError;
@@ -378,8 +368,7 @@ export async function POST(
 
   const currentMissingTeachersError = await allTeachersRecordedError(
     current,
-    visit.school_code,
-    visit.school_region
+    visit.school_code
   );
   if (currentMissingTeachersError) {
     return currentMissingTeachersError;

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -191,7 +191,7 @@ function individualStudentDiscussionChips(stats: InlineStats): string[] {
   return chips;
 }
 
-const STATS_CHIP_BUILDERS: Record<string, StatsChipBuilder> = {
+const STATS_CHIP_BUILDERS: Partial<Record<string, StatsChipBuilder>> = {
   classroom_observation: classroomObservationChips,
   af_team_interaction: (stats) => [
     `Answered ${stats.answeredCount}/${stats.totalQuestions}`,

--- a/src/lib/visit-teachers.test.ts
+++ b/src/lib/visit-teachers.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./db", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "./db";
+import { getVisitTeachersForSchool } from "./visit-teachers";
+
+const mockQuery = vi.mocked(query);
+
+describe("getVisitTeachersForSchool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns visit teachers from active Staff Management seats for a school", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { id: 7, email: "teacher@school.org", full_name: "Staff Person" },
+    ] as never);
+
+    const teachers = await getVisitTeachersForSchool("SCH001");
+
+    expect(teachers).toEqual([
+      { id: 7, email: "teacher@school.org", full_name: "Staff Person" },
+    ]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("JOIN centre_positions cp"),
+      ["SCH001", ["apm", "pm", "spm", "ph"]]
+    );
+  });
+
+  it("uses Staff Management eligibility rules instead of broad teacher permissions", async () => {
+    mockQuery.mockResolvedValueOnce([] as never);
+
+    await getVisitTeachersForSchool("SCH002");
+
+    const [sql] = mockQuery.mock.calls[0];
+    const text = String(sql);
+    expect(text).toContain("DISTINCT ON (up.id)");
+    expect(text).toContain("t.is_af_teacher = true");
+    expect(text).toContain("t.exit_date IS NULL");
+    expect(text).toContain("up.revoked_at IS NULL");
+    expect(text).toContain("cp.deleted_at IS NULL");
+    expect(text).toContain("NOT (cp.role = ANY($2::text[]))");
+    expect(text).toContain("c.is_active IS TRUE");
+    expect(text).toContain("JOIN school s ON s.id = c.school_id");
+    expect(text).toContain("WHERE s.code = $1");
+    expect(text).toContain("COALESCE(");
+    expect(text).not.toContain("LIMIT 1");
+    expect(text).not.toContain("up.role = 'teacher'");
+    expect(text).not.toContain("school_codes @>");
+    expect(text).not.toContain("regions @>");
+  });
+});

--- a/src/lib/visit-teachers.ts
+++ b/src/lib/visit-teachers.ts
@@ -1,0 +1,46 @@
+import { query } from "./db";
+import { PM_SEAT_ROLES } from "./staff-shared";
+
+export interface VisitTeacher {
+  id: number;
+  email: string;
+  full_name: string;
+}
+
+export async function getVisitTeachersForSchool(
+  schoolCode: string
+): Promise<VisitTeacher[]> {
+  return query<VisitTeacher>(
+    `WITH visit_teachers AS (
+       SELECT DISTINCT ON (up.id)
+         up.id,
+         up.email,
+         COALESCE(
+           NULLIF(BTRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''),
+           NULLIF(BTRIM(up.full_name), ''),
+           up.email
+         ) AS full_name
+       FROM teacher t
+       JOIN "user" u ON u.id = t.user_id
+       JOIN user_permission up
+         ON up.revoked_at IS NULL
+        AND (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+       JOIN centre_positions cp
+         ON cp.user_id = u.id
+        AND cp.deleted_at IS NULL
+        AND NOT (cp.role = ANY($2::text[]))
+       JOIN centres c
+         ON c.id = cp.centre_id
+        AND c.is_active IS TRUE
+       JOIN school s ON s.id = c.school_id
+       WHERE s.code = $1
+         AND t.is_af_teacher = true
+         AND t.exit_date IS NULL
+       ORDER BY up.id
+     )
+     SELECT id, email, full_name
+     FROM visit_teachers
+     ORDER BY full_name ASC, email ASC`,
+    [schoolCode, [...PM_SEAT_ROLES]]
+  );
+}


### PR DESCRIPTION
## Summary

- Replaces School Visit teacher sourcing with the Staff Management Visit Teacher roster via a shared server-only lookup.
- Keeps `/api/pm/teachers?school_code=...` API-compatible while returning active real AF teachers with active LMS permissions and active teacher-type Centre seats at active Centres linked to the requested School.
- Reuses the same Visit Teacher source for Individual AF Teacher Interaction completion validation, so broad permission-only teachers no longer block completion.
- Updates focused unit tests, route tests, E2E fixtures, and visit E2E assertions for the Staff Management roster source.
- Updates `.mex` visit context and E2E fixture debugging notes to record the new teacher-picker source and fixture gotchas.

## Linked Issues

- Closes #138
- Closes #139
- Closes #140

## Final Review

- Final review passed with no acceptance blockers, behavioral regressions, permission bypasses, SQL interpolation issues, server/client boundary issues, GPS logging issues, or scope creep requiring implementation changes.
- Quality checks passed: `npm test` (2410 passed, 3 skipped), `npm run lint` (0 errors, 18 warnings), `npm run build`, and `npm run test:e2e` (65/65 passed).
- Acceptance criteria verified for #139 and #140: the shared lookup is Staff Management-backed, excludes ineligible teachers and PM-family seats, dedupes by active `user_permission.id`, preserves the API response shape, and is reused by Individual AF Teacher Interaction completion validation.

## Human QA Checklist

- [ ] As a PM with School Visit access, open a Visit for a School with active Staff Management teacher seats and confirm Classroom Observation teacher picker shows only seated Visit Teachers.
- [ ] Confirm AF Team Interaction and Individual AF Teacher Interaction use the same teacher list as Classroom Observation.
- [ ] Confirm a broad LMS `role = "teacher"` permission user who is not seated in Staff Management does not appear in pickers.
- [ ] Confirm exited teachers, pending teachers, inactive Centre seats, inactive Centres, unlinked Centres, and PM-family seats do not appear.
- [ ] Confirm a School with multiple active linked Centres shows the union of eligible Visit Teachers without duplicate rows for the same active permission.
- [ ] Confirm a School with no Staff Management Visit Teachers shows the existing empty teacher picker state and does not fall back to broad LMS teacher permissions.
- [ ] End an Individual AF Teacher Interaction after recording all current Visit Teachers and confirm completion succeeds.
- [ ] Try ending an Individual AF Teacher Interaction with a current Visit Teacher missing and confirm the missing-teacher validation message names the missing teacher.
- [ ] Open an existing Visit summary with historical teacher names and confirm saved names still render without migration or rewriting.
