### PR TITLE
Academic Mentorship mentor-mentee mappings

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -20,7 +20,7 @@ edges:
     condition: when working on PM school visits or visit action types
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-07-01
+last_updated: 2026-07-02
 ---
 
 # Session Bootstrap
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, direct LMS-owned mapping writes, and Staff Management delete/exit safeguards for Academic Mentors with Mapping history.
+- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with Program filtering, current-year manual add/remove/reassign controls, CSV template/upload import for selected years, selector options API, direct LMS-owned mapping writes, and Staff Management delete/exit safeguards for Academic Mentors with Mapping history.
 - Deploy via AWS Amplify; ~2472 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, and direct LMS-owned mapping writes.
+- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, and direct LMS-owned mapping writes.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove controls, selector options API, and direct LMS-owned mapping writes.
+- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, selector options API, and direct LMS-owned mapping writes.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` read-only grouped mapping overview, and `/api/academic-mentorship/mappings`.
+- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove controls, selector options API, and direct LMS-owned mapping writes.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`; teacher pickers use the Staff Management Visit Teacher roster.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with Program filtering, current-year manual add/remove/reassign controls, CSV template/upload import for selected years, selector options API, direct LMS-owned mapping writes, and Staff Management delete/exit safeguards for Academic Mentors with Mapping history.
+- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with Program filtering, current-year manual add/remove/reassign controls, CSV template/upload import for supported years with prior-year rows stored as historical, selector options API, direct LMS-owned mapping writes, and Staff Management delete/exit safeguards for Academic Mentors with Mapping history.
 - Deploy via AWS Amplify; ~2472 unit tests (Vitest/RTL) + 65 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,7 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, selector options API, and direct LMS-owned mapping writes.
+- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, and direct LMS-owned mapping writes.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -20,7 +20,7 @@ edges:
     condition: when working on PM school visits or visit action types
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-06-25
+last_updated: 2026-07-01
 ---
 
 # Session Bootstrap
@@ -37,6 +37,7 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
+- Academic Mentorship foundation: `academic_mentorship` feature key, guarded `/admin/academic-mentorship` read-only grouped mapping overview, and `/api/academic-mentorship/mappings`.
 - Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -37,8 +37,8 @@ Then read this file fully before doing anything else in this session.
 - Permission system: feature×role matrix, 3-level school scope, program/NVS gating, `read_only` downgrade, additive centre-seat scope.
 - PM school visits: GPS-tracked lifecycle + 7 visit action types (registry pattern), scoped by `visits-policy`.
 - Curriculum tracking, quiz sessions + quiz analytics (BigQuery), performance dashboard (DynamoDB), admin of users/schools/batches/centres/staff.
-- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, and direct LMS-owned mapping writes.
-- Deploy via AWS Amplify; ~1341 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
+- Academic Mentorship foundation: `academic_mentorship` feature key, School page current-year Mentorship tab views, guarded `/admin/academic-mentorship` grouped mapping overview with manual add/remove/reassign controls, CSV template/upload import, selector options API, direct LMS-owned mapping writes, and Staff Management delete/exit safeguards for Academic Mentors with Mapping history.
+- Deploy via AWS Amplify; ~2472 unit tests (Vitest/RTL) + ~39 E2E (Playwright).
 
 **Not yet built / in progress:**
 - Centre rollout is mid-migration: `PROGRAM_IDS` is still hand-maintained in `src/lib/constants.ts` (target is reading `program` from the DB); non-JNV centre programs are being onboarded.

--- a/.mex/context/data-access.md
+++ b/.mex/context/data-access.md
@@ -31,7 +31,7 @@ Five backends. Picking the wrong one for a write is a real bug — read this bef
 ## 1. PostgreSQL — `query()` (the default)
 `import { query } from "@/lib/db"` → `query<RowType>(sql, params)`. Returns `rows`.
 - **All reads** (lists, dashboards, detail pages, scope resolution).
-- **Direct writes** for LMS-owned tables only: PM visits (`lms_pm_school_visits`, `lms_pm_school_visit_actions`), curriculum, permissions/centre tables.
+- **Direct writes** for LMS-owned tables only: PM visits (`lms_pm_school_visits`, `lms_pm_school_visit_actions`), curriculum, permissions/centre tables, and Academic Mentor-Mentee Mappings.
 - Multi-statement writes: `withTransaction(async (client) => { ... })` (no nesting — it throws).
 - Pool is a singleton (10 conns, 15s `statement_timeout`, 5s connect timeout). **Always `$1` placeholders.** This module is server-only — never import it (transitively) into a client component.
 - DB naming: Ecto — `inserted_at`/`updated_at`, snake_case, server TZ UTC. Derive IST dates in SQL: `(NOW() AT TIME ZONE 'Asia/Kolkata')::date`.
@@ -65,7 +65,7 @@ if (!res.ok) { const text = await res.text(); /* surface upstream error */ }
 | Operation | Backend |
 |-----------|---------|
 | Any read / list / dashboard | Postgres `query()` |
-| Visit / curriculum / permissions / centre write | Postgres `query()` (direct) |
+| Visit / curriculum / permissions / centre / Academic Mentor-Mentee Mapping write | Postgres `query()` (direct) |
 | Student / batch / quiz-session / document-metadata write | DB Service `fetch` (Bearer token) |
 | Quiz analytics read | BigQuery (`bigquery.ts`) |
 | Performance deep-dive read | DynamoDB (`dynamodb.ts`) |

--- a/.mex/context/permissions.md
+++ b/.mex/context/permissions.md
@@ -22,13 +22,14 @@ edges:
     condition: when a user is wrongly denied or wrongly granted access
   - target: patterns/add-api-route.md
     condition: when adding a route that needs gating
-last_updated: 2026-06-25
+last_updated: 2026-07-01
 ---
 
 # Permissions
 
 Core file: `src/lib/permissions.ts`. Client-safe constants: `src/lib/constants.ts`
-(`PROGRAM_IDS`, `PROGRAM_ID_TO_LABEL`). Auth config: `src/lib/auth.ts`.
+(`PROGRAM_IDS`, `PROGRAM_ID_TO_LABEL`, `ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST`).
+Auth config: `src/lib/auth.ts`.
 
 ## The model — three independent axes
 1. **Role** (`UserRole`): `teacher` | `program_manager` | `program_admin` | `admin`.
@@ -40,7 +41,8 @@ A `read_only` flag downgrades any `edit` to `view`.
 ## Feature access — the matrix
 `getFeatureAccess(permission, feature, opts?)` returns `{ access, canView, canEdit }`:
 - Looks up `FEATURE_PERMISSIONS[feature][role]` (`none`/`view`/`edit`).
-- **NVS gating:** features in `NVS_GATED_FEATURES` (`visits`, `curriculum`, `mentorship`, `pm_dashboard`, `summary_stats`, `quiz_sessions`) become `none` unless the user `hasCoEOrNodal`.
+- **NVS gating:** features in `NVS_GATED_FEATURES` (`visits`, `curriculum`, `pm_dashboard`, `summary_stats`, `quiz_sessions`) become `none` unless the user `hasCoEOrNodal`.
+- **Academic Mentorship:** uses the `academic_mentorship` feature key and its own Program allowlist (`ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST`, v1 wildcard `*`), so NVS-only users are not blocked by the NVS-gated feature set.
 - **`read_only` downgrade:** `edit` → `view`.
 - **Passcode users** (`opts.isPasscodeUser`): `students` → `edit`, everything else → `none`.
 
@@ -53,6 +55,7 @@ Per-row ownership uses `ownsRecord(permission, programId)` — admins own all, n
 
 ## The gate — what to call
 - **General routes:** `getServerSession(authOptions)` → `isAdmin(email)` (admin-only) or `canAccessSchool(email, code, region?)` / `canAccessStudent(session, studentId, { requireEdit })`.
+- **Academic Mentorship routes:** use `requireAcademicMentorshipAccess(session, "view"|"edit", { schoolCode? })` from `src/lib/academic-mentorship.ts`.
 - **Visit routes:** use `src/lib/visits-policy.ts` instead — `requireVisitsAccess(session, "view"|"edit")` then `enforceVisit*`. See `context/visits.md`.
 - **List queries:** scope at the SQL level with `getAccessibleSchoolCodes(email)` (returns `"all"` or `string[]`) or, for visits, `buildVisitScopePredicate(actor)`.
 

--- a/.mex/context/permissions.md
+++ b/.mex/context/permissions.md
@@ -56,6 +56,7 @@ Per-row ownership uses `ownsRecord(permission, programId)` — admins own all, n
 ## The gate — what to call
 - **General routes:** `getServerSession(authOptions)` → `isAdmin(email)` (admin-only) or `canAccessSchool(email, code, region?)` / `canAccessStudent(session, studentId, { requireEdit })`.
 - **Academic Mentorship routes:** use `requireAcademicMentorshipAccess(session, "view"|"edit", { schoolCode? })` from `src/lib/academic-mentorship.ts`.
+- **School page Mentorship tab:** visibility comes from `academic_mentorship` feature access. Teachers see only their own current-year active Mentees; PMs/Admins/Program Admins see a read-only School overview; only Admins and Program Admins get the management link.
 - **Visit routes:** use `src/lib/visits-policy.ts` instead — `requireVisitsAccess(session, "view"|"edit")` then `enforceVisit*`. See `context/visits.md`.
 - **List queries:** scope at the SQL level with `getAccessibleSchoolCodes(email)` (returns `"all"` or `string[]`) or, for visits, `buildVisitScopePredicate(actor)`.
 

--- a/.mex/context/permissions.md
+++ b/.mex/context/permissions.md
@@ -43,6 +43,7 @@ A `read_only` flag downgrades any `edit` to `view`.
 - Looks up `FEATURE_PERMISSIONS[feature][role]` (`none`/`view`/`edit`).
 - **NVS gating:** features in `NVS_GATED_FEATURES` (`visits`, `curriculum`, `pm_dashboard`, `summary_stats`, `quiz_sessions`) become `none` unless the user `hasCoEOrNodal`.
 - **Academic Mentorship:** uses the `academic_mentorship` feature key and its own Program allowlist (`ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST`, v1 wildcard `*`), so NVS-only users are not blocked by the NVS-gated feature set.
+- **Staff Management Academic Mentor safeguards:** deleting a Teacher-linked permission blocks on any Academic Mentor-Mentee Mapping history; Teacher exit/revoke blocks only on active Mentees. These checks use `academic_mentorship_mentor_mentee_mappings.mentor_user_id` (`user.id`), not `user_permission.id`, and blocker messages link back to `/admin/academic-mentorship` when School/year context is available.
 - **`read_only` downgrade:** `edit` → `view`.
 - **Passcode users** (`opts.isPasscodeUser`): `students` → `edit`, everything else → `none`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,32 @@ _Avoid_: Viewer, observer
 Numeric access scope: Level 3 = all schools, Level 2 = region, Level 1 = specific school codes.
 _Avoid_: Access tier, role level
 
+### Academic Mentorship
+
+**Academic Mentorship**:
+The LMS domain for assigning teacher mentors to selected students for a school and academic year.
+_Avoid_: Mentorship tab, holistic mentorship, AI report generation
+
+**Academic Mentor**:
+A completed Staff Management Teacher who is eligible to be assigned responsibility for one or more Mentees at their school.
+_Avoid_: Pending teacher, owner, counsellor
+
+**Mentee**:
+A Student assigned to an Academic Mentor for the academic year.
+_Avoid_: Learner, advisee
+
+**Academic Mentor-Mentee Mapping**:
+A historical assignment record connecting one Academic Mentor to one Mentee for one school and academic year.
+_Avoid_: Pairing, link row, live assignment only
+
+**Academic Mentorship Mentor-Mentee Mapping Table**:
+The database table `academic_mentorship_mentor_mentee_mappings`, storing Academic Mentor-Mentee Mapping history.
+_Avoid_: `acad_mentorship_teacher_feedback`, report-generation tables
+
+**Mentorship Tab**:
+The School page umbrella surface for school mentorship workflows.
+_Avoid_: Academic Mentorship tab
+
 ## Relationships
 
 - A **School** has many **Students** (via `group` → `group_user`)
@@ -187,6 +213,87 @@ _Avoid_: Access tier, role level
 - In Curriculum, **Exam Track** is selected before grade and subject; available subjects are filtered by the selected **Exam Track**
 - Curriculum chapter order follows **LMS Chapter Exam Config** coverage order before falling back to chapter code
 - Deleting an **LMS Curriculum Log** means soft deletion, so covered-topic and teaching-time progress ignores it without losing audit history
+- **Academic Mentorship** uses the `academic_mentorship` permission key and is part of the same mentorship product language as AI Mentorship Guide, not a separate generic "mentorship" feature
+- The School page **Mentorship Tab** remains labelled `Mentorship`; **Academic Mentorship** is one workflow inside that tab
+- An **Academic Mentor** must be a completed Staff Management Teacher: active LMS permission with teacher role, a real AF `teacher` record, a non-exited Staff Management state, and effective access to the selected School
+- The Academic Mentor dropdown includes eligible Academic Mentors even if they already have active Mentees
+- Academic Mentorship mentor selectors are searchable by mentor name and email
+- Academic Mentorship uses a dedicated Program allowlist, separate from the existing CoE/Nodal-only gate used by other LMS features
+- Academic Mentorship allowed Program gating uses a code constant in v1
+- Academic Mentorship can proceed with the approved Program gating list set to `[*]` (all Programs) while exact Program ids are confirmed later
+- Exact Academic Mentorship allowed Program ids are not a blocker for the rest of requirements grilling; confirm before implementation and update the code constant when needed
+- Academic Mentor and Mentee eligibility requires the same selected School and an allowed Academic Mentorship Program; Mentor and Mentee do not need to be in the same Program
+- **Academic Mentor-Mentee Mappings** store the Academic Mentor as the mentor's `user.id`; `teacher` is joined only for completed Staff Management eligibility and display metadata
+- An **Academic Mentor** can have many **Mentees** in an academic year
+- A **Mentee** has at most one active **Academic Mentor-Mentee Mapping** per school and academic year
+- A **Mentee** can have multiple historical **Academic Mentor-Mentee Mappings** in one academic year when they are removed from mentorship and later selected again, or when they are reassigned from one Academic Mentor to another
+- The db-service table for **Academic Mentor-Mentee Mappings** is `academic_mentorship_mentor_mentee_mappings`
+- The **Academic Mentorship Mentor-Mentee Mapping Table** stores `id`, `school_id`, nullable `program_id`, `academic_year`, `mentor_user_id`, `student_id`, `assigned_at`, `assigned_by_user_id`, `ended_at`, `ended_by_user_id`, optional `end_reason`, and normal timestamps
+- `assigned_by_user_id` and `ended_by_user_id` on the **Academic Mentorship Mentor-Mentee Mapping Table** reference `user.id`, not `user_permission.id`, because mappings audit the person taking the action rather than the person's mutable permission row
+- `program_id` on the **Academic Mentorship Mentor-Mentee Mapping Table** is nullable in v1 and stores the Mentee's roster Program when available
+- New **Academic Mentor-Mentee Mappings** auto-fill nullable `program_id` from the selected Mentee's current roster program when available; otherwise it stays null
+- The **Academic Mentorship Mentor-Mentee Mapping Table** enforces one active mapping per Mentee per School and academic year with a partial unique index on `(school_id, academic_year, student_id)` where `ended_at IS NULL`
+- **Academic Mentor-Mentee Mappings** preserve history when removed or reassigned
+- Staff Management hard delete blocks Teachers with any Academic Mentor-Mentee Mapping history
+- Staff Management exit/revoke blocks Teachers only when they have active Mentees; historical mappings can remain after exit
+- Staff Management shows a warning/blocking message when Teacher delete or exit/revoke is blocked by Academic Mentor-Mentee Mappings
+- Staff Management mentorship block warnings include active Mentee count and a link to `/admin/academic-mentorship` for the relevant School and academic year when available
+- Manual reassignment is a dedicated Reassign action on an existing active **Academic Mentor-Mentee Mapping**
+- The Add Mapping form only shows unassigned **Mentees**; it does not implicitly reassign already-mapped Students
+- Academic Mentorship student selectors are searchable by Student name and external `student_id`
+- The Academic Mentorship admin table defaults to active mappings only, grouped by Academic Mentor
+- The Academic Mentorship admin table shows a Mentee count in each Academic Mentor group header
+- Academic Mentorship mapping rows show Mentee name, grade, external `student_id`, assigned date, and status; when Show history is enabled, rows also show ended date
+- Academic Mentorship mapping rows do not show `program_id`, `assigned_by_user_id`, or `ended_by_user_id` by default in v1; those fields stay stored for audit and future use
+- Active Academic Mentorship mapping rows show Reassign and Remove actions for users with edit access; historical mapping rows show no actions
+- Removing an active Academic Mentor-Mentee Mapping requires confirmation that the Student will no longer have an active Academic Mentor
+- Reassigning an active Academic Mentor-Mentee Mapping requires confirmation that the old mapping will be ended and a new mapping will be created
+- If a manual add fails because the Student was already mapped concurrently, the UI shows "Student already has a mentor mapped" and refreshes the table
+- After manual add, remove, or reassign succeeds, the UI shows a small success message and refreshes the mapping table automatically
+- Reassignment excludes the current active Academic Mentor from the replacement Academic Mentor options
+- The Academic Mentorship admin table can include historical mappings via a Show history toggle that extends the same view
+- Academic Mentorship grouped overview only shows Academic Mentors who have mappings in the selected view and academic year
+- The `/admin/academic-mentorship` page is accessible only to Admins and Program Admins; Teachers use only the School page Mentorship Tab
+- Admins and Program Admins see a read-only overview on the School page Mentorship Tab, with management actions kept on `/admin/academic-mentorship`
+- Admins and Program Admins see a Manage mappings link from the School page Mentorship Tab to `/admin/academic-mentorship`; read-only Program Admins land there in view-only mode
+- The Manage mappings link preselects the current School and current academic year on `/admin/academic-mentorship` via query params
+- The School page Mentorship Tab shows the current academic year only, with no academic year picker
+- Passcode users do not see the School page Mentorship Tab; Academic Mentorship is for Google-login staff governed by Staff Management permissions
+- Program Managers do not get an admin page link for Academic Mentorship; they use only the School page Mentorship Tab read-only view
+- Academic Mentorship APIs live under `/api/academic-mentorship/*`, with route handlers checking role, School scope, Program allowlist, and requested action
+- Academic Mentorship route handlers use a shared server-side access helper for role, School scope, Program allowlist, `read_only`, and requested action checks
+- The `/admin/academic-mentorship` School picker auto-selects when the user has exactly one accessible School; otherwise it starts empty and asks the user to pick a School
+- The `/admin/academic-mentorship` academic year options reuse the existing LMS current-academic-year source and show current plus two prior academic years
+- The `/admin/academic-mentorship` page allows edits for the current and prior academic years shown in the picker; assignment and end timestamps still use the actual action time
+- The `/admin/academic-mentorship` page blocks edits for academic years outside the supported picker years, even if a user manually changes URL params
+- The `/admin/academic-mentorship` selected School and academic year are reflected in URL query params such as `school_code` and `academic_year`
+- Teachers see only their current active Mentees on the School page Mentorship Tab as a flat list sorted by grade, then name
+- Teacher empty state for the School page Mentorship Tab is "No mentees assigned for this academic year."
+- Program Managers see active Academic Mentor-Mentee Mappings only on the School page Mentorship Tab in v1; history stays on the admin management page
+- Ending an **Academic Mentor-Mentee Mapping** does not ask for a reason in v1; `end_reason` stays optional in the table for later use
+- In v1, **Academic Mentor-Mentee Mapping** assignment and end timestamps are system-recorded when the action happens; admins do not backdate assignment or removal dates
+- Academic Mentorship CSV upload identifies mentors by email and mentees by external `student.student_id`; stored mappings still use internal Main DB ids
+- The Academic Mentorship admin page provides a CSV template download with `mentor_email,student_id` headers
+- Academic Mentorship CSV upload validates `mentor_email` as an eligible completed Staff Management Teacher at the selected School
+- Academic Mentorship CSV upload validates `student_id` as an active roster Student at the selected School and academic year
+- Academic Mentorship CSV upload applies to the page-selected academic year, which defaults to the current academic year; CSV files do not include an academic year column
+- Academic Mentorship CSV upload requires `mentor_email` and `student_id` headers but allows extra columns and ignores them
+- Academic Mentorship CSV upload shows a normal file-level error, not an error CSV, when the file is empty or required headers are missing
+- Academic Mentorship CSV upload trims `mentor_email` and `student_id`; mentor email lookup is case-insensitive, while `student_id` matches trimmed exact text
+- Academic Mentorship CSV upload ignores completely blank rows; rows with one required field present and another required field blank produce row-level validation errors
+- Academic Mentorship CSV upload is capped at 2,000 data rows in v1
+- Academic Mentorship CSV upload fails the whole file when a row targets a student who already has an active Academic Mentor-Mentee Mapping; the validation error must include the CSV row number and say the student already has a mentor mapped
+- Academic Mentorship CSV upload fails the whole file when the same `student_id` appears more than once in the CSV; duplicate rows should be reported as duplicate student rows in the file
+- Academic Mentorship CSV upload should let admins download an error CSV containing only rejected rows and an error reason column
+- Academic Mentorship CSV error downloads include the original uploaded columns plus an `error_reason` column
+- Academic Mentorship CSV validation row numbers match spreadsheet row numbers: the header is row 1, and the first data row is row 2
+- Successful Academic Mentorship CSV upload shows a success count, and the mapping table refreshes automatically
+- Academic Mentorship v1 does not include a general "Export mappings CSV" action
+- Academic Mentorship mentee selection uses the same active-student rules as the School page roster for the selected School and academic year, excluding dropouts and students who already have an active mapping
+- Academic Mentorship access in v1 is controlled by role, school scope, `read_only`, and the Academic Mentorship Program allowlist
+- Academic Mentorship data model supports all programs, including NVS and PMU schools
+- `program_admin` users can enter `/admin` only to discover Academic Mentorship management; existing admin-only cards remain restricted to `admin`
+- `read_only` downgrades Academic Mentorship management to view-only
 - A **PM** creates **Visits** to a **School**
 - A **Visit** has many **Actions** (each with an **Action Type**)
 - A **Visit** can only be completed when all 7 **Action Types** have at least one completed **Action**
@@ -212,3 +319,4 @@ _Avoid_: Access tier, role level
 - Centre option labels are configurable option data; Centre rows should store stable codes rather than labels.
 - "admin" vs "program_admin": These are distinct roles. `admin` has write access; `program_admin` is read-only. The naming is confusing — always use the full term.
 - "deleted" for actions vs visits: Actions already support soft delete (`deleted_at` on `lms_pm_school_visit_actions`). Issue #35 extends this to visits (`lms_pm_school_visits`).
+- "mentorship" as a UI label vs permission key: the School page tab stays **Mentorship Tab** as an umbrella, while the internal feature key and domain term are **Academic Mentorship** / `academic_mentorship`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -268,8 +268,8 @@ _Avoid_: Academic Mentorship tab
 - Academic Mentorship route handlers use a shared server-side access helper for role, School scope, Program allowlist, `read_only`, and requested action checks
 - The `/admin/academic-mentorship` School picker auto-selects when the user has exactly one accessible School; otherwise it starts empty and asks the user to pick a School
 - The `/admin/academic-mentorship` academic year options reuse the existing LMS current-academic-year source and show current plus two prior academic years
-- The `/admin/academic-mentorship` page allows edits for the current and prior academic years shown in the picker; assignment and end timestamps still use the actual action time
-- The `/admin/academic-mentorship` page blocks edits for academic years outside the supported picker years, even if a user manually changes URL params
+- The `/admin/academic-mentorship` page allows manual add, remove, and reassign only for the current academic year; assignment and end timestamps use the actual action time
+- Academic Mentorship CSV import allows only the current plus two prior academic years shown in the picker; unsupported years are rejected server-side even if a user crafts a direct API request
 - The `/admin/academic-mentorship` selected School and academic year are reflected in URL query params such as `school_code` and `academic_year`
 - Teachers see only their current active Mentees on the School page Mentorship Tab as a flat list sorted by grade, then name
 - Teacher empty state for the School page Mentorship Tab is "No mentees assigned for this academic year."
@@ -281,6 +281,7 @@ _Avoid_: Academic Mentorship tab
 - Academic Mentorship CSV upload validates `mentor_email` as an eligible completed Staff Management Teacher at the selected School
 - Academic Mentorship CSV upload validates `student_id` as an active roster Student at the selected School and academic year
 - Academic Mentorship CSV upload applies to the page-selected academic year, which defaults to the current academic year; CSV files do not include an academic year column
+- Academic Mentorship CSV uploads for prior academic years are inserted as historical mappings by setting `ended_at` and `ended_by_user_id`, so Staff Management does not treat them as active Mentees
 - Academic Mentorship CSV upload requires `mentor_email` and `student_id` headers but allows extra columns and ignores them
 - Academic Mentorship CSV upload shows a normal file-level error, not an error CSV, when the file is empty or required headers are missing
 - Academic Mentorship CSV upload trims `mentor_email` and `student_id`; mentor email lookup is case-insensitive, while `student_id` matches trimmed exact text

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -222,11 +222,11 @@ async function main() {
     }
 
     // CSV
-    const header = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"];
+    const header: (keyof Out)[] = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"];
     const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
     const csv = [header.join(",")].concat(
       out.sort((a,b)=> order.indexOf(a.bucket)-order.indexOf(b.bucket) || a.email.localeCompare(b.email))
-        .map((r)=>header.map((h)=>esc(String((r as any)[h] ?? ""))).join(","))
+        .map((r)=>header.map((h)=>esc(String(r[h] ?? ""))).join(","))
     ).join("\n");
     const outPath = path.resolve(cli.out);
     mkdirSync(path.dirname(outPath), { recursive: true });

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -49,6 +49,10 @@ function poolFromEnvFile(envFile: string, label: string): Pool {
     max: 4, connectionTimeoutMillis: 8000, statement_timeout: 30000,
   });
 }
+async function databaseName(pool: Pool): Promise<string> {
+  const result = await pool.query<{ d: string }>("SELECT current_database() d");
+  return result.rows[0].d;
+}
 const setsEqual = (a: Set<string>, b: Set<string>) => a.size === b.size && [...a].every((x) => b.has(x));
 const sortedList = (s: Iterable<string>) => [...s].sort();
 
@@ -72,43 +76,26 @@ type Out = {
   prod_role: string; staging_role: string; note: string;
 };
 
-function csvCell(value: string): string {
-  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+function promotionReportName(): string {
+  return "promotion-school-diff";
 }
 
-function writePromotionCsv(rows: Out[], bucketOrder: string[], outFile: string) {
-  const columns: (keyof Out)[] = [
-    "bucket",
-    "email",
-    "prod_role",
-    "staging_role",
-    "prod_access",
-    "staging_access",
-    "schools_added",
-    "schools_removed",
-    "note",
-  ];
-  const sortedRows = rows.sort(
-    (a, b) =>
-      bucketOrder.indexOf(a.bucket) - bucketOrder.indexOf(b.bucket) ||
-      a.email.localeCompare(b.email)
-  );
-  const csvRows = sortedRows.map((row) =>
-    columns.map((column) => csvCell(String(row[column] ?? ""))).join(",")
-  );
-  const target = path.resolve(outFile);
-  mkdirSync(path.dirname(target), { recursive: true });
-  writeFileSync(target, [columns.join(","), ...csvRows].join("\n") + "\n");
-  console.log(`\nCSV written to ${target} (${rows.length} rows; contains emails - gitignored dir)`);
+function openPromotionContext(argv: string[]) {
+  const cli = parseArgs(argv);
+  return {
+    cli,
+    staging: poolFromEnvFile(cli.stagingEnv, "STAGING"),
+    prod: poolFromEnvFile(cli.prodEnv, "PROD"),
+  };
 }
 
 async function main() {
-  const cli = parseArgs(process.argv.slice(2));
-  const staging = poolFromEnvFile(cli.stagingEnv, "STAGING");
-  const prod = poolFromEnvFile(cli.prodEnv, "PROD");
+  const { cli, staging, prod } = openPromotionContext(process.argv.slice(2));
   try {
-    const sName = (await staging.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
-    const pName = (await prod.query<{ d: string }>("SELECT current_database() d")).rows[0].d;
+    const [sName, pName] = await Promise.all([
+      databaseName(staging),
+      databaseName(prod),
+    ]);
 
     // --- DOMAIN: centre-linked schools in program 1/2 (staging = target model) ---
     const domRows = (await staging.query<{ code: string; name: string }>(
@@ -222,7 +209,7 @@ async function main() {
 
     // --- OUTPUT ---
     const order = ["LOST_ONLY", "CHANGED_BOTH", "GAINED_ONLY", "NEW_IN_STAGING", "UNCHANGED", "UNTOUCHED"];
-    console.log(`\n=== Promotion school-access diff — JNV CoE (1) + JNV Nodal (2), teachers & staff ===`);
+    console.log(`\n=== ${promotionReportName()} - JNV CoE (1) + JNV Nodal (2), teachers & staff ===`);
     console.log(`staging(target): ${sName}   prod(current): ${pName}`);
     console.log(`migration domain: ${DOMAIN.size} centre-linked schools in prog 1/2`);
     console.log(`people in scope: ${people.size}`);
@@ -253,6 +240,48 @@ async function main() {
     }
 
     writePromotionCsv(out, order, cli.out);
-  } finally { await staging.end(); await prod.end(); }
+  } finally {
+    await closePools(staging, prod);
+  }
 }
-main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });
+
+function csvCell(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function writePromotionCsv(rows: Out[], bucketOrder: string[], outFile: string) {
+  const columns: (keyof Out)[] = [
+    "bucket",
+    "email",
+    "prod_role",
+    "staging_role",
+    "prod_access",
+    "staging_access",
+    "schools_added",
+    "schools_removed",
+    "note",
+  ];
+  const sortedRows = rows.sort(
+    (a, b) =>
+      bucketOrder.indexOf(a.bucket) - bucketOrder.indexOf(b.bucket) ||
+      a.email.localeCompare(b.email)
+  );
+  const csvRows = sortedRows.map((row) =>
+    columns.map((column) => csvCell(String(row[column] ?? ""))).join(",")
+  );
+  const target = path.resolve(outFile);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, [columns.join(","), ...csvRows].join("\n") + "\n");
+  console.log(`\nCSV written to ${target} (${rows.length} rows; contains emails - gitignored dir)`);
+}
+
+async function closePools(staging: Pool, prod: Pool): Promise<void> {
+  await Promise.all([staging.end(), prod.end()]);
+}
+
+function reportFailure(error: unknown): void {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exitCode = 1;
+}
+
+void main().catch(reportFailure);

--- a/scripts/check-promotion-school-diff.ts
+++ b/scripts/check-promotion-school-diff.ts
@@ -65,6 +65,43 @@ type PersonAgg = {
   seated: boolean;
 };
 
+type Out = {
+  email: string; bucket: string;
+  prod_access: string; staging_access: string;
+  schools_added: string; schools_removed: string;
+  prod_role: string; staging_role: string; note: string;
+};
+
+function csvCell(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function writePromotionCsv(rows: Out[], bucketOrder: string[], outFile: string) {
+  const columns: (keyof Out)[] = [
+    "bucket",
+    "email",
+    "prod_role",
+    "staging_role",
+    "prod_access",
+    "staging_access",
+    "schools_added",
+    "schools_removed",
+    "note",
+  ];
+  const sortedRows = rows.sort(
+    (a, b) =>
+      bucketOrder.indexOf(a.bucket) - bucketOrder.indexOf(b.bucket) ||
+      a.email.localeCompare(b.email)
+  );
+  const csvRows = sortedRows.map((row) =>
+    columns.map((column) => csvCell(String(row[column] ?? ""))).join(",")
+  );
+  const target = path.resolve(outFile);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, [columns.join(","), ...csvRows].join("\n") + "\n");
+  console.log(`\nCSV written to ${target} (${rows.length} rows; contains emails - gitignored dir)`);
+}
+
 async function main() {
   const cli = parseArgs(process.argv.slice(2));
   const staging = poolFromEnvFile(cli.stagingEnv, "STAGING");
@@ -138,12 +175,6 @@ async function main() {
     }
 
     // --- CLASSIFY ---
-    type Out = {
-      email: string; bucket: string;
-      prod_access: string; staging_access: string;
-      schools_added: string; schools_removed: string;
-      prod_role: string; staging_role: string; note: string;
-    };
     const out: Out[] = [];
     const buckets: Record<string, number> = {};
     let totalAdded = 0, totalRemoved = 0;
@@ -221,17 +252,7 @@ async function main() {
       }
     }
 
-    // CSV
-    const header: (keyof Out)[] = ["bucket","email","prod_role","staging_role","prod_access","staging_access","schools_added","schools_removed","note"];
-    const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
-    const csv = [header.join(",")].concat(
-      out.sort((a,b)=> order.indexOf(a.bucket)-order.indexOf(b.bucket) || a.email.localeCompare(b.email))
-        .map((r)=>header.map((h)=>esc(String(r[h] ?? ""))).join(","))
-    ).join("\n");
-    const outPath = path.resolve(cli.out);
-    mkdirSync(path.dirname(outPath), { recursive: true });
-    writeFileSync(outPath, csv + "\n");
-    console.log(`\nCSV: ${outPath}  (${out.length} rows; contains emails — gitignored dir)`);
+    writePromotionCsv(out, order, cli.out);
   } finally { await staging.end(); await prod.end(); }
 }
 main().catch((e) => { console.error(e instanceof Error ? e.stack || e.message : e); process.exitCode = 1; });

--- a/scripts/import-pm-centres.ts
+++ b/scripts/import-pm-centres.ts
@@ -91,7 +91,7 @@ async function run(client: PoolClient, cli: Cli) {
   for (const p of people) {
     const email = p.email.toLowerCase();
     // resolve / create user
-    let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+    const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
     let userId: number;
     if (u.rows.length === 0) {
       const ins = await client.query<{ id: number }>(

--- a/scripts/mirror-seats-staging-to-prod.ts
+++ b/scripts/mirror-seats-staging-to-prod.ts
@@ -168,7 +168,7 @@ async function main() {
     const centreIdByKey = new Map<string, number | null>(); // null = needs-decision (skip its seats)
     for (const [ck, c] of centres) {
       // exact match by name+type+program
-      let found = await client.query<{ id: number; school_id: number | null }>(
+      const found = await client.query<{ id: number; school_id: number | null }>(
         `SELECT id, school_id FROM centres WHERE lower(name)=lower($1) AND coalesce(type_code,'')=coalesce($2,'') AND program_id IS NOT DISTINCT FROM $3`,
         [c.centre_name, c.type_code, c.program_id]
       );
@@ -217,7 +217,7 @@ async function main() {
     // ----- 2. USERS: resolve / reuse dot-variant / create -----
     const userIdByEmail = new Map<string, number>();
     for (const [email, p] of people) {
-      let u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
+      const u = await client.query<{ id: number }>(`SELECT id FROM "user" WHERE lower(email)=$1`, [email]);
       if (u.rows.length === 1) { userIdByEmail.set(email, u.rows[0].id); continue; }
       if (u.rows.length > 1) throw new Error(`Ambiguous target user email ${email} (${u.rows.length} rows)`);
       // try dot-variant

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -8,8 +8,8 @@ const {
   mockListAccessibleAcademicMentorshipSchools,
   mockGetAcademicMentorshipAcademicYears,
   mockListAcademicMentorshipMappings,
+  mockListAcademicMentorshipProgramSchoolLinks,
   mockListAcademicMentorshipProgramsForSchools,
-  mockFilterAcademicMentorshipSchoolsByProgram,
 } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
@@ -19,8 +19,8 @@ const {
   mockListAccessibleAcademicMentorshipSchools: vi.fn(),
   mockGetAcademicMentorshipAcademicYears: vi.fn(),
   mockListAcademicMentorshipMappings: vi.fn(),
+  mockListAcademicMentorshipProgramSchoolLinks: vi.fn(),
   mockListAcademicMentorshipProgramsForSchools: vi.fn(),
-  mockFilterAcademicMentorshipSchoolsByProgram: vi.fn(),
 }));
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
@@ -31,8 +31,8 @@ vi.mock("@/lib/academic-mentorship", () => ({
   listAccessibleAcademicMentorshipSchools: mockListAccessibleAcademicMentorshipSchools,
   getAcademicMentorshipAcademicYears: mockGetAcademicMentorshipAcademicYears,
   listAcademicMentorshipMappings: mockListAcademicMentorshipMappings,
+  listAcademicMentorshipProgramSchoolLinks: mockListAcademicMentorshipProgramSchoolLinks,
   listAcademicMentorshipProgramsForSchools: mockListAcademicMentorshipProgramsForSchools,
-  filterAcademicMentorshipSchoolsByProgram: mockFilterAcademicMentorshipSchoolsByProgram,
   isValidAcademicYear: (value: string) => /^\d{4}-\d{4}$/.test(value),
   isAcademicMentorshipEditableYear: (value: string) => value === "2026-2027",
 }));
@@ -75,10 +75,10 @@ describe("AcademicMentorshipPage", () => {
     mockListAcademicMentorshipProgramsForSchools.mockResolvedValue([
       { id: 64, name: "JNV NVS" },
     ]);
-    mockFilterAcademicMentorshipSchoolsByProgram.mockImplementation(
-      async (schools: Array<{ id: number; code: string; name: string; region: string | null }>) =>
-        schools
-    );
+    mockListAcademicMentorshipProgramSchoolLinks.mockResolvedValue([
+      { programId: 64, schoolId: 20 },
+      { programId: 64, schoolId: 21 },
+    ]);
   });
 
   it("auto-selects the only accessible School and current academic year into the URL", async () => {
@@ -162,8 +162,8 @@ describe("AcademicMentorshipPage", () => {
       { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
       { id: 21, code: "SCH002", name: "Second School", region: "West" },
     ]);
-    mockFilterAcademicMentorshipSchoolsByProgram.mockResolvedValue([
-      { id: 21, code: "SCH002", name: "Second School", region: "West" },
+    mockListAcademicMentorshipProgramSchoolLinks.mockResolvedValue([
+      { programId: 64, schoolId: 21 },
     ]);
 
     await expect(

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -156,4 +156,26 @@ describe("AcademicMentorshipPage", () => {
       programId: null,
     });
   });
+
+  it("clears a School that is not available under the selected Program", async () => {
+    mockListAccessibleAcademicMentorshipSchools.mockResolvedValue([
+      { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      { id: 21, code: "SCH002", name: "Second School", region: "West" },
+    ]);
+    mockFilterAcademicMentorshipSchoolsByProgram.mockResolvedValue([
+      { id: 21, code: "SCH002", name: "Second School", region: "West" },
+    ]);
+
+    await expect(
+      AcademicMentorshipPage({
+        searchParams: Promise.resolve({
+          program_id: "64",
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+        }),
+      })
+    ).rejects.toThrow(
+      "REDIRECT:/admin/academic-mentorship?academic_year=2026-2027&program_id=64"
+    );
+  });
 });

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -8,6 +8,8 @@ const {
   mockListAccessibleAcademicMentorshipSchools,
   mockGetAcademicMentorshipAcademicYears,
   mockListAcademicMentorshipMappings,
+  mockListAcademicMentorshipProgramsForSchools,
+  mockFilterAcademicMentorshipSchoolsByProgram,
 } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
@@ -17,6 +19,8 @@ const {
   mockListAccessibleAcademicMentorshipSchools: vi.fn(),
   mockGetAcademicMentorshipAcademicYears: vi.fn(),
   mockListAcademicMentorshipMappings: vi.fn(),
+  mockListAcademicMentorshipProgramsForSchools: vi.fn(),
+  mockFilterAcademicMentorshipSchoolsByProgram: vi.fn(),
 }));
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
@@ -27,9 +31,10 @@ vi.mock("@/lib/academic-mentorship", () => ({
   listAccessibleAcademicMentorshipSchools: mockListAccessibleAcademicMentorshipSchools,
   getAcademicMentorshipAcademicYears: mockGetAcademicMentorshipAcademicYears,
   listAcademicMentorshipMappings: mockListAcademicMentorshipMappings,
+  listAcademicMentorshipProgramsForSchools: mockListAcademicMentorshipProgramsForSchools,
+  filterAcademicMentorshipSchoolsByProgram: mockFilterAcademicMentorshipSchoolsByProgram,
   isValidAcademicYear: (value: string) => /^\d{4}-\d{4}$/.test(value),
-  isAcademicMentorshipEditableYear: (value: string) =>
-    ["2026-2027", "2025-2026", "2024-2025"].includes(value),
+  isAcademicMentorshipEditableYear: (value: string) => value === "2026-2027",
 }));
 vi.mock("next/link", () => ({
   __esModule: true,
@@ -67,6 +72,13 @@ describe("AcademicMentorshipPage", () => {
       "2024-2025",
     ]);
     mockListAcademicMentorshipMappings.mockResolvedValue([]);
+    mockListAcademicMentorshipProgramsForSchools.mockResolvedValue([
+      { id: 64, name: "JNV NVS" },
+    ]);
+    mockFilterAcademicMentorshipSchoolsByProgram.mockImplementation(
+      async (schools: Array<{ id: number; code: string; name: string; region: string | null }>) =>
+        schools
+    );
   });
 
   it("auto-selects the only accessible School and current academic year into the URL", async () => {
@@ -104,6 +116,7 @@ describe("AcademicMentorshipPage", () => {
               name: "Meena Student",
               studentId: "STU001",
               grade: 11,
+              programId: 64,
             },
             assignedDate: "2026-07-01",
             endedDate: null,
@@ -121,6 +134,7 @@ describe("AcademicMentorshipPage", () => {
     });
     render(jsx);
 
+    expect(screen.getByLabelText("Program")).toHaveValue("");
     expect(screen.getByLabelText("School")).toHaveValue("SCH001");
     expect(screen.getByLabelText("Academic year")).toHaveValue("2026-2027");
     expect(screen.getByText("2025-2026")).toBeInTheDocument();
@@ -139,6 +153,7 @@ describe("AcademicMentorshipPage", () => {
       schoolId: 20,
       academicYear: "2026-2027",
       includeHistory: false,
+      programId: null,
     });
   });
 });

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const {
+  mockGetServerSession,
+  mockRedirect,
+  mockRequireAcademicMentorshipAccess,
+  mockListAccessibleAcademicMentorshipSchools,
+  mockGetAcademicMentorshipAcademicYears,
+  mockListAcademicMentorshipMappings,
+} = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+  mockRequireAcademicMentorshipAccess: vi.fn(),
+  mockListAccessibleAcademicMentorshipSchools: vi.fn(),
+  mockGetAcademicMentorshipAcademicYears: vi.fn(),
+  mockListAcademicMentorshipMappings: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("@/lib/academic-mentorship", () => ({
+  requireAcademicMentorshipAccess: mockRequireAcademicMentorshipAccess,
+  listAccessibleAcademicMentorshipSchools: mockListAccessibleAcademicMentorshipSchools,
+  getAcademicMentorshipAcademicYears: mockGetAcademicMentorshipAcademicYears,
+  listAcademicMentorshipMappings: mockListAcademicMentorshipMappings,
+  isValidAcademicYear: (value: string) => /^\d{4}-\d{4}$/.test(value),
+  isAcademicMentorshipEditableYear: (value: string) =>
+    ["2026-2027", "2025-2026", "2024-2025"].includes(value),
+}));
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import AcademicMentorshipPage from "./page";
+
+const session = { user: { email: "pa@avantifellows.org" } };
+const access = {
+  ok: true,
+  email: "pa@avantifellows.org",
+  permission: {
+    email: "pa@avantifellows.org",
+    level: 3,
+    role: "program_admin",
+    school_codes: null,
+    regions: null,
+    program_ids: [64],
+    read_only: false,
+  },
+  canEdit: true,
+};
+
+describe("AcademicMentorshipPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(session);
+    mockRequireAcademicMentorshipAccess.mockResolvedValue(access);
+    mockGetAcademicMentorshipAcademicYears.mockReturnValue([
+      "2026-2027",
+      "2025-2026",
+      "2024-2025",
+    ]);
+    mockListAcademicMentorshipMappings.mockResolvedValue([]);
+  });
+
+  it("auto-selects the only accessible School and current academic year into the URL", async () => {
+    mockListAccessibleAcademicMentorshipSchools.mockResolvedValue([
+      { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+    ]);
+
+    await expect(
+      AcademicMentorshipPage({ searchParams: Promise.resolve({}) })
+    ).rejects.toThrow(
+      "REDIRECT:/admin/academic-mentorship?school_code=SCH001&academic_year=2026-2027"
+    );
+  });
+
+  it("renders selectors and grouped active mappings for the selected School/year", async () => {
+    mockRequireAcademicMentorshipAccess
+      .mockResolvedValueOnce(access)
+      .mockResolvedValueOnce({
+        ...access,
+        school: { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      });
+    mockListAccessibleAcademicMentorshipSchools.mockResolvedValue([
+      { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      { id: 21, code: "SCH002", name: "Second School", region: "West" },
+    ]);
+    mockListAcademicMentorshipMappings.mockResolvedValue([
+      {
+        mentor: { userId: 101, name: "Anita Mentor", email: "anita@avantifellows.org" },
+        menteeCount: 1,
+        mappings: [
+          {
+            id: 1,
+            mentee: {
+              studentPkId: 201,
+              name: "Meena Student",
+              studentId: "STU001",
+              grade: 11,
+            },
+            assignedDate: "2026-07-01",
+            endedDate: null,
+            status: "active",
+          },
+        ],
+      },
+    ]);
+
+    const jsx = await AcademicMentorshipPage({
+      searchParams: Promise.resolve({
+        school_code: "SCH001",
+        academic_year: "2026-2027",
+      }),
+    });
+    render(jsx);
+
+    expect(screen.getByLabelText("School")).toHaveValue("SCH001");
+    expect(screen.getByLabelText("Academic year")).toHaveValue("2026-2027");
+    expect(screen.getByText("2025-2026")).toBeInTheDocument();
+    expect(screen.getByText("Anita Mentor")).toBeInTheDocument();
+    expect(screen.getByText("1 mentee")).toBeInTheDocument();
+    expect(screen.getByText("Meena Student")).toBeInTheDocument();
+    expect(screen.getByText("STU001")).toBeInTheDocument();
+    expect(screen.getByText("Grade 11")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Edit access")).toBeInTheDocument();
+    expect(screen.getByText("Show history").closest("a")).toHaveAttribute(
+      "href",
+      "/admin/academic-mentorship?school_code=SCH001&academic_year=2026-2027&include_history=true"
+    );
+    expect(mockListAcademicMentorshipMappings).toHaveBeenCalledWith({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      includeHistory: false,
+    });
+  });
+});

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -12,6 +12,7 @@ import {
   requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
 import { Card } from "@/components/ui";
+import AcademicMentorshipManager from "@/components/academic-mentorship/AcademicMentorshipManager";
 
 interface PageProps {
   searchParams?:
@@ -176,42 +177,17 @@ export default async function AcademicMentorshipPage({ searchParams }: PageProps
           )}
         </div>
 
-        <section className="mt-4 space-y-4">
-          {!selectedSchool ? (
-            <Card className="p-6 text-sm text-text-muted">Select a School to view mappings.</Card>
-          ) : groups.length === 0 ? (
-            <Card className="p-6 text-sm text-text-muted">
-              No Academic Mentor-Mentee Mappings found.
-            </Card>
-          ) : (
-            groups.map((group) => (
-              <Card key={group.mentor.userId} className="p-0">
-                <div className="border-b border-border px-4 py-3">
-                  <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
-                  <p className="text-sm text-text-muted">{group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}</p>
-                </div>
-                <div className="divide-y divide-border">
-                  {group.mappings.map((mapping) => (
-                    <div key={String(mapping.id)} className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px]">
-                      <div>
-                        <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
-                        <div className="text-sm text-text-muted">{mapping.mentee.studentId}</div>
-                      </div>
-                      <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
-                      <div className="text-sm text-text-muted">{mapping.assignedDate}</div>
-                      <div className="text-sm font-semibold text-text-primary">
-                        {mapping.status === "active" ? "Active" : "Historical"}
-                        {includeHistory && mapping.endedDate ? (
-                          <span className="block font-normal text-text-muted">Ended {mapping.endedDate}</span>
-                        ) : null}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-            ))
-          )}
-        </section>
+        {!selectedSchool ? (
+          <Card className="mt-4 p-6 text-sm text-text-muted">Select a School to view mappings.</Card>
+        ) : (
+          <AcademicMentorshipManager
+            schoolCode={selectedSchool.code}
+            academicYear={selectedAcademicYear}
+            includeHistory={includeHistory}
+            canEdit={canEdit}
+            initialGroups={groups}
+          />
+        )}
       </main>
     </div>
   );

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -11,7 +12,7 @@ import {
   listAccessibleAcademicMentorshipSchools,
   requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
-import { Card } from "@/components/ui";
+import { Badge, Card } from "@/components/ui";
 import AcademicMentorshipManager from "@/components/academic-mentorship/AcademicMentorshipManager";
 
 interface PageProps {
@@ -100,20 +101,25 @@ export default async function AcademicMentorshipPage({ searchParams }: PageProps
         includeHistory: !includeHistory,
       })
     : "#";
+  const accessLabel = canEdit ? "Edit access" : "View-only";
 
   return (
     <div className="min-h-screen bg-bg">
       <header className="bg-bg-card border-b border-border shadow-sm">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
           <div className="flex items-center gap-3">
-            <Link href="/admin" className="text-text-muted hover:text-text-primary p-1 -m-1">
-              <span aria-hidden="true">{"<"}</span>
+            <Link
+              href="/admin"
+              className="-m-1 inline-flex h-9 w-9 items-center justify-center rounded-md text-text-muted hover:bg-hover-bg hover:text-text-primary"
+              aria-label="Back to admin"
+            >
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
             </Link>
             <div>
-              <h1 className="text-xl sm:text-2xl font-bold text-text-primary uppercase tracking-tight">
+              <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
                 Academic Mentorship
               </h1>
-              <p className="text-xs text-text-muted font-mono">{session.user.email}</p>
+              <p className="font-mono text-xs text-text-muted">{session.user.email}</p>
             </div>
           </div>
           <Link href="/api/auth/signout" className="text-sm font-bold text-danger hover:text-danger/80">
@@ -123,31 +129,31 @@ export default async function AcademicMentorshipPage({ searchParams }: PageProps
       </header>
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <Card className="p-4">
-          <form action="/admin/academic-mentorship" className="grid gap-4 md:grid-cols-[1fr_220px_auto]">
-            <label className="grid gap-1 text-sm font-semibold text-text-primary" htmlFor="school_code">
+        <Card className="overflow-hidden p-4">
+          <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto] lg:items-end">
+            <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="school_code">
               School
               <select
                 id="school_code"
                 name="school_code"
                 defaultValue={selectedSchoolCode}
-                className="rounded-md border border-border bg-bg-card px-3 py-2 font-normal"
+                className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
               >
                 <option value="">Select a School</option>
                 {schools.map((school) => (
-                  <option key={school.code} value={school.code}>
+                  <option key={`${school.id}-${school.code}`} value={school.code}>
                     {school.name} ({school.code})
                   </option>
                 ))}
               </select>
             </label>
-            <label className="grid gap-1 text-sm font-semibold text-text-primary" htmlFor="academic_year">
+            <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="academic_year">
               Academic year
               <select
                 id="academic_year"
                 name="academic_year"
                 defaultValue={selectedAcademicYear}
-                className="rounded-md border border-border bg-bg-card px-3 py-2 font-normal"
+                className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
               >
                 {!academicYears.includes(selectedAcademicYear) && (
                   <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
@@ -160,18 +166,28 @@ export default async function AcademicMentorshipPage({ searchParams }: PageProps
               </select>
             </label>
             {includeHistory && <input type="hidden" name="include_history" value="true" />}
-            <button className="self-end rounded-md bg-accent px-4 py-2 text-sm font-bold text-white">
+            <button className="min-h-[44px] rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover">
               Apply
             </button>
           </form>
         </Card>
 
-        <div className="mt-4 flex items-center justify-between">
-          <div className="text-sm text-text-muted">
-            {canEdit ? "Edit access" : "View-only"}
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+            <Badge variant={canEdit ? "success" : "default"}>{accessLabel}</Badge>
+            {selectedSchool ? (
+              <span>
+                {selectedSchool.name} | <span className="font-mono">{selectedAcademicYear}</span>
+              </span>
+            ) : (
+              <span>Select a School to load mentorship mappings.</span>
+            )}
           </div>
           {selectedSchool && (
-            <Link href={historyHref} className="text-sm font-bold text-accent hover:text-accent-hover">
+            <Link
+              href={historyHref}
+              className="inline-flex min-h-9 w-fit items-center justify-center rounded-lg border border-border bg-bg-card px-3 text-sm font-bold text-accent hover:bg-hover-bg hover:text-accent-hover"
+            >
               {includeHistory ? "Hide history" : "Show history"}
             </Link>
           )}

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -6,12 +6,15 @@ import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
 import {
   getAcademicMentorshipAcademicYears,
+  filterAcademicMentorshipSchoolsByProgram,
   isAcademicMentorshipEditableYear,
   isValidAcademicYear,
   listAcademicMentorshipMappings,
+  listAcademicMentorshipProgramsForSchools,
   listAccessibleAcademicMentorshipSchools,
   requireAcademicMentorshipAccess,
   type AcademicMentorshipMappingGroup,
+  type AcademicMentorshipProgram,
   type AcademicMentorshipSchool,
 } from "@/lib/academic-mentorship";
 import { Badge, Card } from "@/components/ui";
@@ -35,11 +38,14 @@ interface PageModel {
   academicYears: string[];
   selectedAcademicYear: string;
   selectedSchoolCode: string;
+  selectedProgramId: number | null;
   includeHistory: boolean;
+  programs: AcademicMentorshipProgram[];
   schools: AcademicMentorshipSchool[];
   selectedSchool: AcademicMentorshipSchool | undefined;
   groups: AcademicMentorshipMappingGroup[];
   canEdit: boolean;
+  canUpload: boolean;
   historyHref: string;
   accessLabel: string;
 }
@@ -51,12 +57,14 @@ function firstParam(value: string | string[] | undefined): string {
 function selectionUrl(params: {
   schoolCode: string;
   academicYear: string;
+  programId?: number | null;
   includeHistory?: boolean;
 }) {
   const searchParams = new URLSearchParams({
     school_code: params.schoolCode,
     academic_year: params.academicYear,
   });
+  if (params.programId) searchParams.set("program_id", String(params.programId));
   if (params.includeHistory) searchParams.set("include_history", "true");
   return `/admin/academic-mentorship?${searchParams.toString()}`;
 }
@@ -71,9 +79,11 @@ async function requirePageAccess(session: Session) {
 }
 
 function selectedFilters(searchParams: SearchParams, academicYears: string[]) {
+  const programId = Number(firstParam(searchParams.program_id));
   return {
     academicYear: firstParam(searchParams.academic_year) || academicYears[0],
     schoolCode: firstParam(searchParams.school_code),
+    programId: Number.isInteger(programId) && programId > 0 ? programId : null,
     includeHistory: firstParam(searchParams.include_history) === "true",
   };
 }
@@ -81,10 +91,11 @@ function selectedFilters(searchParams: SearchParams, academicYears: string[]) {
 function historyUrl(
   schoolCode: string | undefined,
   academicYear: string,
+  programId: number | null,
   includeHistory: boolean
 ) {
   return schoolCode
-    ? selectionUrl({ schoolCode, academicYear, includeHistory: !includeHistory })
+    ? selectionUrl({ schoolCode, academicYear, programId, includeHistory: !includeHistory })
     : "#";
 }
 
@@ -106,6 +117,7 @@ function redirectToOnlySchool(params: {
   schools: AcademicMentorshipSchool[];
   selectedSchoolCode: string;
   selectedAcademicYear: string;
+  selectedProgramId: number | null;
   includeHistory: boolean;
 }) {
   if (params.selectedSchoolCode || params.schools.length !== 1) return;
@@ -113,6 +125,7 @@ function redirectToOnlySchool(params: {
     selectionUrl({
       schoolCode: params.schools[0].code,
       academicYear: params.selectedAcademicYear,
+      programId: params.selectedProgramId,
       includeHistory: params.includeHistory,
     })
   );
@@ -136,13 +149,15 @@ async function resolveSelectedAccess(
 async function loadSelectedGroups(
   selectedAccess: AcademicMentorshipOkAccess | null,
   selectedAcademicYear: string,
-  includeHistory: boolean
+  includeHistory: boolean,
+  programId: number | null
 ): Promise<AcademicMentorshipMappingGroup[]> {
   if (!selectedAccess?.school) return [];
   return listAcademicMentorshipMappings({
     schoolId: selectedAccess.school.id,
     academicYear: selectedAcademicYear,
     includeHistory,
+    programId,
   });
 }
 
@@ -165,11 +180,27 @@ async function loadPageModel(
   const {
     academicYear: selectedAcademicYear,
     schoolCode: selectedSchoolCode,
+    programId: selectedProgramId,
     includeHistory,
   } = selectedFilters(resolvedSearchParams, academicYears);
-  const schools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
+  const accessibleSchools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
+  const programs = await listAcademicMentorshipProgramsForSchools(
+    accessibleSchools.map((school) => school.id),
+    selectedAcademicYear
+  );
+  const schools = await filterAcademicMentorshipSchoolsByProgram(
+    accessibleSchools,
+    selectedAcademicYear,
+    selectedProgramId
+  );
 
-  redirectToOnlySchool({ schools, selectedSchoolCode, selectedAcademicYear, includeHistory });
+  redirectToOnlySchool({
+    schools,
+    selectedSchoolCode,
+    selectedAcademicYear,
+    selectedProgramId,
+    includeHistory,
+  });
 
   const selectedSchool = schools.find((school) => school.code === selectedSchoolCode);
   const selectedAccess = await resolveSelectedAccess(
@@ -180,21 +211,31 @@ async function loadPageModel(
   const groups = await loadSelectedGroups(
     selectedAccess,
     selectedAcademicYear,
-    includeHistory
+    includeHistory,
+    selectedProgramId
   );
   const canEdit = canEditSelection(selectedAccess, selectedAcademicYear);
-  const historyHref = historyUrl(selectedSchool?.code, selectedAcademicYear, includeHistory);
-  const accessLabel = canEdit ? "Edit access" : "View-only";
+  const canUpload = selectedAccess?.canEdit === true;
+  const historyHref = historyUrl(
+    selectedSchool?.code,
+    selectedAcademicYear,
+    selectedProgramId,
+    includeHistory
+  );
+  const accessLabel = canEdit ? "Edit access" : canUpload ? "CSV-only backfill" : "View-only";
 
   return {
     academicYears,
     selectedAcademicYear,
     selectedSchoolCode,
+    selectedProgramId,
     includeHistory,
+    programs,
     schools,
     selectedSchool,
     groups,
     canEdit,
+    canUpload,
     historyHref,
     accessLabel,
   };
@@ -231,19 +272,39 @@ function SelectionForm({
   academicYears,
   selectedAcademicYear,
   selectedSchoolCode,
+  selectedProgramId,
   includeHistory,
+  programs,
   schools,
 }: Pick<
   PageModel,
   | "academicYears"
   | "selectedAcademicYear"
   | "selectedSchoolCode"
+  | "selectedProgramId"
   | "includeHistory"
+  | "programs"
   | "schools"
 >) {
   return (
     <Card className="overflow-hidden p-4">
-      <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto] lg:items-end">
+      <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[220px_minmax(0,1fr)_220px_auto] lg:items-end">
+        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="program_id">
+          Program
+          <select
+            id="program_id"
+            name="program_id"
+            defaultValue={selectedProgramId ?? ""}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            <option value="">All programs</option>
+            {programs.map((program) => (
+              <option key={program.id} value={program.id}>
+                {program.name}
+              </option>
+            ))}
+          </select>
+        </label>
         <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="school_code">
           School
           <select
@@ -330,12 +391,20 @@ function SelectionSummary({
 function SelectedSchoolContent({
   selectedSchool,
   selectedAcademicYear,
+  selectedProgramId,
   includeHistory,
   canEdit,
+  canUpload,
   groups,
 }: Pick<
   PageModel,
-  "selectedSchool" | "selectedAcademicYear" | "includeHistory" | "canEdit" | "groups"
+  | "selectedSchool"
+  | "selectedAcademicYear"
+  | "selectedProgramId"
+  | "includeHistory"
+  | "canEdit"
+  | "canUpload"
+  | "groups"
 >) {
   if (!selectedSchool) {
     return <Card className="mt-4 p-6 text-sm text-text-muted">Select a School to view mappings.</Card>;
@@ -345,8 +414,10 @@ function SelectedSchoolContent({
     <AcademicMentorshipManager
       schoolCode={selectedSchool.code}
       academicYear={selectedAcademicYear}
+      programId={selectedProgramId}
       includeHistory={includeHistory}
       canEdit={canEdit}
+      canUpload={canUpload}
       initialGroups={groups}
     />
   );

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -144,7 +144,7 @@ function schoolsForProgram(
       .filter((link) => link.programId === programId)
       .map((link) => link.schoolId)
   );
-  return schools.filter((school) => schoolIds.has(school.id));
+  return schools.filter((school) => schoolIds.has(Number(school.id)));
 }
 
 function redirectInvalidSchoolSelection(params: {

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/academic-mentorship";
 import { Badge, Card } from "@/components/ui";
 import AcademicMentorshipManager from "@/components/academic-mentorship/AcademicMentorshipManager";
+import AcademicMentorshipSelectionForm from "@/components/academic-mentorship/AcademicMentorshipSelectionForm";
 
 interface PageProps {
   searchParams?:
@@ -55,15 +56,14 @@ function firstParam(value: string | string[] | undefined): string {
 }
 
 function selectionUrl(params: {
-  schoolCode: string;
+  schoolCode?: string;
   academicYear: string;
   programId?: number | null;
   includeHistory?: boolean;
 }) {
-  const searchParams = new URLSearchParams({
-    school_code: params.schoolCode,
-    academic_year: params.academicYear,
-  });
+  const searchParams = new URLSearchParams();
+  if (params.schoolCode) searchParams.set("school_code", params.schoolCode);
+  searchParams.set("academic_year", params.academicYear);
   if (params.programId) searchParams.set("program_id", String(params.programId));
   if (params.includeHistory) searchParams.set("include_history", "true");
   return `/admin/academic-mentorship?${searchParams.toString()}`;
@@ -124,6 +124,23 @@ function redirectToOnlySchool(params: {
   redirect(
     selectionUrl({
       schoolCode: params.schools[0].code,
+      academicYear: params.selectedAcademicYear,
+      programId: params.selectedProgramId,
+      includeHistory: params.includeHistory,
+    })
+  );
+}
+
+function redirectInvalidSchoolSelection(params: {
+  selectedSchoolCode: string;
+  selectedSchool: AcademicMentorshipSchool | undefined;
+  selectedAcademicYear: string;
+  selectedProgramId: number | null;
+  includeHistory: boolean;
+}) {
+  if (!params.selectedSchoolCode || params.selectedSchool) return;
+  redirect(
+    selectionUrl({
       academicYear: params.selectedAcademicYear,
       programId: params.selectedProgramId,
       includeHistory: params.includeHistory,
@@ -203,6 +220,13 @@ async function loadPageModel(
   });
 
   const selectedSchool = schools.find((school) => school.code === selectedSchoolCode);
+  redirectInvalidSchoolSelection({
+    selectedSchoolCode,
+    selectedSchool,
+    selectedAcademicYear,
+    selectedProgramId,
+    includeHistory,
+  });
   const selectedAccess = await resolveSelectedAccess(
     session,
     selectedSchool,
@@ -265,86 +289,6 @@ function PageHeader({ email }: { email: string }) {
         </Link>
       </div>
     </header>
-  );
-}
-
-function SelectionForm({
-  academicYears,
-  selectedAcademicYear,
-  selectedSchoolCode,
-  selectedProgramId,
-  includeHistory,
-  programs,
-  schools,
-}: Pick<
-  PageModel,
-  | "academicYears"
-  | "selectedAcademicYear"
-  | "selectedSchoolCode"
-  | "selectedProgramId"
-  | "includeHistory"
-  | "programs"
-  | "schools"
->) {
-  return (
-    <Card className="overflow-hidden p-4">
-      <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[220px_minmax(0,1fr)_220px_auto] lg:items-end">
-        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="program_id">
-          Program
-          <select
-            id="program_id"
-            name="program_id"
-            defaultValue={selectedProgramId ?? ""}
-            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-          >
-            <option value="">All programs</option>
-            {programs.map((program) => (
-              <option key={program.id} value={program.id}>
-                {program.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="school_code">
-          School
-          <select
-            id="school_code"
-            name="school_code"
-            defaultValue={selectedSchoolCode}
-            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-          >
-            <option value="">Select a School</option>
-            {schools.map((school) => (
-              <option key={`${school.id}-${school.code}`} value={school.code}>
-                {school.name} ({school.code})
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="academic_year">
-          Academic year
-          <select
-            id="academic_year"
-            name="academic_year"
-            defaultValue={selectedAcademicYear}
-            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-          >
-            {!academicYears.includes(selectedAcademicYear) && (
-              <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
-            )}
-            {academicYears.map((year) => (
-              <option key={year} value={year}>
-                {year}
-              </option>
-            ))}
-          </select>
-        </label>
-        {includeHistory && <input type="hidden" name="include_history" value="true" />}
-        <button className="min-h-[44px] rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover">
-          Apply
-        </button>
-      </form>
-    </Card>
   );
 }
 
@@ -433,7 +377,7 @@ export default async function AcademicMentorshipPage({ searchParams }: PageProps
       <PageHeader email={session.user.email} />
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <SelectionForm {...model} />
+        <AcademicMentorshipSelectionForm {...model} />
         <SelectionSummary {...model} />
         <SelectedSchoolContent {...model} />
       </main>

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -11,6 +11,8 @@ import {
   listAcademicMentorshipMappings,
   listAccessibleAcademicMentorshipSchools,
   requireAcademicMentorshipAccess,
+  type AcademicMentorshipMappingGroup,
+  type AcademicMentorshipSchool,
 } from "@/lib/academic-mentorship";
 import { Badge, Card } from "@/components/ui";
 import AcademicMentorshipManager from "@/components/academic-mentorship/AcademicMentorshipManager";
@@ -19,6 +21,27 @@ interface PageProps {
   searchParams?:
     | Promise<{ [key: string]: string | string[] | undefined }>
     | { [key: string]: string | string[] | undefined };
+}
+
+type SearchParams = { [key: string]: string | string[] | undefined };
+type Session = NonNullable<Awaited<ReturnType<typeof getServerSession>>>;
+type AuthenticatedSession = Session & { user: { email: string } };
+type AcademicMentorshipAccess = Awaited<
+  ReturnType<typeof requireAcademicMentorshipAccess>
+>;
+type AcademicMentorshipOkAccess = Extract<AcademicMentorshipAccess, { ok: true }>;
+
+interface PageModel {
+  academicYears: string[];
+  selectedAcademicYear: string;
+  selectedSchoolCode: string;
+  includeHistory: boolean;
+  schools: AcademicMentorshipSchool[];
+  selectedSchool: AcademicMentorshipSchool | undefined;
+  groups: AcademicMentorshipMappingGroup[];
+  canEdit: boolean;
+  historyHref: string;
+  accessLabel: string;
 }
 
 function firstParam(value: string | string[] | undefined): string {
@@ -38,172 +61,310 @@ function selectionUrl(params: {
   return `/admin/academic-mentorship?${searchParams.toString()}`;
 }
 
-export default async function AcademicMentorshipPage({ searchParams }: PageProps = {}) {
+async function requirePageAccess(session: Session) {
+  const access = await requireAcademicMentorshipAccess(session, "view");
+  const role = access.ok ? access.permission.role : null;
+  if (!access.ok || (role !== "admin" && role !== "program_admin")) {
+    redirect("/dashboard");
+  }
+  return access;
+}
+
+function selectedFilters(searchParams: SearchParams, academicYears: string[]) {
+  return {
+    academicYear: firstParam(searchParams.academic_year) || academicYears[0],
+    schoolCode: firstParam(searchParams.school_code),
+    includeHistory: firstParam(searchParams.include_history) === "true",
+  };
+}
+
+function historyUrl(
+  schoolCode: string | undefined,
+  academicYear: string,
+  includeHistory: boolean
+) {
+  return schoolCode
+    ? selectionUrl({ schoolCode, academicYear, includeHistory: !includeHistory })
+    : "#";
+}
+
+async function requireSession(): Promise<AuthenticatedSession> {
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
     redirect("/");
   }
+  return session as AuthenticatedSession;
+}
 
-  const baseAccess = await requireAcademicMentorshipAccess(session, "view");
-  const role = baseAccess.ok ? baseAccess.permission.role : null;
-  if (!baseAccess.ok || (role !== "admin" && role !== "program_admin")) {
+async function resolveSearchParams(
+  searchParams: PageProps["searchParams"]
+): Promise<SearchParams> {
+  return searchParams ? Promise.resolve(searchParams) : {};
+}
+
+function redirectToOnlySchool(params: {
+  schools: AcademicMentorshipSchool[];
+  selectedSchoolCode: string;
+  selectedAcademicYear: string;
+  includeHistory: boolean;
+}) {
+  if (params.selectedSchoolCode || params.schools.length !== 1) return;
+  redirect(
+    selectionUrl({
+      schoolCode: params.schools[0].code,
+      academicYear: params.selectedAcademicYear,
+      includeHistory: params.includeHistory,
+    })
+  );
+}
+
+async function resolveSelectedAccess(
+  session: AuthenticatedSession,
+  selectedSchool: AcademicMentorshipSchool | undefined,
+  selectedAcademicYear: string
+): Promise<AcademicMentorshipOkAccess | null> {
+  if (!selectedSchool || !isValidAcademicYear(selectedAcademicYear)) return null;
+  const access = await requireAcademicMentorshipAccess(session, "view", {
+    schoolCode: selectedSchool.code,
+  });
+  if (!access.ok) {
     redirect("/dashboard");
   }
+  return access;
+}
 
-  const resolvedSearchParams = searchParams
-    ? await Promise.resolve(searchParams)
-    : {};
+async function loadSelectedGroups(
+  selectedAccess: AcademicMentorshipOkAccess | null,
+  selectedAcademicYear: string,
+  includeHistory: boolean
+): Promise<AcademicMentorshipMappingGroup[]> {
+  if (!selectedAccess?.school) return [];
+  return listAcademicMentorshipMappings({
+    schoolId: selectedAccess.school.id,
+    academicYear: selectedAcademicYear,
+    includeHistory,
+  });
+}
+
+function canEditSelection(
+  selectedAccess: AcademicMentorshipOkAccess | null,
+  selectedAcademicYear: string
+) {
+  return (
+    selectedAccess?.canEdit === true &&
+    isAcademicMentorshipEditableYear(selectedAcademicYear)
+  );
+}
+
+async function loadPageModel(
+  session: AuthenticatedSession,
+  resolvedSearchParams: SearchParams
+): Promise<PageModel> {
+  const baseAccess = await requirePageAccess(session);
   const academicYears = getAcademicMentorshipAcademicYears();
-  const selectedAcademicYear =
-    firstParam(resolvedSearchParams.academic_year) || academicYears[0];
-  const selectedSchoolCode = firstParam(resolvedSearchParams.school_code);
-  const includeHistory = firstParam(resolvedSearchParams.include_history) === "true";
+  const {
+    academicYear: selectedAcademicYear,
+    schoolCode: selectedSchoolCode,
+    includeHistory,
+  } = selectedFilters(resolvedSearchParams, academicYears);
   const schools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
 
-  if (!selectedSchoolCode && schools.length === 1) {
-    redirect(
-      selectionUrl({
-        schoolCode: schools[0].code,
-        academicYear: selectedAcademicYear,
-        includeHistory,
-      })
-    );
-  }
+  redirectToOnlySchool({ schools, selectedSchoolCode, selectedAcademicYear, includeHistory });
 
   const selectedSchool = schools.find((school) => school.code === selectedSchoolCode);
-  const selectedAccess =
-    selectedSchool && isValidAcademicYear(selectedAcademicYear)
-      ? await requireAcademicMentorshipAccess(session, "view", {
-          schoolCode: selectedSchool.code,
-        })
-      : null;
-  if (selectedAccess && !selectedAccess.ok) {
-    redirect("/dashboard");
+  const selectedAccess = await resolveSelectedAccess(
+    session,
+    selectedSchool,
+    selectedAcademicYear
+  );
+  const groups = await loadSelectedGroups(
+    selectedAccess,
+    selectedAcademicYear,
+    includeHistory
+  );
+  const canEdit = canEditSelection(selectedAccess, selectedAcademicYear);
+  const historyHref = historyUrl(selectedSchool?.code, selectedAcademicYear, includeHistory);
+  const accessLabel = canEdit ? "Edit access" : "View-only";
+
+  return {
+    academicYears,
+    selectedAcademicYear,
+    selectedSchoolCode,
+    includeHistory,
+    schools,
+    selectedSchool,
+    groups,
+    canEdit,
+    historyHref,
+    accessLabel,
+  };
+}
+
+function PageHeader({ email }: { email: string }) {
+  return (
+    <header className="bg-bg-card border-b border-border shadow-sm">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/admin"
+            className="-m-1 inline-flex h-9 w-9 items-center justify-center rounded-md text-text-muted hover:bg-hover-bg hover:text-text-primary"
+            aria-label="Back to admin"
+          >
+            <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
+              Academic Mentorship
+            </h1>
+            <p className="font-mono text-xs text-text-muted">{email}</p>
+          </div>
+        </div>
+        <Link href="/api/auth/signout" className="text-sm font-bold text-danger hover:text-danger/80">
+          Sign out
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function SelectionForm({
+  academicYears,
+  selectedAcademicYear,
+  selectedSchoolCode,
+  includeHistory,
+  schools,
+}: Pick<
+  PageModel,
+  | "academicYears"
+  | "selectedAcademicYear"
+  | "selectedSchoolCode"
+  | "includeHistory"
+  | "schools"
+>) {
+  return (
+    <Card className="overflow-hidden p-4">
+      <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto] lg:items-end">
+        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="school_code">
+          School
+          <select
+            id="school_code"
+            name="school_code"
+            defaultValue={selectedSchoolCode}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            <option value="">Select a School</option>
+            {schools.map((school) => (
+              <option key={`${school.id}-${school.code}`} value={school.code}>
+                {school.name} ({school.code})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="academic_year">
+          Academic year
+          <select
+            id="academic_year"
+            name="academic_year"
+            defaultValue={selectedAcademicYear}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            {!academicYears.includes(selectedAcademicYear) && (
+              <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
+            )}
+            {academicYears.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </select>
+        </label>
+        {includeHistory && <input type="hidden" name="include_history" value="true" />}
+        <button className="min-h-[44px] rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover">
+          Apply
+        </button>
+      </form>
+    </Card>
+  );
+}
+
+function SelectionSummary({
+  canEdit,
+  accessLabel,
+  selectedSchool,
+  selectedAcademicYear,
+  historyHref,
+  includeHistory,
+}: Pick<
+  PageModel,
+  | "canEdit"
+  | "accessLabel"
+  | "selectedSchool"
+  | "selectedAcademicYear"
+  | "historyHref"
+  | "includeHistory"
+>) {
+  return (
+    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+        <Badge variant={canEdit ? "success" : "default"}>{accessLabel}</Badge>
+        {selectedSchool ? (
+          <span>
+            {selectedSchool.name} | <span className="font-mono">{selectedAcademicYear}</span>
+          </span>
+        ) : (
+          <span>Select a School to load mentorship mappings.</span>
+        )}
+      </div>
+      {selectedSchool && (
+        <Link
+          href={historyHref}
+          className="inline-flex min-h-9 w-fit items-center justify-center rounded-lg border border-border bg-bg-card px-3 text-sm font-bold text-accent hover:bg-hover-bg hover:text-accent-hover"
+        >
+          {includeHistory ? "Hide history" : "Show history"}
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function SelectedSchoolContent({
+  selectedSchool,
+  selectedAcademicYear,
+  includeHistory,
+  canEdit,
+  groups,
+}: Pick<
+  PageModel,
+  "selectedSchool" | "selectedAcademicYear" | "includeHistory" | "canEdit" | "groups"
+>) {
+  if (!selectedSchool) {
+    return <Card className="mt-4 p-6 text-sm text-text-muted">Select a School to view mappings.</Card>;
   }
 
-  const groups =
-    selectedAccess?.ok && selectedAccess.school
-      ? await listAcademicMentorshipMappings({
-          schoolId: selectedAccess.school.id,
-          academicYear: selectedAcademicYear,
-          includeHistory,
-        })
-      : [];
-  const canEdit =
-    selectedAccess?.ok === true &&
-    selectedAccess.canEdit &&
-    isAcademicMentorshipEditableYear(selectedAcademicYear);
+  return (
+    <AcademicMentorshipManager
+      schoolCode={selectedSchool.code}
+      academicYear={selectedAcademicYear}
+      includeHistory={includeHistory}
+      canEdit={canEdit}
+      initialGroups={groups}
+    />
+  );
+}
 
-  const historyHref = selectedSchool
-    ? selectionUrl({
-        schoolCode: selectedSchool.code,
-        academicYear: selectedAcademicYear,
-        includeHistory: !includeHistory,
-      })
-    : "#";
-  const accessLabel = canEdit ? "Edit access" : "View-only";
+export default async function AcademicMentorshipPage({ searchParams }: PageProps = {}) {
+  const session = await requireSession();
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const model = await loadPageModel(session, resolvedSearchParams);
 
   return (
     <div className="min-h-screen bg-bg">
-      <header className="bg-bg-card border-b border-border shadow-sm">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-3">
-            <Link
-              href="/admin"
-              className="-m-1 inline-flex h-9 w-9 items-center justify-center rounded-md text-text-muted hover:bg-hover-bg hover:text-text-primary"
-              aria-label="Back to admin"
-            >
-              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
-            </Link>
-            <div>
-              <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
-                Academic Mentorship
-              </h1>
-              <p className="font-mono text-xs text-text-muted">{session.user.email}</p>
-            </div>
-          </div>
-          <Link href="/api/auth/signout" className="text-sm font-bold text-danger hover:text-danger/80">
-            Sign out
-          </Link>
-        </div>
-      </header>
+      <PageHeader email={session.user.email} />
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <Card className="overflow-hidden p-4">
-          <form action="/admin/academic-mentorship" className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto] lg:items-end">
-            <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="school_code">
-              School
-              <select
-                id="school_code"
-                name="school_code"
-                defaultValue={selectedSchoolCode}
-                className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-              >
-                <option value="">Select a School</option>
-                {schools.map((school) => (
-                  <option key={`${school.id}-${school.code}`} value={school.code}>
-                    {school.name} ({school.code})
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary" htmlFor="academic_year">
-              Academic year
-              <select
-                id="academic_year"
-                name="academic_year"
-                defaultValue={selectedAcademicYear}
-                className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-              >
-                {!academicYears.includes(selectedAcademicYear) && (
-                  <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
-                )}
-                {academicYears.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {includeHistory && <input type="hidden" name="include_history" value="true" />}
-            <button className="min-h-[44px] rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover">
-              Apply
-            </button>
-          </form>
-        </Card>
-
-        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
-            <Badge variant={canEdit ? "success" : "default"}>{accessLabel}</Badge>
-            {selectedSchool ? (
-              <span>
-                {selectedSchool.name} | <span className="font-mono">{selectedAcademicYear}</span>
-              </span>
-            ) : (
-              <span>Select a School to load mentorship mappings.</span>
-            )}
-          </div>
-          {selectedSchool && (
-            <Link
-              href={historyHref}
-              className="inline-flex min-h-9 w-fit items-center justify-center rounded-lg border border-border bg-bg-card px-3 text-sm font-bold text-accent hover:bg-hover-bg hover:text-accent-hover"
-            >
-              {includeHistory ? "Hide history" : "Show history"}
-            </Link>
-          )}
-        </div>
-
-        {!selectedSchool ? (
-          <Card className="mt-4 p-6 text-sm text-text-muted">Select a School to view mappings.</Card>
-        ) : (
-          <AcademicMentorshipManager
-            schoolCode={selectedSchool.code}
-            academicYear={selectedAcademicYear}
-            includeHistory={includeHistory}
-            canEdit={canEdit}
-            initialGroups={groups}
-          />
-        )}
+        <SelectionForm {...model} />
+        <SelectionSummary {...model} />
+        <SelectedSchoolContent {...model} />
       </main>
     </div>
   );

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -6,15 +6,16 @@ import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
 import {
   getAcademicMentorshipAcademicYears,
-  filterAcademicMentorshipSchoolsByProgram,
   isAcademicMentorshipEditableYear,
   isValidAcademicYear,
   listAcademicMentorshipMappings,
+  listAcademicMentorshipProgramSchoolLinks,
   listAcademicMentorshipProgramsForSchools,
   listAccessibleAcademicMentorshipSchools,
   requireAcademicMentorshipAccess,
   type AcademicMentorshipMappingGroup,
   type AcademicMentorshipProgram,
+  type AcademicMentorshipProgramSchoolLink,
   type AcademicMentorshipSchool,
 } from "@/lib/academic-mentorship";
 import { Badge, Card } from "@/components/ui";
@@ -42,6 +43,7 @@ interface PageModel {
   selectedProgramId: number | null;
   includeHistory: boolean;
   programs: AcademicMentorshipProgram[];
+  programSchoolLinks: AcademicMentorshipProgramSchoolLink[];
   schools: AcademicMentorshipSchool[];
   selectedSchool: AcademicMentorshipSchool | undefined;
   groups: AcademicMentorshipMappingGroup[];
@@ -131,6 +133,20 @@ function redirectToOnlySchool(params: {
   );
 }
 
+function schoolsForProgram(
+  schools: AcademicMentorshipSchool[],
+  programSchoolLinks: AcademicMentorshipProgramSchoolLink[],
+  programId: number | null
+): AcademicMentorshipSchool[] {
+  if (programId === null) return schools;
+  const schoolIds = new Set(
+    programSchoolLinks
+      .filter((link) => link.programId === programId)
+      .map((link) => link.schoolId)
+  );
+  return schools.filter((school) => schoolIds.has(school.id));
+}
+
 function redirectInvalidSchoolSelection(params: {
   selectedSchoolCode: string;
   selectedSchool: AcademicMentorshipSchool | undefined;
@@ -201,25 +217,32 @@ async function loadPageModel(
     includeHistory,
   } = selectedFilters(resolvedSearchParams, academicYears);
   const accessibleSchools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
+  const accessibleSchoolIds = accessibleSchools.map((school) => school.id);
   const programs = await listAcademicMentorshipProgramsForSchools(
-    accessibleSchools.map((school) => school.id),
+    accessibleSchoolIds,
     selectedAcademicYear
   );
-  const schools = await filterAcademicMentorshipSchoolsByProgram(
+  const programSchoolLinks = await listAcademicMentorshipProgramSchoolLinks(
+    accessibleSchoolIds,
+    selectedAcademicYear
+  );
+  const schoolsForSelectedProgram = schoolsForProgram(
     accessibleSchools,
-    selectedAcademicYear,
+    programSchoolLinks,
     selectedProgramId
   );
 
   redirectToOnlySchool({
-    schools,
+    schools: schoolsForSelectedProgram,
     selectedSchoolCode,
     selectedAcademicYear,
     selectedProgramId,
     includeHistory,
   });
 
-  const selectedSchool = schools.find((school) => school.code === selectedSchoolCode);
+  const selectedSchool = schoolsForSelectedProgram.find(
+    (school) => school.code === selectedSchoolCode
+  );
   redirectInvalidSchoolSelection({
     selectedSchoolCode,
     selectedSchool,
@@ -255,7 +278,8 @@ async function loadPageModel(
     selectedProgramId,
     includeHistory,
     programs,
-    schools,
+    programSchoolLinks,
+    schools: accessibleSchools,
     selectedSchool,
     groups,
     canEdit,

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -1,0 +1,218 @@
+import { getServerSession } from "next-auth";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { authOptions } from "@/lib/auth";
+import {
+  getAcademicMentorshipAcademicYears,
+  isAcademicMentorshipEditableYear,
+  isValidAcademicYear,
+  listAcademicMentorshipMappings,
+  listAccessibleAcademicMentorshipSchools,
+  requireAcademicMentorshipAccess,
+} from "@/lib/academic-mentorship";
+import { Card } from "@/components/ui";
+
+interface PageProps {
+  searchParams?:
+    | Promise<{ [key: string]: string | string[] | undefined }>
+    | { [key: string]: string | string[] | undefined };
+}
+
+function firstParam(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function selectionUrl(params: {
+  schoolCode: string;
+  academicYear: string;
+  includeHistory?: boolean;
+}) {
+  const searchParams = new URLSearchParams({
+    school_code: params.schoolCode,
+    academic_year: params.academicYear,
+  });
+  if (params.includeHistory) searchParams.set("include_history", "true");
+  return `/admin/academic-mentorship?${searchParams.toString()}`;
+}
+
+export default async function AcademicMentorshipPage({ searchParams }: PageProps = {}) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    redirect("/");
+  }
+
+  const baseAccess = await requireAcademicMentorshipAccess(session, "view");
+  const role = baseAccess.ok ? baseAccess.permission.role : null;
+  if (!baseAccess.ok || (role !== "admin" && role !== "program_admin")) {
+    redirect("/dashboard");
+  }
+
+  const resolvedSearchParams = searchParams
+    ? await Promise.resolve(searchParams)
+    : {};
+  const academicYears = getAcademicMentorshipAcademicYears();
+  const selectedAcademicYear =
+    firstParam(resolvedSearchParams.academic_year) || academicYears[0];
+  const selectedSchoolCode = firstParam(resolvedSearchParams.school_code);
+  const includeHistory = firstParam(resolvedSearchParams.include_history) === "true";
+  const schools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
+
+  if (!selectedSchoolCode && schools.length === 1) {
+    redirect(
+      selectionUrl({
+        schoolCode: schools[0].code,
+        academicYear: selectedAcademicYear,
+        includeHistory,
+      })
+    );
+  }
+
+  const selectedSchool = schools.find((school) => school.code === selectedSchoolCode);
+  const selectedAccess =
+    selectedSchool && isValidAcademicYear(selectedAcademicYear)
+      ? await requireAcademicMentorshipAccess(session, "view", {
+          schoolCode: selectedSchool.code,
+        })
+      : null;
+  if (selectedAccess && !selectedAccess.ok) {
+    redirect("/dashboard");
+  }
+
+  const groups =
+    selectedAccess?.ok && selectedAccess.school
+      ? await listAcademicMentorshipMappings({
+          schoolId: selectedAccess.school.id,
+          academicYear: selectedAcademicYear,
+          includeHistory,
+        })
+      : [];
+  const canEdit =
+    selectedAccess?.ok === true &&
+    selectedAccess.canEdit &&
+    isAcademicMentorshipEditableYear(selectedAcademicYear);
+
+  const historyHref = selectedSchool
+    ? selectionUrl({
+        schoolCode: selectedSchool.code,
+        academicYear: selectedAcademicYear,
+        includeHistory: !includeHistory,
+      })
+    : "#";
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <header className="bg-bg-card border-b border-border shadow-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <Link href="/admin" className="text-text-muted hover:text-text-primary p-1 -m-1">
+              <span aria-hidden="true">{"<"}</span>
+            </Link>
+            <div>
+              <h1 className="text-xl sm:text-2xl font-bold text-text-primary uppercase tracking-tight">
+                Academic Mentorship
+              </h1>
+              <p className="text-xs text-text-muted font-mono">{session.user.email}</p>
+            </div>
+          </div>
+          <Link href="/api/auth/signout" className="text-sm font-bold text-danger hover:text-danger/80">
+            Sign out
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <Card className="p-4">
+          <form action="/admin/academic-mentorship" className="grid gap-4 md:grid-cols-[1fr_220px_auto]">
+            <label className="grid gap-1 text-sm font-semibold text-text-primary" htmlFor="school_code">
+              School
+              <select
+                id="school_code"
+                name="school_code"
+                defaultValue={selectedSchoolCode}
+                className="rounded-md border border-border bg-bg-card px-3 py-2 font-normal"
+              >
+                <option value="">Select a School</option>
+                {schools.map((school) => (
+                  <option key={school.code} value={school.code}>
+                    {school.name} ({school.code})
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="grid gap-1 text-sm font-semibold text-text-primary" htmlFor="academic_year">
+              Academic year
+              <select
+                id="academic_year"
+                name="academic_year"
+                defaultValue={selectedAcademicYear}
+                className="rounded-md border border-border bg-bg-card px-3 py-2 font-normal"
+              >
+                {!academicYears.includes(selectedAcademicYear) && (
+                  <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
+                )}
+                {academicYears.map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {includeHistory && <input type="hidden" name="include_history" value="true" />}
+            <button className="self-end rounded-md bg-accent px-4 py-2 text-sm font-bold text-white">
+              Apply
+            </button>
+          </form>
+        </Card>
+
+        <div className="mt-4 flex items-center justify-between">
+          <div className="text-sm text-text-muted">
+            {canEdit ? "Edit access" : "View-only"}
+          </div>
+          {selectedSchool && (
+            <Link href={historyHref} className="text-sm font-bold text-accent hover:text-accent-hover">
+              {includeHistory ? "Hide history" : "Show history"}
+            </Link>
+          )}
+        </div>
+
+        <section className="mt-4 space-y-4">
+          {!selectedSchool ? (
+            <Card className="p-6 text-sm text-text-muted">Select a School to view mappings.</Card>
+          ) : groups.length === 0 ? (
+            <Card className="p-6 text-sm text-text-muted">
+              No Academic Mentor-Mentee Mappings found.
+            </Card>
+          ) : (
+            groups.map((group) => (
+              <Card key={group.mentor.userId} className="p-0">
+                <div className="border-b border-border px-4 py-3">
+                  <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
+                  <p className="text-sm text-text-muted">{group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}</p>
+                </div>
+                <div className="divide-y divide-border">
+                  {group.mappings.map((mapping) => (
+                    <div key={String(mapping.id)} className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px]">
+                      <div>
+                        <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
+                        <div className="text-sm text-text-muted">{mapping.mentee.studentId}</div>
+                      </div>
+                      <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
+                      <div className="text-sm text-text-muted">{mapping.assignedDate}</div>
+                      <div className="text-sm font-semibold text-text-primary">
+                        {mapping.status === "active" ? "Active" : "Historical"}
+                        {includeHistory && mapping.endedDate ? (
+                          <span className="block font-normal text-text-muted">Ended {mapping.endedDate}</span>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            ))
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -3,18 +3,22 @@ import { render, screen } from "@testing-library/react";
 
 // ---- mocks (hoisted) ----
 
-const { mockGetServerSession, mockIsAdmin, mockRedirect } = vi.hoisted(() => ({
+const { mockGetServerSession, mockIsAdmin, mockRedirect, mockRequireAcademicMentorshipAccess } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockIsAdmin: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
+  mockRequireAcademicMentorshipAccess: vi.fn(),
 }));
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
+vi.mock("@/lib/academic-mentorship", () => ({
+  requireAcademicMentorshipAccess: mockRequireAcademicMentorshipAccess,
+}));
 vi.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -34,11 +38,27 @@ const adminSession = {
   user: { email: "admin@avantifellows.org" },
 };
 
+const academicAccess = (role: "admin" | "program_admin") => ({
+  ok: true,
+  email: `${role}@avantifellows.org`,
+  permission: {
+    email: `${role}@avantifellows.org`,
+    level: 3,
+    role,
+    school_codes: null,
+    regions: null,
+    program_ids: [64],
+    read_only: false,
+  },
+  canEdit: true,
+});
+
 // ---- tests ----
 
 describe("AdminPage (server component)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequireAcademicMentorshipAccess.mockResolvedValue({ ok: false, status: 403, error: "Forbidden" });
   });
 
   it("redirects to / when there is no session", async () => {
@@ -56,18 +76,19 @@ describe("AdminPage (server component)", () => {
     expect(mockRedirect).toHaveBeenCalledWith("/");
   });
 
-  it("redirects to /dashboard when user is not admin", async () => {
+  it("redirects to /dashboard when user lacks Academic Mentorship admin access", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(false);
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/dashboard");
     expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
-    expect(mockIsAdmin).toHaveBeenCalledWith("admin@avantifellows.org");
+    expect(mockRequireAcademicMentorshipAccess).toHaveBeenCalledWith(adminSession, "view");
   });
 
   it("renders admin links when user is admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
+    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("admin"));
 
     const jsx = await AdminPage();
     render(jsx);
@@ -78,6 +99,7 @@ describe("AdminPage (server component)", () => {
     expect(screen.getByText("School Programs")).toBeInTheDocument();
     expect(screen.getByText("Centre Management")).toBeInTheDocument();
     expect(screen.getByText("Centre Option Configuration")).toBeInTheDocument();
+    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
 
     // verify links
     expect(screen.getByText("User Management").closest("a")).toHaveAttribute(
@@ -100,11 +122,32 @@ describe("AdminPage (server component)", () => {
       "href",
       "/admin/centres/config"
     );
+    expect(screen.getByText("Academic Mentorship").closest("a")).toHaveAttribute(
+      "href",
+      "/admin/academic-mentorship"
+    );
+  });
+
+  it("lets program_admin users enter for Academic Mentorship only", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { email: "program_admin@avantifellows.org" } });
+    mockIsAdmin.mockResolvedValue(false);
+    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("program_admin"));
+
+    const jsx = await AdminPage();
+    render(jsx);
+
+    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
+    expect(screen.queryByText("User Management")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batch Metadata")).not.toBeInTheDocument();
+    expect(screen.queryByText("School Programs")).not.toBeInTheDocument();
+    expect(screen.queryByText("Centre Management")).not.toBeInTheDocument();
+    expect(screen.queryByText("Centre Option Configuration")).not.toBeInTheDocument();
   });
 
   it("displays user email and navigation links", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
+    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("admin"));
 
     const jsx = await AdminPage();
     render(jsx);

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { isAdmin } from "@/lib/permissions";
+import { requireAcademicMentorshipAccess } from "@/lib/academic-mentorship";
 import Link from "next/link";
 import { Card } from "@/components/ui";
 
@@ -12,8 +12,11 @@ export default async function AdminPage() {
     redirect("/");
   }
 
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
+  const academicMentorshipAccess = await requireAcademicMentorshipAccess(session, "view");
+  const role = academicMentorshipAccess.ok ? academicMentorshipAccess.permission.role : null;
+  const showAdminCards = role === "admin";
+  const showAcademicMentorshipCard = role === "admin" || role === "program_admin";
+  if (!showAcademicMentorshipCard) {
     redirect("/dashboard");
   }
 
@@ -42,56 +45,69 @@ export default async function AdminPage() {
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          <Link href="/admin/users">
-            <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">User Management</h3>
-              <p className="mt-2 text-sm text-text-muted">
-                Add, edit, and remove users. Assign permission levels.
-              </p>
-            </Card>
-          </Link>
+          {showAdminCards && (
+            <>
+              <Link href="/admin/users">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">User Management</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Add, edit, and remove users. Assign permission levels.
+                  </p>
+                </Card>
+              </Link>
 
-          <Link href="/admin/batches">
-            <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Batch Metadata</h3>
-              <p className="mt-2 text-sm text-text-muted">
-                Configure stream and grade metadata for program batches.
-              </p>
-            </Card>
-          </Link>
+              <Link href="/admin/batches">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Batch Metadata</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Configure stream and grade metadata for program batches.
+                  </p>
+                </Card>
+              </Link>
 
-          <Link href="/admin/schools">
-            <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">School Programs</h3>
-              <p className="mt-2 text-sm text-text-muted">
-                Assign programs (CoE, Nodal, NVS) to schools.
-              </p>
-            </Card>
-          </Link>
+              <Link href="/admin/schools">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">School Programs</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Assign programs (CoE, Nodal, NVS) to schools.
+                  </p>
+                </Card>
+              </Link>
 
-          <Link href="/admin/centres">
-            <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Management</h3>
-              <p className="mt-2 text-sm text-text-muted">
-                Manage Centres, School links, streams, and active status.
-              </p>
-            </Card>
-          </Link>
+              <Link href="/admin/centres">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Management</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Manage Centres, School links, streams, and active status.
+                  </p>
+                </Card>
+              </Link>
 
-          <Link href="/admin/staff">
-            <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Staff Management</h3>
-              <p className="mt-2 text-sm text-text-muted">
-                Manage AF teachers, PMs, employee codes, and Centre seats.
-              </p>
-            </Card>
-          </Link>
+              <Link href="/admin/staff">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Staff Management</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Manage AF teachers, PMs, employee codes, and Centre seats.
+                  </p>
+                </Card>
+              </Link>
 
-          <Link href="/admin/centres/config">
+              <Link href="/admin/centres/config">
+                <Card className="block p-6">
+                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Option Configuration</h3>
+                  <p className="mt-2 text-sm text-text-muted">
+                    Manage Centre type, category, sub-category, and Centre Stream options.
+                  </p>
+                </Card>
+              </Link>
+            </>
+          )}
+
+          <Link href="/admin/academic-mentorship">
             <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Option Configuration</h3>
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Academic Mentorship</h3>
               <p className="mt-2 text-sm text-text-muted">
-                Manage Centre type, category, sub-category, and Centre Stream options.
+                View Academic Mentor-Mentee Mappings by School and academic year.
               </p>
             </Card>
           </Link>

--- a/src/app/admin/users/AddUserModal.tsx
+++ b/src/app/admin/users/AddUserModal.tsx
@@ -297,7 +297,7 @@ export default function AddUserModal({ user, regions, schoolCodeToName, onClose,
               </div>
               {isNVSOnly && (
                 <p className="mt-2 text-xs text-amber-600 bg-amber-50 p-2 rounded">
-                  Note: NVS-only users have limited access (students and analytics only, no visits/curriculum/mentorship).
+                  Note: NVS-only users have limited access (students and analytics only, no visits/curriculum).
                 </p>
               )}
               {selectedPrograms.length === 0 && (

--- a/src/app/api/academic-mentorship/mappings/import/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.test.ts
@@ -213,7 +213,7 @@ describe("POST /api/academic-mentorship/mappings/import", () => {
     expect(response.status).toBe(422);
     expect(body).toMatchObject({
       error: "CSV upload has row errors",
-      errors: [{ rowNumber: 2, error: "student_id is required" }],
+      errors: [{ rowNumber: 2, field: "student_id", error: "student_id is required" }],
     });
     expect(body.errorCsv).toContain("mentor_email,student_id,notes,error_reason");
     expect(mockWithTransaction).not.toHaveBeenCalled();

--- a/src/app/api/academic-mentorship/mappings/import/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetServerSession } = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn(),
+}));
+
+import { query, withTransaction } from "@/lib/db";
+import { GET, POST } from "./route";
+import { PROGRAM_IDS } from "@/lib/constants";
+
+const mockQuery = vi.mocked(query);
+const mockWithTransaction = vi.mocked(withTransaction);
+
+function request(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+function csvUploadRequest(csvText: string) {
+  const formData = new FormData();
+  formData.set("school_code", "SCH001");
+  formData.set("academic_year", "2026-2027");
+  formData.set("file", new Blob([csvText], { type: "text/csv" }), "mappings.csv");
+  return { formData: async () => formData } as unknown as NextRequest;
+}
+
+describe("GET /api/academic-mentorship/mappings/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("downloads the CSV template for editable users", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ]);
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/mappings/import?school_code=SCH001&academic_year=2026-2027"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("mentor_email,student_id\n");
+    expect(response.headers.get("content-disposition")).toContain(
+      "academic-mentorship-template.csv"
+    );
+  });
+
+  it("denies read-only users before template download", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "readonly@avantifellows.org" },
+    });
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "readonly@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.NVS],
+        read_only: true,
+        user_id: 501,
+      },
+    ]);
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/mappings/import?school_code=SCH001&academic_year=2026-2027"
+      )
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /api/academic-mentorship/mappings/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("bulk imports a valid CSV for editable users", async () => {
+    const txQuery = vi.fn().mockResolvedValueOnce({ rows: [{ id: 31 }] });
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ email: "anita@avantifellows.org", user_id: 101 }])
+      .mockResolvedValueOnce([
+        {
+          student_id: "STU001",
+          student_pk_id: 201,
+          program_id: 64,
+          active_mapping_id: null,
+        },
+      ]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const response = await POST(
+      csvUploadRequest("mentor_email,student_id\nANITA@AVANTIFELLOWS.ORG, STU001 \n")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ success: true, insertedCount: 1 });
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns file-level CSV errors without an error CSV", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ]);
+
+    const response = await POST(csvUploadRequest("mentor_email,name\nanita@x,Meena\n"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "CSV must include mentor_email and student_id headers",
+    });
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns row-level CSV errors with downloadable CSV contents", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ]);
+
+    const response = await POST(
+      csvUploadRequest("mentor_email,student_id,notes\nanita@x,,missing\n")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body).toMatchObject({
+      error: "CSV upload has row errors",
+      errors: [{ rowNumber: 2, error: "student_id is required" }],
+    });
+    expect(body.errorCsv).toContain("mentor_email,student_id,notes,error_reason");
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 before database access", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const response = await POST(
+      csvUploadRequest("mentor_email,student_id\nanita@x,STU001\n")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/academic-mentorship/mappings/import/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.test.ts
@@ -203,7 +203,9 @@ describe("POST /api/academic-mentorship/mappings/import", () => {
       ])
       .mockResolvedValueOnce([
         { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
-      ]);
+      ])
+      .mockResolvedValueOnce([{ email: "anita@x", user_id: 101 }])
+      .mockResolvedValueOnce([]);
 
     const response = await POST(
       csvUploadRequest("mentor_email,student_id,notes\nanita@x,,missing\n")

--- a/src/app/api/academic-mentorship/mappings/import/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.test.ts
@@ -23,10 +23,10 @@ function request(path: string) {
   return new NextRequest(`http://localhost${path}`);
 }
 
-function csvUploadRequest(csvText: string) {
+function csvUploadRequest(csvText: string, academicYear = "2026-2027") {
   const formData = new FormData();
   formData.set("school_code", "SCH001");
-  formData.set("academic_year", "2026-2027");
+  formData.set("academic_year", academicYear);
   formData.set("file", new Blob([csvText], { type: "text/csv" }), "mappings.csv");
   return { formData: async () => formData } as unknown as NextRequest;
 }
@@ -99,6 +99,23 @@ describe("GET /api/academic-mentorship/mappings/import", () => {
     expect(response.status).toBe(403);
     expect(body.error).toBe("Forbidden");
     expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unsupported academic years before template access checks", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/mappings/import?school_code=SCH001&academic_year=2023-2024"
+      )
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Academic year is not supported");
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 
@@ -231,6 +248,22 @@ describe("POST /api/academic-mentorship/mappings/import", () => {
 
     expect(response.status).toBe(401);
     expect(body.error).toBe("Unauthorized");
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported academic years before database access", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+
+    const response = await POST(
+      csvUploadRequest("mentor_email,student_id\nanita@x,STU001\n", "2023-2024")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Academic year is not supported");
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockWithTransaction).not.toHaveBeenCalled();
   });

--- a/src/app/api/academic-mentorship/mappings/import/route.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
 
   const parsed = parseSchoolYearSearchParams(request, {
     requireEditable: false,
+    requireSupported: true,
   });
   if (!parsed.ok) return parsed.response;
 
@@ -55,6 +56,7 @@ export async function POST(request: NextRequest) {
     schoolCode: formString(formData, "school_code"),
     academicYear: formString(formData, "academic_year"),
     requireEditable: false,
+    requireSupported: true,
   });
   if (!parsed.ok) return parsed.response;
 

--- a/src/app/api/academic-mentorship/mappings/import/route.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   if (!session.ok) return session.response;
 
   const parsed = parseSchoolYearSearchParams(request, {
-    requireEditable: true,
+    requireEditable: false,
   });
   if (!parsed.ok) return parsed.response;
 
@@ -54,7 +54,7 @@ export async function POST(request: NextRequest) {
   const parsed = parseSchoolYear({
     schoolCode: formString(formData, "school_code"),
     academicYear: formString(formData, "academic_year"),
-    requireEditable: true,
+    requireEditable: false,
   });
   if (!parsed.ok) return parsed.response;
 

--- a/src/app/api/academic-mentorship/mappings/import/route.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.ts
@@ -1,68 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
 
-import { authOptions } from "@/lib/auth";
 import {
-  getAcademicMentorshipActorUserId,
   importAcademicMentorshipMappingsFromCsv,
-  isAcademicMentorshipEditableYear,
-  isValidAcademicYear,
-  requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
+import {
+  academicMentorshipError,
+  formString,
+  getAcademicMentorshipSession,
+  parseSchoolYear,
+  parseSchoolYearSearchParams,
+  requireAcademicMentorshipActor,
+  requireAcademicMentorshipRouteAccess,
+} from "../../route-helpers";
 
 const TEMPLATE = "mentor_email,student_id\n";
 
-function requireSchoolAndYear(
-  schoolCode: string | null | undefined,
-  academicYear: string | null | undefined
-): { ok: true; schoolCode: string; academicYear: string } | { ok: false; response: NextResponse } {
-  const trimmedSchoolCode = schoolCode?.trim() ?? "";
-  if (!trimmedSchoolCode) {
-    return {
-      ok: false,
-      response: NextResponse.json({ error: "school_code is required" }, { status: 400 }),
-    };
-  }
-  const trimmedAcademicYear = academicYear?.trim() ?? "";
-  if (!isValidAcademicYear(trimmedAcademicYear)) {
-    return {
-      ok: false,
-      response: NextResponse.json(
-        { error: "academic_year must use YYYY-YYYY format" },
-        { status: 400 }
-      ),
-    };
-  }
-  if (!isAcademicMentorshipEditableYear(trimmedAcademicYear)) {
-    return {
-      ok: false,
-      response: NextResponse.json(
-        { error: "Academic year is not editable" },
-        { status: 403 }
-      ),
-    };
-  }
-  return { ok: true, schoolCode: trimmedSchoolCode, academicYear: trimmedAcademicYear };
-}
-
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const session = await getAcademicMentorshipSession();
+  if (!session.ok) return session.response;
 
-  const parsed = requireSchoolAndYear(
-    request.nextUrl.searchParams.get("school_code"),
-    request.nextUrl.searchParams.get("academic_year")
-  );
+  const parsed = parseSchoolYearSearchParams(request, {
+    requireEditable: true,
+  });
   if (!parsed.ok) return parsed.response;
 
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode: parsed.schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
+  const access = await requireAcademicMentorshipRouteAccess(
+    session.value,
+    "edit",
+    parsed.value.schoolCode
+  );
+  if (!access.ok) return access.response;
 
   return new NextResponse(TEMPLATE, {
     headers: {
@@ -74,54 +41,41 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const session = await getAcademicMentorshipSession();
+  if (!session.ok) return session.response;
 
   let formData: FormData;
   try {
     formData = await request.formData();
   } catch {
-    return NextResponse.json({ error: "Invalid multipart form data" }, { status: 400 });
+    return academicMentorshipError("Invalid multipart form data", 400);
   }
 
-  const parsed = requireSchoolAndYear(
-    typeof formData.get("school_code") === "string"
-      ? String(formData.get("school_code"))
-      : "",
-    typeof formData.get("academic_year") === "string"
-      ? String(formData.get("academic_year"))
-      : ""
-  );
+  const parsed = parseSchoolYear({
+    schoolCode: formString(formData, "school_code"),
+    academicYear: formString(formData, "academic_year"),
+    requireEditable: true,
+  });
   if (!parsed.ok) return parsed.response;
 
   const file = formData.get("file");
   if (!file || typeof file === "string" || typeof file.text !== "function") {
-    return NextResponse.json({ error: "CSV file is required" }, { status: 400 });
+    return academicMentorshipError("CSV file is required", 400);
   }
 
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode: parsed.schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
-  const actorUserId = await getAcademicMentorshipActorUserId(
-    access.email,
-    access.permission
+  const actor = await requireAcademicMentorshipActor(
+    session.value,
+    parsed.value.schoolCode
   );
-  if (actorUserId === null) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  if (!actor.ok) return actor.response;
 
   const result = await importAcademicMentorshipMappingsFromCsv({
     csvText: await file.text(),
-    schoolId: access.school!.id,
-    schoolCode: access.school!.code,
-    schoolRegion: access.school!.region,
-    academicYear: parsed.academicYear,
-    assignedByUserId: actorUserId,
+    schoolId: actor.value.access.school!.id,
+    schoolCode: actor.value.access.school!.code,
+    schoolRegion: actor.value.access.school!.region,
+    academicYear: parsed.value.academicYear,
+    assignedByUserId: actor.value.actorUserId,
   });
 
   if (result.ok) {
@@ -131,7 +85,7 @@ export async function POST(request: NextRequest) {
     );
   }
   if (result.type === "file") {
-    return NextResponse.json({ error: result.error }, { status: 400 });
+    return academicMentorshipError(result.error, 400);
   }
   return NextResponse.json(
     {

--- a/src/app/api/academic-mentorship/mappings/import/route.ts
+++ b/src/app/api/academic-mentorship/mappings/import/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  getAcademicMentorshipActorUserId,
+  importAcademicMentorshipMappingsFromCsv,
+  isAcademicMentorshipEditableYear,
+  isValidAcademicYear,
+  requireAcademicMentorshipAccess,
+} from "@/lib/academic-mentorship";
+
+const TEMPLATE = "mentor_email,student_id\n";
+
+function requireSchoolAndYear(
+  schoolCode: string | null | undefined,
+  academicYear: string | null | undefined
+): { ok: true; schoolCode: string; academicYear: string } | { ok: false; response: NextResponse } {
+  const trimmedSchoolCode = schoolCode?.trim() ?? "";
+  if (!trimmedSchoolCode) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "school_code is required" }, { status: 400 }),
+    };
+  }
+  const trimmedAcademicYear = academicYear?.trim() ?? "";
+  if (!isValidAcademicYear(trimmedAcademicYear)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "academic_year must use YYYY-YYYY format" },
+        { status: 400 }
+      ),
+    };
+  }
+  if (!isAcademicMentorshipEditableYear(trimmedAcademicYear)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Academic year is not editable" },
+        { status: 403 }
+      ),
+    };
+  }
+  return { ok: true, schoolCode: trimmedSchoolCode, academicYear: trimmedAcademicYear };
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = requireSchoolAndYear(
+    request.nextUrl.searchParams.get("school_code"),
+    request.nextUrl.searchParams.get("academic_year")
+  );
+  if (!parsed.ok) return parsed.response;
+
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
+    schoolCode: parsed.schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  return new NextResponse(TEMPLATE, {
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition":
+        'attachment; filename="academic-mentorship-template.csv"',
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid multipart form data" }, { status: 400 });
+  }
+
+  const parsed = requireSchoolAndYear(
+    typeof formData.get("school_code") === "string"
+      ? String(formData.get("school_code"))
+      : "",
+    typeof formData.get("academic_year") === "string"
+      ? String(formData.get("academic_year"))
+      : ""
+  );
+  if (!parsed.ok) return parsed.response;
+
+  const file = formData.get("file");
+  if (!file || typeof file === "string" || typeof file.text !== "function") {
+    return NextResponse.json({ error: "CSV file is required" }, { status: 400 });
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
+    schoolCode: parsed.schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  const actorUserId = await getAcademicMentorshipActorUserId(
+    access.email,
+    access.permission
+  );
+  if (actorUserId === null) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await importAcademicMentorshipMappingsFromCsv({
+    csvText: await file.text(),
+    schoolId: access.school!.id,
+    schoolCode: access.school!.code,
+    schoolRegion: access.school!.region,
+    academicYear: parsed.academicYear,
+    assignedByUserId: actorUserId,
+  });
+
+  if (result.ok) {
+    return NextResponse.json(
+      { success: true, insertedCount: result.insertedCount },
+      { status: 201 }
+    );
+  }
+  if (result.type === "file") {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+  return NextResponse.json(
+    {
+      error: "CSV upload has row errors",
+      errors: result.errors,
+      errorCsv: result.errorCsv,
+    },
+    { status: 422 }
+  );
+}

--- a/src/app/api/academic-mentorship/mappings/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/route.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetServerSession } = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@/lib/db";
+import { GET } from "./route";
+import { PROGRAM_IDS } from "@/lib/constants";
+
+const mockQuery = vi.mocked(query);
+
+function request(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe("GET /api/academic-mentorship/mappings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it("returns 401 when unauthenticated before database access", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const response = await GET(request("/api/academic-mentorship/mappings"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed academic_year before database access", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+
+    const response = await GET(
+      request("/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("academic_year must use YYYY-YYYY format");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns active grouped mappings by default", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          mentor_user_id: 101,
+          mentor_name: "Anita Mentor",
+          mentor_email: "anita@avantifellows.org",
+          student_pk_id: 201,
+          mentee_name: "Meena Student",
+          mentee_student_id: "STU001",
+          mentee_grade: 11,
+          assigned_date: "2026-07-01",
+          ended_date: null,
+        },
+      ]);
+
+    const response = await GET(
+      request("/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      academicYear: "2026-2027",
+      includeHistory: false,
+      canEdit: true,
+      groups: [
+        {
+          mentor: { name: "Anita Mentor" },
+          menteeCount: 1,
+          mappings: [
+            {
+              mentee: { name: "Meena Student", studentId: "STU001", grade: 11 },
+              assignedDate: "2026-07-01",
+              status: "active",
+            },
+          ],
+        },
+      ],
+    });
+    const mappingCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(mappingCall?.[1]).toEqual([20, "2026-2027", false]);
+  });
+
+  it("passes include_history=true through to the mapping read", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          mentor_user_id: 101,
+          mentor_name: "Anita Mentor",
+          mentor_email: "anita@avantifellows.org",
+          student_pk_id: 201,
+          mentee_name: "Meena Student",
+          mentee_student_id: "STU001",
+          mentee_grade: 11,
+          assigned_date: "2026-07-01",
+          ended_date: "2026-08-01",
+        },
+      ]);
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027&include_history=true"
+      )
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.includeHistory).toBe(true);
+    expect(body.groups[0].mappings[0]).toMatchObject({
+      endedDate: "2026-08-01",
+      status: "historical",
+    });
+    const mappingCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(mappingCall?.[1]).toEqual([20, "2026-2027", true]);
+  });
+
+  it("returns canEdit=false for valid academic years outside the supported picker range", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const response = await GET(
+      request("/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2023-2024")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.canEdit).toBe(false);
+    expect(body.academicYear).toBe("2023-2024");
+  });
+});

--- a/src/app/api/academic-mentorship/mappings/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/db", () => ({
 }));
 
 import { query } from "@/lib/db";
-import { GET } from "./route";
+import { DELETE, GET, POST } from "./route";
 import { PROGRAM_IDS } from "@/lib/constants";
 
 const mockQuery = vi.mocked(query);
@@ -202,5 +202,193 @@ describe("GET /api/academic-mentorship/mappings", () => {
     expect(response.status).toBe(200);
     expect(body.canEdit).toBe(false);
     expect(body.academicYear).toBe("2023-2024");
+  });
+});
+
+describe("POST /api/academic-mentorship/mappings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it("creates a Mapping for editable users", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 101 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ student_pk_id: 201, program_id: null }])
+      .mockResolvedValueOnce([{ id: 7 }]);
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "POST",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mentor_user_id: 101,
+          student_id: 201,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ success: true, mappingId: 7 });
+    const insertCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(insertCall?.[1]).toEqual([
+      20,
+      "2026-2027",
+      101,
+      201,
+      null,
+      501,
+    ]);
+  });
+
+  it("denies read-only users before write queries", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "readonly@avantifellows.org" },
+    });
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "readonly@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.NVS],
+        read_only: true,
+        user_id: 501,
+      },
+    ]);
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "POST",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mentor_user_id: 101,
+          student_id: 201,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps active uniqueness races to the expected conflict message", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    const duplicateError = new Error("duplicate key value violates unique constraint");
+    Object.assign(duplicateError, { code: "23505" });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 101 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ student_pk_id: 201, program_id: 64 }])
+      .mockRejectedValueOnce(duplicateError);
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "POST",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mentor_user_id: 101,
+          student_id: 201,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("Student already has a mentor mapped");
+  });
+});
+
+describe("DELETE /api/academic-mentorship/mappings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it("ends an active Mapping for editable users", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ id: 7 }]);
+
+    const response = await DELETE(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "DELETE",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, mappingId: 7 });
+    const updateCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("UPDATE academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(updateCall?.[1]).toEqual([7, 20, "2026-2027", 501]);
   });
 });

--- a/src/app/api/academic-mentorship/mappings/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/route.test.ts
@@ -56,6 +56,43 @@ describe("GET /api/academic-mentorship/mappings", () => {
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
+  it("rejects Teachers from the full-school mapping API", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "teacher@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "teacher@avantifellows.org",
+          level: 1,
+          role: "teacher",
+          school_codes: ["SCH001"],
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ]);
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027&include_history=true"
+      )
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(
+      mockQuery.mock.calls.some(([sql]) =>
+        String(sql).includes("academic_mentorship_mentor_mentee_mappings")
+      )
+    ).toBe(false);
+  });
+
   it("returns active grouped mappings by default", async () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: "admin@avantifellows.org" },

--- a/src/app/api/academic-mentorship/mappings/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/route.test.ts
@@ -123,6 +123,7 @@ describe("GET /api/academic-mentorship/mappings", () => {
           mentee_name: "Meena Student",
           mentee_student_id: "STU001",
           mentee_grade: 11,
+          program_id: PROGRAM_IDS.NVS,
           assigned_date: "2026-07-01",
           ended_date: null,
         },
@@ -155,7 +156,7 @@ describe("GET /api/academic-mentorship/mappings", () => {
     const mappingCall = mockQuery.mock.calls.find(([sql]) =>
       String(sql).includes("academic_mentorship_mentor_mentee_mappings")
     );
-    expect(mappingCall?.[1]).toEqual([20, "2026-2027", false]);
+    expect(mappingCall?.[1]).toEqual([20, "2026-2027", false, null]);
   });
 
   it("passes include_history=true through to the mapping read", async () => {
@@ -188,6 +189,7 @@ describe("GET /api/academic-mentorship/mappings", () => {
           mentee_name: "Meena Student",
           mentee_student_id: "STU001",
           mentee_grade: 11,
+          program_id: PROGRAM_IDS.NVS,
           assigned_date: "2026-07-01",
           ended_date: "2026-08-01",
         },
@@ -209,7 +211,7 @@ describe("GET /api/academic-mentorship/mappings", () => {
     const mappingCall = mockQuery.mock.calls.find(([sql]) =>
       String(sql).includes("academic_mentorship_mentor_mentee_mappings")
     );
-    expect(mappingCall?.[1]).toEqual([20, "2026-2027", true]);
+    expect(mappingCall?.[1]).toEqual([20, "2026-2027", true, null]);
   });
 
   it("returns canEdit=false for valid academic years outside the supported picker range", async () => {

--- a/src/app/api/academic-mentorship/mappings/route.test.ts
+++ b/src/app/api/academic-mentorship/mappings/route.test.ts
@@ -9,13 +9,15 @@ vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({
   query: vi.fn(),
+  withTransaction: vi.fn(),
 }));
 
-import { query } from "@/lib/db";
-import { DELETE, GET, POST } from "./route";
+import { query, withTransaction } from "@/lib/db";
+import { DELETE, GET, PATCH, POST } from "./route";
 import { PROGRAM_IDS } from "@/lib/constants";
 
 const mockQuery = vi.mocked(query);
+const mockWithTransaction = vi.mocked(withTransaction);
 
 function request(path: string) {
   return new NextRequest(`http://localhost${path}`);
@@ -25,6 +27,7 @@ describe("GET /api/academic-mentorship/mappings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuery.mockReset();
+    mockWithTransaction.mockReset();
   });
 
   it("returns 401 when unauthenticated before database access", async () => {
@@ -209,6 +212,7 @@ describe("POST /api/academic-mentorship/mappings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuery.mockReset();
+    mockWithTransaction.mockReset();
   });
 
   it("creates a Mapping for editable users", async () => {
@@ -348,6 +352,7 @@ describe("DELETE /api/academic-mentorship/mappings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuery.mockReset();
+    mockWithTransaction.mockReset();
   });
 
   it("ends an active Mapping for editable users", async () => {
@@ -390,5 +395,321 @@ describe("DELETE /api/academic-mentorship/mappings", () => {
       String(sql).includes("UPDATE academic_mentorship_mentor_mentee_mappings")
     );
     expect(updateCall?.[1]).toEqual([7, 20, "2026-2027", 501]);
+  });
+});
+
+describe("PATCH /api/academic-mentorship/mappings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("reassigns an active Mapping for editable users", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    const txQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ student_id: 201, mentor_user_id: 101 }] })
+      .mockResolvedValueOnce({ rows: [{ student_pk_id: 201, program_id: 64 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 7 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 9 }] });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 102 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, mappingId: 9 });
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 401 before database access", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when replacement mentor is missing before database access", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("mentor_user_id is required");
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("denies read-only users before reassignment", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "readonly@avantifellows.org" },
+    });
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "readonly@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.NVS],
+        read_only: true,
+        user_id: 501,
+      },
+    ]);
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects replacement mentors that are not eligible for the School", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error).toBe("Academic Mentor is not eligible for this School");
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects the current Academic Mentor as the replacement", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    const txQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ student_id: 201, mentor_user_id: 101 }] });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 101 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 101,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error).toBe("Replacement Academic Mentor must be different");
+  });
+
+  it("denies inactive or historical Mappings", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    const txQuery = vi.fn().mockResolvedValueOnce({ rows: [] });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 102 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe("Active Mapping not found");
+  });
+
+  it("maps concurrent active Mapping races to the expected conflict message", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    const duplicateError = new Error("duplicate key value violates unique constraint");
+    Object.assign(duplicateError, { code: "23505" });
+    const txQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ student_id: 201, mentor_user_id: 101 }] })
+      .mockResolvedValueOnce({ rows: [{ student_pk_id: 201, program_id: 64 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 7 }] })
+      .mockRejectedValueOnce(duplicateError);
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([{ user_id: 102 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const response = await PATCH(
+      new NextRequest("http://localhost/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("Student already has a mentor mapped");
   });
 });

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -96,10 +96,12 @@ export async function GET(request: NextRequest) {
   }
 
   const includeHistory = request.nextUrl.searchParams.get("include_history") === "true";
+  const programId = positiveInteger(request.nextUrl.searchParams.get("program_id"));
   const groups = await listAcademicMentorshipMappings({
     schoolId: access.value.school!.id,
     academicYear: parsed.value.academicYear,
     includeHistory,
+    programId,
   });
 
   return NextResponse.json({

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -9,6 +9,7 @@ import {
   isAcademicMentorshipEditableYear,
   isValidAcademicYear,
   listAcademicMentorshipMappings,
+  reassignAcademicMentorshipMapping,
   requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
 import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
@@ -186,6 +187,73 @@ export async function DELETE(request: NextRequest) {
     academicYear,
     mappingId,
     endedByUserId: actorUserId,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ success: true, mappingId: result.mappingId });
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
+  if (!schoolCode) {
+    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
+  }
+  const academicYear =
+    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
+  if (!isValidAcademicYear(academicYear)) {
+    return NextResponse.json(
+      { error: "academic_year must use YYYY-YYYY format" },
+      { status: 400 }
+    );
+  }
+  if (!isAcademicMentorshipEditableYear(academicYear)) {
+    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
+  }
+  const mappingId = positiveInteger(body.mapping_id);
+  if (mappingId === null) {
+    return NextResponse.json({ error: "mapping_id is required" }, { status: 400 });
+  }
+  const mentorUserId = positiveInteger(body.mentor_user_id);
+  if (mentorUserId === null) {
+    return NextResponse.json({ error: "mentor_user_id is required" }, { status: 400 });
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
+    schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  const actorUserId = await getAcademicMentorshipActorUserId(
+    access.email,
+    access.permission
+  );
+  if (actorUserId === null) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await reassignAcademicMentorshipMapping({
+    schoolId: access.school!.id,
+    schoolCode: access.school!.code,
+    schoolRegion: access.school!.region,
+    academicYear,
+    mappingId,
+    replacementMentorUserId: mentorUserId,
+    assignedByUserId: actorUserId,
   });
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: result.status });

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  isAcademicMentorshipEditableYear,
+  isValidAcademicYear,
+  listAcademicMentorshipMappings,
+  requireAcademicMentorshipAccess,
+} from "@/lib/academic-mentorship";
+import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.isPasscodeUser) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
+  if (!schoolCode) {
+    return NextResponse.json(
+      { error: "school_code query parameter is required" },
+      { status: 400 }
+    );
+  }
+  const academicYear =
+    request.nextUrl.searchParams.get("academic_year")?.trim() || CURRENT_ACADEMIC_YEAR;
+  if (!isValidAcademicYear(academicYear)) {
+    return NextResponse.json(
+      { error: "academic_year must use YYYY-YYYY format" },
+      { status: 400 }
+    );
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "view", {
+    schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  const includeHistory = request.nextUrl.searchParams.get("include_history") === "true";
+  const groups = await listAcademicMentorshipMappings({
+    schoolId: access.school!.id,
+    academicYear,
+    includeHistory,
+  });
+
+  return NextResponse.json({
+    school: access.school,
+    academicYear,
+    includeHistory,
+    canEdit: access.canEdit && isAcademicMentorshipEditableYear(academicYear),
+    groups,
+  });
+}

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -3,6 +3,9 @@ import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
 import {
+  createAcademicMentorshipMapping,
+  endAcademicMentorshipMapping,
+  getAcademicMentorshipActorUserId,
   isAcademicMentorshipEditableYear,
   isValidAcademicYear,
   listAcademicMentorshipMappings,
@@ -34,7 +37,6 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   }
-
   const access = await requireAcademicMentorshipAccess(session, "view", {
     schoolCode,
   });
@@ -55,4 +57,139 @@ export async function GET(request: NextRequest) {
     canEdit: access.canEdit && isAcademicMentorshipEditableYear(academicYear),
     groups,
   });
+}
+
+function positiveInteger(value: unknown): number | null {
+  const numberValue = Number(value);
+  return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
+  if (!schoolCode) {
+    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
+  }
+  const academicYear =
+    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
+  if (!isValidAcademicYear(academicYear)) {
+    return NextResponse.json(
+      { error: "academic_year must use YYYY-YYYY format" },
+      { status: 400 }
+    );
+  }
+  if (!isAcademicMentorshipEditableYear(academicYear)) {
+    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
+  }
+  const mentorUserId = positiveInteger(body.mentor_user_id);
+  if (mentorUserId === null) {
+    return NextResponse.json({ error: "mentor_user_id is required" }, { status: 400 });
+  }
+  const studentPkId = positiveInteger(body.student_id);
+  if (studentPkId === null) {
+    return NextResponse.json({ error: "student_id is required" }, { status: 400 });
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
+    schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  const actorUserId = await getAcademicMentorshipActorUserId(
+    access.email,
+    access.permission
+  );
+  if (actorUserId === null) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await createAcademicMentorshipMapping({
+    schoolId: access.school!.id,
+    schoolCode: access.school!.code,
+    schoolRegion: access.school!.region,
+    academicYear,
+    mentorUserId,
+    studentPkId,
+    assignedByUserId: actorUserId,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(
+    { success: true, mappingId: result.mappingId },
+    { status: 201 }
+  );
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
+  if (!schoolCode) {
+    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
+  }
+  const academicYear =
+    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
+  if (!isValidAcademicYear(academicYear)) {
+    return NextResponse.json(
+      { error: "academic_year must use YYYY-YYYY format" },
+      { status: 400 }
+    );
+  }
+  if (!isAcademicMentorshipEditableYear(academicYear)) {
+    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
+  }
+  const mappingId = positiveInteger(body.mapping_id);
+  if (mappingId === null) {
+    return NextResponse.json({ error: "mapping_id is required" }, { status: 400 });
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
+    schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  const actorUserId = await getAcademicMentorshipActorUserId(
+    access.email,
+    access.permission
+  );
+  if (actorUserId === null) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await endAcademicMentorshipMapping({
+    schoolId: access.school!.id,
+    academicYear,
+    mappingId,
+    endedByUserId: actorUserId,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ success: true, mappingId: result.mappingId });
 }

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -6,6 +6,7 @@ import {
   createAcademicMentorshipMapping,
   endAcademicMentorshipMapping,
   getAcademicMentorshipActorUserId,
+  isAcademicMentorshipManagementRole,
   isAcademicMentorshipEditableYear,
   isValidAcademicYear,
   listAcademicMentorshipMappings,
@@ -43,6 +44,9 @@ export async function GET(request: NextRequest) {
   });
   if (!access.ok) {
     return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+  if (!isAcademicMentorshipManagementRole(access.permission)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   const includeHistory = request.nextUrl.searchParams.get("include_history") === "true";
   const groups = await listAcademicMentorshipMappings({

--- a/src/app/api/academic-mentorship/mappings/route.ts
+++ b/src/app/api/academic-mentorship/mappings/route.ts
@@ -1,128 +1,137 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
 
-import { authOptions } from "@/lib/auth";
 import {
   createAcademicMentorshipMapping,
   endAcademicMentorshipMapping,
-  getAcademicMentorshipActorUserId,
   isAcademicMentorshipManagementRole,
   isAcademicMentorshipEditableYear,
-  isValidAcademicYear,
   listAcademicMentorshipMappings,
   reassignAcademicMentorshipMapping,
-  requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
 import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
+import {
+  academicMentorshipError,
+  getAcademicMentorshipSession,
+  parseSchoolYear,
+  parseSchoolYearSearchParams,
+  positiveInteger,
+  readAcademicMentorshipJsonBody,
+  requireAcademicMentorshipActor,
+  requireAcademicMentorshipRouteAccess,
+  stringValue,
+  type AcademicMentorshipRouteSession,
+  type ApiResult,
+} from "../route-helpers";
+
+interface EditContext {
+  session: AcademicMentorshipRouteSession;
+  body: Record<string, unknown>;
+  schoolCode: string;
+  academicYear: string;
+}
+
+async function readEditContext(request: NextRequest): Promise<ApiResult<EditContext>> {
+  const session = await getAcademicMentorshipSession();
+  if (!session.ok) return session;
+
+  const body = await readAcademicMentorshipJsonBody(request);
+  if (!body.ok) return body;
+
+  const parsed = parseSchoolYear({
+    schoolCode: stringValue(body.value.school_code),
+    academicYear: stringValue(body.value.academic_year),
+    requireEditable: true,
+  });
+  if (!parsed.ok) return parsed;
+
+  return {
+    ok: true,
+    value: {
+      session: session.value,
+      body: body.value,
+      schoolCode: parsed.value.schoolCode,
+      academicYear: parsed.value.academicYear,
+    },
+  };
+}
+
+function parseMappingId(body: Record<string, unknown>): ApiResult<number> {
+  const mappingId = positiveInteger(body.mapping_id);
+  if (mappingId === null) {
+    return { ok: false, response: academicMentorshipError("mapping_id is required", 400) };
+  }
+  return { ok: true, value: mappingId };
+}
+
+async function readMappingEditContext(
+  request: NextRequest
+): Promise<ApiResult<EditContext & { mappingId: number }>> {
+  const context = await readEditContext(request);
+  if (!context.ok) return context;
+
+  const mappingId = parseMappingId(context.value.body);
+  if (!mappingId.ok) return mappingId;
+
+  return { ok: true, value: { ...context.value, mappingId: mappingId.value } };
+}
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.isPasscodeUser) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const session = await getAcademicMentorshipSession();
+  if (!session.ok) return session.response;
+
+  const parsed = parseSchoolYearSearchParams(request, {
+    defaultAcademicYear: CURRENT_ACADEMIC_YEAR,
+    missingSchoolCodeMessage: "school_code query parameter is required",
+  });
+  if (!parsed.ok) return parsed.response;
+
+  const access = await requireAcademicMentorshipRouteAccess(
+    session.value,
+    "view",
+    parsed.value.schoolCode
+  );
+  if (!access.ok) return access.response;
+  if (!isAcademicMentorshipManagementRole(access.value.permission)) {
+    return academicMentorshipError("Forbidden", 403);
   }
 
-  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
-  if (!schoolCode) {
-    return NextResponse.json(
-      { error: "school_code query parameter is required" },
-      { status: 400 }
-    );
-  }
-  const academicYear =
-    request.nextUrl.searchParams.get("academic_year")?.trim() || CURRENT_ACADEMIC_YEAR;
-  if (!isValidAcademicYear(academicYear)) {
-    return NextResponse.json(
-      { error: "academic_year must use YYYY-YYYY format" },
-      { status: 400 }
-    );
-  }
-  const access = await requireAcademicMentorshipAccess(session, "view", {
-    schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
-  if (!isAcademicMentorshipManagementRole(access.permission)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
   const includeHistory = request.nextUrl.searchParams.get("include_history") === "true";
   const groups = await listAcademicMentorshipMappings({
-    schoolId: access.school!.id,
-    academicYear,
+    schoolId: access.value.school!.id,
+    academicYear: parsed.value.academicYear,
     includeHistory,
   });
 
   return NextResponse.json({
-    school: access.school,
-    academicYear,
+    school: access.value.school,
+    academicYear: parsed.value.academicYear,
     includeHistory,
-    canEdit: access.canEdit && isAcademicMentorshipEditableYear(academicYear),
+    canEdit: access.value.canEdit && isAcademicMentorshipEditableYear(parsed.value.academicYear),
     groups,
   });
 }
 
-function positiveInteger(value: unknown): number | null {
-  const numberValue = Number(value);
-  return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null;
-}
-
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const context = await readEditContext(request);
+  if (!context.ok) return context.response;
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
-  if (!schoolCode) {
-    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
-  }
-  const academicYear =
-    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
-  if (!isValidAcademicYear(academicYear)) {
-    return NextResponse.json(
-      { error: "academic_year must use YYYY-YYYY format" },
-      { status: 400 }
-    );
-  }
-  if (!isAcademicMentorshipEditableYear(academicYear)) {
-    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
-  }
+  const { session, body, schoolCode, academicYear } = context.value;
   const mentorUserId = positiveInteger(body.mentor_user_id);
   if (mentorUserId === null) {
-    return NextResponse.json({ error: "mentor_user_id is required" }, { status: 400 });
+    return academicMentorshipError("mentor_user_id is required", 400);
   }
   const studentPkId = positiveInteger(body.student_id);
   if (studentPkId === null) {
-    return NextResponse.json({ error: "student_id is required" }, { status: 400 });
+    return academicMentorshipError("student_id is required", 400);
   }
 
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
-  const actorUserId = await getAcademicMentorshipActorUserId(
-    access.email,
-    access.permission
-  );
-  if (actorUserId === null) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const actor = await requireAcademicMentorshipActor(session, schoolCode);
+  if (!actor.ok) return actor.response;
+  const { access, actorUserId } = actor.value;
 
   const result = await createAcademicMentorshipMapping({
     schoolId: access.school!.id,
-    schoolCode: access.school!.code,
+    schoolCode,
     schoolRegion: access.school!.region,
     academicYear,
     mentorUserId,
@@ -130,7 +139,7 @@ export async function POST(request: NextRequest) {
     assignedByUserId: actorUserId,
   });
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return academicMentorshipError(result.error, result.status);
   }
 
   return NextResponse.json(
@@ -140,51 +149,14 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const context = await readMappingEditContext(request);
+  if (!context.ok) return context.response;
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const { session, schoolCode, academicYear, mappingId } = context.value;
 
-  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
-  if (!schoolCode) {
-    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
-  }
-  const academicYear =
-    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
-  if (!isValidAcademicYear(academicYear)) {
-    return NextResponse.json(
-      { error: "academic_year must use YYYY-YYYY format" },
-      { status: 400 }
-    );
-  }
-  if (!isAcademicMentorshipEditableYear(academicYear)) {
-    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
-  }
-  const mappingId = positiveInteger(body.mapping_id);
-  if (mappingId === null) {
-    return NextResponse.json({ error: "mapping_id is required" }, { status: 400 });
-  }
-
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
-  const actorUserId = await getAcademicMentorshipActorUserId(
-    access.email,
-    access.permission
-  );
-  if (actorUserId === null) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const actor = await requireAcademicMentorshipActor(session, schoolCode);
+  if (!actor.ok) return actor.response;
+  const { access, actorUserId } = actor.value;
 
   const result = await endAcademicMentorshipMapping({
     schoolId: access.school!.id,
@@ -193,62 +165,25 @@ export async function DELETE(request: NextRequest) {
     endedByUserId: actorUserId,
   });
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return academicMentorshipError(result.error, result.status);
   }
 
   return NextResponse.json({ success: true, mappingId: result.mappingId });
 }
 
 export async function PATCH(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const context = await readMappingEditContext(request);
+  if (!context.ok) return context.response;
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const schoolCode = typeof body.school_code === "string" ? body.school_code.trim() : "";
-  if (!schoolCode) {
-    return NextResponse.json({ error: "school_code is required" }, { status: 400 });
-  }
-  const academicYear =
-    typeof body.academic_year === "string" ? body.academic_year.trim() : "";
-  if (!isValidAcademicYear(academicYear)) {
-    return NextResponse.json(
-      { error: "academic_year must use YYYY-YYYY format" },
-      { status: 400 }
-    );
-  }
-  if (!isAcademicMentorshipEditableYear(academicYear)) {
-    return NextResponse.json({ error: "Academic year is not editable" }, { status: 403 });
-  }
-  const mappingId = positiveInteger(body.mapping_id);
-  if (mappingId === null) {
-    return NextResponse.json({ error: "mapping_id is required" }, { status: 400 });
-  }
+  const { session, body, schoolCode, academicYear, mappingId } = context.value;
   const mentorUserId = positiveInteger(body.mentor_user_id);
   if (mentorUserId === null) {
-    return NextResponse.json({ error: "mentor_user_id is required" }, { status: 400 });
+    return academicMentorshipError("mentor_user_id is required", 400);
   }
 
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
-  const actorUserId = await getAcademicMentorshipActorUserId(
-    access.email,
-    access.permission
-  );
-  if (actorUserId === null) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const actor = await requireAcademicMentorshipActor(session, schoolCode);
+  if (!actor.ok) return actor.response;
+  const { access, actorUserId } = actor.value;
 
   const result = await reassignAcademicMentorshipMapping({
     schoolId: access.school!.id,
@@ -260,7 +195,7 @@ export async function PATCH(request: NextRequest) {
     assignedByUserId: actorUserId,
   });
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return academicMentorshipError(result.error, result.status);
   }
 
   return NextResponse.json({ success: true, mappingId: result.mappingId });

--- a/src/app/api/academic-mentorship/options/route.test.ts
+++ b/src/app/api/academic-mentorship/options/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetServerSession } = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@/lib/db";
+import { GET } from "./route";
+import { PROGRAM_IDS } from "@/lib/constants";
+
+const mockQuery = vi.mocked(query);
+
+function request(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe("GET /api/academic-mentorship/options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it("returns searchable Academic Mentor options after view access is granted", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          user_id: 101,
+          name: "Anita Mentor",
+          email: "anita@avantifellows.org",
+        },
+      ]);
+
+    const response = await GET(
+      request("/api/academic-mentorship/options?type=mentors&school_code=SCH001&q=anita")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.options).toEqual([
+      {
+        userId: 101,
+        name: "Anita Mentor",
+        email: "anita@avantifellows.org",
+      },
+    ]);
+    const optionCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("FROM teacher t")
+    );
+    expect(optionCall?.[1]).toEqual(["SCH001", "North", 20, "%anita%"]);
+  });
+
+  it("returns searchable Mentee options for the selected academic year", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "admin@avantifellows.org" },
+    });
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: [PROGRAM_IDS.NVS],
+          read_only: false,
+          user_id: 501,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          student_pk_id: 201,
+          name: "Meena Student",
+          student_id: "STU001",
+          grade: 11,
+          program_id: 64,
+        },
+      ]);
+
+    const response = await GET(
+      request(
+        "/api/academic-mentorship/options?type=mentees&school_code=SCH001&academic_year=2026-2027&q=STU"
+      )
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.options).toEqual([
+      {
+        studentPkId: 201,
+        name: "Meena Student",
+        studentId: "STU001",
+        grade: 11,
+        programId: 64,
+      },
+    ]);
+    const optionCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("active_mapping.id IS NULL")
+    );
+    expect(optionCall?.[1]).toEqual([20, "2026-2027", "%STU%"]);
+  });
+
+  it("returns 401 before database access when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const response = await GET(
+      request("/api/academic-mentorship/options?type=mentors&school_code=SCH001")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/academic-mentorship/options/route.test.ts
+++ b/src/app/api/academic-mentorship/options/route.test.ts
@@ -27,7 +27,7 @@ describe("GET /api/academic-mentorship/options", () => {
     mockQuery.mockReset();
   });
 
-  it("returns searchable Academic Mentor options after view access is granted", async () => {
+  it("returns searchable Academic Mentor options after edit access is granted", async () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: "admin@avantifellows.org" },
     });
@@ -138,5 +138,32 @@ describe("GET /api/academic-mentorship/options", () => {
     expect(response.status).toBe(401);
     expect(body.error).toBe("Unauthorized");
     expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects read-only users before exposing selector options", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: "readonly@avantifellows.org" },
+    });
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "readonly@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.NVS],
+        read_only: true,
+        user_id: 501,
+      },
+    ]);
+
+    const response = await GET(
+      request("/api/academic-mentorship/options?type=mentors&school_code=SCH001")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/academic-mentorship/options/route.test.ts
+++ b/src/app/api/academic-mentorship/options/route.test.ts
@@ -124,7 +124,7 @@ describe("GET /api/academic-mentorship/options", () => {
     const optionCall = mockQuery.mock.calls.find(([sql]) =>
       String(sql).includes("active_mapping.id IS NULL")
     );
-    expect(optionCall?.[1]).toEqual([20, "2026-2027", "%STU%"]);
+    expect(optionCall?.[1]).toEqual([20, "2026-2027", "%STU%", null]);
   });
 
   it("returns 401 before database access when unauthenticated", async () => {

--- a/src/app/api/academic-mentorship/options/route.ts
+++ b/src/app/api/academic-mentorship/options/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import {
+  isValidAcademicYear,
+  listAcademicMentorshipMenteeOptions,
+  listAcademicMentorshipMentorOptions,
+  requireAcademicMentorshipAccess,
+} from "@/lib/academic-mentorship";
+import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const type = request.nextUrl.searchParams.get("type")?.trim();
+  if (type !== "mentors" && type !== "mentees") {
+    return NextResponse.json(
+      { error: "type must be mentors or mentees" },
+      { status: 400 }
+    );
+  }
+
+  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
+  if (!schoolCode) {
+    return NextResponse.json(
+      { error: "school_code query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  const access = await requireAcademicMentorshipAccess(session, "view", {
+    schoolCode,
+  });
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const search = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+  if (type === "mentors") {
+    const options = await listAcademicMentorshipMentorOptions({
+      schoolId: access.school!.id,
+      schoolCode: access.school!.code,
+      schoolRegion: access.school!.region,
+      search,
+    });
+    return NextResponse.json({ options });
+  }
+
+  const academicYear =
+    request.nextUrl.searchParams.get("academic_year")?.trim() || CURRENT_ACADEMIC_YEAR;
+  if (!isValidAcademicYear(academicYear)) {
+    return NextResponse.json(
+      { error: "academic_year must use YYYY-YYYY format" },
+      { status: 400 }
+    );
+  }
+
+  const options = await listAcademicMentorshipMenteeOptions({
+    schoolId: access.school!.id,
+    academicYear,
+    search,
+  });
+  return NextResponse.json({ options });
+}

--- a/src/app/api/academic-mentorship/options/route.ts
+++ b/src/app/api/academic-mentorship/options/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const access = await requireAcademicMentorshipAccess(session, "view", {
+  const access = await requireAcademicMentorshipAccess(session, "edit", {
     schoolCode,
   });
   if (!access.ok) {

--- a/src/app/api/academic-mentorship/options/route.ts
+++ b/src/app/api/academic-mentorship/options/route.ts
@@ -10,6 +10,7 @@ import {
   getAcademicMentorshipSession,
   parseAcademicYear,
   parseSchoolCode,
+  positiveInteger,
   requireAcademicMentorshipRouteAccess,
 } from "../route-helpers";
 
@@ -36,6 +37,7 @@ export async function GET(request: NextRequest) {
   if (!access.ok) return access.response;
 
   const search = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+  const programId = positiveInteger(request.nextUrl.searchParams.get("program_id"));
   if (type === "mentors") {
     const options = await listAcademicMentorshipMentorOptions({
       schoolId: access.value.school!.id,
@@ -55,6 +57,7 @@ export async function GET(request: NextRequest) {
   const options = await listAcademicMentorshipMenteeOptions({
     schoolId: access.value.school!.id,
     academicYear: academicYear.value,
+    programId,
     search,
   });
   return NextResponse.json({ options });

--- a/src/app/api/academic-mentorship/options/route.ts
+++ b/src/app/api/academic-mentorship/options/route.ts
@@ -1,67 +1,60 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
 
-import { authOptions } from "@/lib/auth";
 import {
-  isValidAcademicYear,
   listAcademicMentorshipMenteeOptions,
   listAcademicMentorshipMentorOptions,
-  requireAcademicMentorshipAccess,
 } from "@/lib/academic-mentorship";
 import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
+import {
+  academicMentorshipError,
+  getAcademicMentorshipSession,
+  parseAcademicYear,
+  parseSchoolCode,
+  requireAcademicMentorshipRouteAccess,
+} from "../route-helpers";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const session = await getAcademicMentorshipSession();
+  if (!session.ok) return session.response;
 
   const type = request.nextUrl.searchParams.get("type")?.trim();
   if (type !== "mentors" && type !== "mentees") {
-    return NextResponse.json(
-      { error: "type must be mentors or mentees" },
-      { status: 400 }
-    );
+    return academicMentorshipError("type must be mentors or mentees", 400);
   }
 
-  const schoolCode = request.nextUrl.searchParams.get("school_code")?.trim();
-  if (!schoolCode) {
-    return NextResponse.json(
-      { error: "school_code query parameter is required" },
-      { status: 400 }
-    );
-  }
+  const schoolCode = parseSchoolCode(
+    request.nextUrl.searchParams.get("school_code"),
+    "school_code query parameter is required"
+  );
+  if (!schoolCode.ok) return schoolCode.response;
 
-  const access = await requireAcademicMentorshipAccess(session, "edit", {
-    schoolCode,
-  });
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
-  }
+  const access = await requireAcademicMentorshipRouteAccess(
+    session.value,
+    "edit",
+    schoolCode.value
+  );
+  if (!access.ok) return access.response;
 
   const search = request.nextUrl.searchParams.get("q")?.trim() ?? "";
   if (type === "mentors") {
     const options = await listAcademicMentorshipMentorOptions({
-      schoolId: access.school!.id,
-      schoolCode: access.school!.code,
-      schoolRegion: access.school!.region,
+      schoolId: access.value.school!.id,
+      schoolCode: access.value.school!.code,
+      schoolRegion: access.value.school!.region,
       search,
     });
     return NextResponse.json({ options });
   }
 
-  const academicYear =
-    request.nextUrl.searchParams.get("academic_year")?.trim() || CURRENT_ACADEMIC_YEAR;
-  if (!isValidAcademicYear(academicYear)) {
-    return NextResponse.json(
-      { error: "academic_year must use YYYY-YYYY format" },
-      { status: 400 }
-    );
-  }
+  const academicYear = parseAcademicYear(
+    request.nextUrl.searchParams.get("academic_year"),
+    { defaultAcademicYear: CURRENT_ACADEMIC_YEAR }
+  );
+  if (!academicYear.ok) return academicYear.response;
 
   const options = await listAcademicMentorshipMenteeOptions({
-    schoolId: access.school!.id,
-    academicYear,
+    schoolId: access.value.school!.id,
+    academicYear: academicYear.value,
     search,
   });
   return NextResponse.json({ options });

--- a/src/app/api/academic-mentorship/route-helpers.ts
+++ b/src/app/api/academic-mentorship/route-helpers.ts
@@ -1,0 +1,163 @@
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authOptions } from "@/lib/auth";
+import {
+  getAcademicMentorshipActorUserId,
+  isAcademicMentorshipEditableYear,
+  isValidAcademicYear,
+  requireAcademicMentorshipAccess,
+  type AcademicMentorshipAction,
+} from "@/lib/academic-mentorship";
+
+export type ApiResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; response: NextResponse };
+
+type ApiSession = NonNullable<Awaited<ReturnType<typeof getServerSession>>> & {
+  user: { email: string };
+  isPasscodeUser?: boolean;
+};
+export type AcademicMentorshipRouteSession = ApiSession;
+type AccessResult = Awaited<ReturnType<typeof requireAcademicMentorshipAccess>>;
+type OkAccess = Extract<AccessResult, { ok: true }>;
+export type AcademicMentorshipRouteAccess = OkAccess;
+export interface AcademicMentorshipActorContext {
+  access: AcademicMentorshipRouteAccess;
+  actorUserId: number;
+}
+
+export function academicMentorshipError(error: string, status: number): NextResponse {
+  return NextResponse.json({ error }, { status });
+}
+
+export async function getAcademicMentorshipSession(): Promise<ApiResult<ApiSession>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return { ok: false, response: academicMentorshipError("Unauthorized", 401) };
+  }
+  return { ok: true, value: session as ApiSession };
+}
+
+export async function readAcademicMentorshipJsonBody(
+  request: NextRequest
+): Promise<ApiResult<Record<string, unknown>>> {
+  try {
+    return { ok: true, value: (await request.json()) as Record<string, unknown> };
+  } catch {
+    return { ok: false, response: academicMentorshipError("Invalid JSON body", 400) };
+  }
+}
+
+export function positiveInteger(value: unknown): number | null {
+  const numberValue = Number(value);
+  return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null;
+}
+
+export function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function formString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+export function parseSchoolCode(
+  value: string | null | undefined,
+  missingMessage = "school_code is required"
+): ApiResult<string> {
+  const schoolCode = value?.trim() ?? "";
+  if (!schoolCode) {
+    return { ok: false, response: academicMentorshipError(missingMessage, 400) };
+  }
+  return { ok: true, value: schoolCode };
+}
+
+export function parseAcademicYear(
+  value: string | null | undefined,
+  options: { defaultAcademicYear?: string; requireEditable?: boolean } = {}
+): ApiResult<string> {
+  const academicYear = value?.trim() || options.defaultAcademicYear || "";
+  if (!isValidAcademicYear(academicYear)) {
+    return {
+      ok: false,
+      response: academicMentorshipError("academic_year must use YYYY-YYYY format", 400),
+    };
+  }
+  if (options.requireEditable && !isAcademicMentorshipEditableYear(academicYear)) {
+    return { ok: false, response: academicMentorshipError("Academic year is not editable", 403) };
+  }
+  return { ok: true, value: academicYear };
+}
+
+export function parseSchoolYear(params: {
+  schoolCode: string | null | undefined;
+  academicYear: string | null | undefined;
+  defaultAcademicYear?: string;
+  requireEditable?: boolean;
+  missingSchoolCodeMessage?: string;
+}): ApiResult<{ schoolCode: string; academicYear: string }> {
+  const schoolCode = parseSchoolCode(
+    params.schoolCode,
+    params.missingSchoolCodeMessage
+  );
+  if (!schoolCode.ok) return schoolCode;
+
+  const academicYear = parseAcademicYear(params.academicYear, {
+    defaultAcademicYear: params.defaultAcademicYear,
+    requireEditable: params.requireEditable,
+  });
+  if (!academicYear.ok) return academicYear;
+
+  return {
+    ok: true,
+    value: { schoolCode: schoolCode.value, academicYear: academicYear.value },
+  };
+}
+
+export function parseSchoolYearSearchParams(
+  request: NextRequest,
+  options: {
+    defaultAcademicYear?: string;
+    requireEditable?: boolean;
+    missingSchoolCodeMessage?: string;
+  } = {}
+): ApiResult<{ schoolCode: string; academicYear: string }> {
+  return parseSchoolYear({
+    schoolCode: request.nextUrl.searchParams.get("school_code"),
+    academicYear: request.nextUrl.searchParams.get("academic_year"),
+    defaultAcademicYear: options.defaultAcademicYear,
+    requireEditable: options.requireEditable,
+    missingSchoolCodeMessage: options.missingSchoolCodeMessage,
+  });
+}
+
+export async function requireAcademicMentorshipRouteAccess(
+  session: ApiSession,
+  action: AcademicMentorshipAction,
+  schoolCode: string
+): Promise<ApiResult<OkAccess>> {
+  const access = await requireAcademicMentorshipAccess(session, action, { schoolCode });
+  if (!access.ok) {
+    return { ok: false, response: academicMentorshipError(access.error, access.status) };
+  }
+  return { ok: true, value: access };
+}
+
+export async function requireAcademicMentorshipActor(
+  session: ApiSession,
+  schoolCode: string
+): Promise<ApiResult<AcademicMentorshipActorContext>> {
+  const access = await requireAcademicMentorshipRouteAccess(session, "edit", schoolCode);
+  if (!access.ok) return access;
+
+  const actorUserId = await getAcademicMentorshipActorUserId(
+    access.value.email,
+    access.value.permission
+  );
+  if (actorUserId === null) {
+    return { ok: false, response: academicMentorshipError("Forbidden", 403) };
+  }
+  return { ok: true, value: { access: access.value, actorUserId } };
+}

--- a/src/app/api/academic-mentorship/route-helpers.ts
+++ b/src/app/api/academic-mentorship/route-helpers.ts
@@ -5,6 +5,7 @@ import { authOptions } from "@/lib/auth";
 import {
   getAcademicMentorshipActorUserId,
   isAcademicMentorshipEditableYear,
+  isAcademicMentorshipSupportedYear,
   isValidAcademicYear,
   requireAcademicMentorshipAccess,
   type AcademicMentorshipAction,
@@ -76,7 +77,7 @@ export function parseSchoolCode(
 
 export function parseAcademicYear(
   value: string | null | undefined,
-  options: { defaultAcademicYear?: string; requireEditable?: boolean } = {}
+  options: { defaultAcademicYear?: string; requireEditable?: boolean; requireSupported?: boolean } = {}
 ): ApiResult<string> {
   const academicYear = value?.trim() || options.defaultAcademicYear || "";
   if (!isValidAcademicYear(academicYear)) {
@@ -84,6 +85,9 @@ export function parseAcademicYear(
       ok: false,
       response: academicMentorshipError("academic_year must use YYYY-YYYY format", 400),
     };
+  }
+  if (options.requireSupported && !isAcademicMentorshipSupportedYear(academicYear)) {
+    return { ok: false, response: academicMentorshipError("Academic year is not supported", 400) };
   }
   if (options.requireEditable && !isAcademicMentorshipEditableYear(academicYear)) {
     return { ok: false, response: academicMentorshipError("Academic year is not editable", 403) };
@@ -96,6 +100,7 @@ export function parseSchoolYear(params: {
   academicYear: string | null | undefined;
   defaultAcademicYear?: string;
   requireEditable?: boolean;
+  requireSupported?: boolean;
   missingSchoolCodeMessage?: string;
 }): ApiResult<{ schoolCode: string; academicYear: string }> {
   const schoolCode = parseSchoolCode(
@@ -107,6 +112,7 @@ export function parseSchoolYear(params: {
   const academicYear = parseAcademicYear(params.academicYear, {
     defaultAcademicYear: params.defaultAcademicYear,
     requireEditable: params.requireEditable,
+    requireSupported: params.requireSupported,
   });
   if (!academicYear.ok) return academicYear;
 
@@ -121,6 +127,7 @@ export function parseSchoolYearSearchParams(
   options: {
     defaultAcademicYear?: string;
     requireEditable?: boolean;
+    requireSupported?: boolean;
     missingSchoolCodeMessage?: string;
   } = {}
 ): ApiResult<{ schoolCode: string; academicYear: string }> {
@@ -129,6 +136,7 @@ export function parseSchoolYearSearchParams(
     academicYear: request.nextUrl.searchParams.get("academic_year"),
     defaultAcademicYear: options.defaultAcademicYear,
     requireEditable: options.requireEditable,
+    requireSupported: options.requireSupported,
     missingSchoolCodeMessage: options.missingSchoolCodeMessage,
   });
 }

--- a/src/app/api/admin/route-helpers.ts
+++ b/src/app/api/admin/route-helpers.ts
@@ -1,0 +1,29 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+
+import { authOptions } from "@/lib/auth";
+import { isAdmin } from "@/lib/permissions";
+
+type AdminApiResult =
+  | { ok: true; email: string }
+  | { ok: false; response: NextResponse };
+
+export async function requireAdminApiAccess(): Promise<AdminApiResult> {
+  const session = await getServerSession(authOptions);
+  const email = session?.user?.email;
+  if (!email) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  if (!(await isAdmin(email))) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, email };
+}

--- a/src/app/api/admin/schools/route.ts
+++ b/src/app/api/admin/schools/route.ts
@@ -1,21 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
 import { query } from "@/lib/db";
+import { requireAdminApiAccess } from "../route-helpers";
 
 // GET /api/admin/schools - List all JNV schools or search
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireAdminApiAccess();
+  if (!access.ok) return access.response;
 
   const { searchParams } = new URL(request.url);
   const search = searchParams.get("q") || "";

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -50,6 +50,7 @@ describe("DELETE /api/admin/users/[id]", () => {
     const req = jsonRequest("http://localhost/api/admin/users/5", { method: "DELETE" });
     const res = await DELETE(req as never, params);
     expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it("returns 403 when not admin", async () => {
@@ -58,6 +59,7 @@ describe("DELETE /api/admin/users/[id]", () => {
     const req = jsonRequest("http://localhost/api/admin/users/5", { method: "DELETE" });
     const res = await DELETE(req as never, params);
     expect(res.status).toBe(403);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it("prevents deleting yourself", async () => {
@@ -72,11 +74,38 @@ describe("DELETE /api/admin/users/[id]", () => {
     expect(json.error).toContain("Cannot delete your own");
   });
 
+  it("blocks deleting a user with Academic Mentor-Mentee Mapping history", async () => {
+    mockSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsAdmin.mockResolvedValue(true);
+    mockQuery
+      .mockResolvedValueOnce([{ email: "mentor@test.com", user_id: 70 }])
+      .mockResolvedValueOnce([
+        {
+          school_code: "54019",
+          academic_year: "2026-2027",
+        },
+      ]);
+
+    const req = jsonRequest("http://localhost/api/admin/users/5", { method: "DELETE" });
+    const res = await DELETE(req as never, params);
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("Academic Mentor-Mentee Mapping history");
+    expect(json.error).toContain(
+      "/admin/academic-mentorship?school_code=54019&academic_year=2026-2027"
+    );
+    expect(String(mockQuery.mock.calls[1][0])).toContain("m.mentor_user_id = $1");
+    expect(mockQuery.mock.calls[1][1]).toEqual([70]);
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
   it("deletes another user and vacates their centre seats", async () => {
     mockSession.mockResolvedValue(ADMIN_SESSION);
     mockIsAdmin.mockResolvedValue(true);
     mockQuery
       .mockResolvedValueOnce([{ email: "other@test.com", user_id: 70 }]) // lookup
+      .mockResolvedValueOnce([]) // mapping history blocker
       .mockResolvedValueOnce([]) // vacate seats (soft-delete)
       .mockResolvedValueOnce([]); // delete permission
 

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -100,6 +100,25 @@ describe("DELETE /api/admin/users/[id]", () => {
     expect(mockWithTransaction).not.toHaveBeenCalled();
   });
 
+  it("resolves legacy null permission user_id by email before mapping-history checks", async () => {
+    mockSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsAdmin.mockResolvedValue(true);
+    mockQuery
+      .mockResolvedValueOnce([{ email: "mentor@test.com", user_id: 70 }])
+      .mockResolvedValueOnce([{ school_code: "54019", academic_year: "2026-2027" }]);
+
+    const req = jsonRequest("http://localhost/api/admin/users/5", { method: "DELETE" });
+    const res = await DELETE(req as never, params);
+
+    expect(res.status).toBe(409);
+    expect(String(mockQuery.mock.calls[0][0])).toContain(
+      "COALESCE(up.user_id, u.id) AS user_id"
+    );
+    expect(String(mockQuery.mock.calls[0][0])).toContain("LOWER(u.email) = LOWER(up.email)");
+    expect(mockQuery.mock.calls[1][1]).toEqual([70]);
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
   it("deletes another user and vacates their centre seats", async () => {
     mockSession.mockResolvedValue(ADMIN_SESSION);
     mockIsAdmin.mockResolvedValue(true);

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -25,7 +25,15 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
   // Prevent deleting yourself
   const userToDelete = await query<{ email: string; user_id: number | null }>(
-    `SELECT email, user_id FROM user_permission WHERE id = $1`,
+    `SELECT up.email,
+            COALESCE(up.user_id, u.id) AS user_id
+     FROM user_permission up
+     LEFT JOIN "user" u
+       ON up.user_id IS NULL
+      AND LOWER(u.email) = LOWER(up.email)
+     WHERE up.id = $1
+     ORDER BY u.id
+     LIMIT 1`,
     [id]
   );
 

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
 import { query, withTransaction } from "@/lib/db";
 import { blockIfAcademicMentorshipHistory } from "@/lib/staff-admin";
+import { requireAdminApiAccess } from "../../route-helpers";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -11,17 +9,9 @@ interface RouteParams {
 
 // DELETE /api/admin/users/[id] - Delete user
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
-  const session = await getServerSession(authOptions);
+  const access = await requireAdminApiAccess();
   const { id } = await params;
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  if (!access.ok) return access.response;
 
   // Prevent deleting yourself
   const userToDelete = await query<{ email: string; user_id: number | null }>(
@@ -37,7 +27,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     [id]
   );
 
-  if (userToDelete.length > 0 && userToDelete[0].email.toLowerCase() === session.user.email.toLowerCase()) {
+  if (userToDelete.length > 0 && userToDelete[0].email.toLowerCase() === access.email.toLowerCase()) {
     return NextResponse.json(
       { error: "Cannot delete your own account" },
       { status: 400 }
@@ -77,17 +67,9 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
 // PATCH /api/admin/users/[id] - Update user
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
-  const session = await getServerSession(authOptions);
+  const access = await requireAdminApiAccess();
   const { id } = await params;
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  if (!access.ok) return access.response;
 
   try {
     const body = await request.json();

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { isAdmin } from "@/lib/permissions";
 import { query, withTransaction } from "@/lib/db";
+import { blockIfAcademicMentorshipHistory } from "@/lib/staff-admin";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -42,6 +43,16 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   // other systems; the roster already hides them once no live permission
   // exists, and a later re-add reactivates the dormant record.
   const targetUserId = userToDelete[0]?.user_id ?? null;
+  if (targetUserId != null) {
+    const blocker = await blockIfAcademicMentorshipHistory(Number(targetUserId));
+    if (blocker) {
+      return NextResponse.json(
+        { error: blocker.error, code: blocker.code },
+        { status: blocker.status }
+      );
+    }
+  }
+
   await withTransaction(async (client) => {
     if (targetUserId != null) {
       await client.query(

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,25 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
 import { CENTRE_ASSIGNMENTS_SUBQUERY } from "@/lib/centres";
 import { query } from "@/lib/db";
+import { requireAdminApiAccess } from "../route-helpers";
 
 // Disable Next.js caching for this route
 export const dynamic = "force-dynamic";
 
 // GET /api/admin/users - List all users
 export async function GET() {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireAdminApiAccess();
+  if (!access.ok) return access.response;
 
   const users = await query<{
     id: number;
@@ -47,16 +37,8 @@ export async function GET() {
 
 // POST /api/admin/users - Create new user
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireAdminApiAccess();
+  if (!access.ok) return access.response;
 
   try {
     const body = await request.json();

--- a/src/app/api/batches/[id]/route.ts
+++ b/src/app/api/batches/[id]/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
+import { requireAdminApiAccess } from "../../admin/route-helpers";
 
 const DB_SERVICE_URL = process.env.DB_SERVICE_URL;
 const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN;
@@ -15,16 +13,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireAdminApiAccess();
+  if (!access.ok) return access.response;
 
   const { id } = await params;
 

--- a/src/app/api/batches/route.ts
+++ b/src/app/api/batches/route.ts
@@ -1,22 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
+import { requireAdminApiAccess } from "../admin/route-helpers";
 
 const DB_SERVICE_URL = process.env.DB_SERVICE_URL;
 const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN;
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireAdminApiAccess();
+  if (!access.ok) return access.response;
 
   const { searchParams } = new URL(request.url);
   const programId = searchParams.get("program_id");

--- a/src/app/school-visit-summary/[id]/page.tsx
+++ b/src/app/school-visit-summary/[id]/page.tsx
@@ -191,7 +191,7 @@ function individualStudentDiscussionChips(stats: InlineStats): string[] {
   return chips;
 }
 
-const STATS_CHIP_BUILDERS: Record<string, StatsChipBuilder> = {
+const STATS_CHIP_BUILDERS: Partial<Record<string, StatsChipBuilder>> = {
   classroom_observation: classroomObservationChips,
   af_team_interaction: (stats) => [
     `Answered ${stats.answeredCount}/${stats.totalQuestions}`,

--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -12,6 +12,7 @@ const {
   mockRedirect,
   mockNotFound,
   mockProcessStudents,
+  mockGetAcademicMentorshipActorUserId,
   mockListAcademicMentorshipMappings,
   mockListAcademicMentorshipTeacherMentees,
 } = vi.hoisted(() => ({
@@ -27,6 +28,7 @@ const {
     throw new Error("NOT_FOUND");
   }),
   mockProcessStudents: vi.fn(),
+  mockGetAcademicMentorshipActorUserId: vi.fn(),
   mockListAcademicMentorshipMappings: vi.fn(),
   mockListAcademicMentorshipTeacherMentees: vi.fn(),
 }));
@@ -52,6 +54,7 @@ vi.mock("@/lib/school-student-list-data-issues", () => ({
   processStudents: mockProcessStudents,
 }));
 vi.mock("@/lib/academic-mentorship", () => ({
+  getAcademicMentorshipActorUserId: mockGetAcademicMentorshipActorUserId,
   listAcademicMentorshipMappings: mockListAcademicMentorshipMappings,
   listAcademicMentorshipTeacherMentees: mockListAcademicMentorshipTeacherMentees,
 }));
@@ -312,6 +315,7 @@ describe("SchoolPage (server component)", () => {
     });
     mockListAcademicMentorshipMappings.mockResolvedValue([]);
     mockListAcademicMentorshipTeacherMentees.mockResolvedValue([]);
+    mockGetAcademicMentorshipActorUserId.mockResolvedValue(101);
   });
 
   // --- Auth redirects ---
@@ -1247,7 +1251,7 @@ describe("SchoolPage (server component)", () => {
     expect(mockListAcademicMentorshipTeacherMentees).toHaveBeenCalledWith({
       schoolId: 20,
       academicYear: "2026-2027",
-      mentorEmail: "teacher@avantifellows.org",
+      mentorUserId: 101,
     });
     expect(mockListAcademicMentorshipMappings).not.toHaveBeenCalled();
   });

--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -12,6 +12,8 @@ const {
   mockRedirect,
   mockNotFound,
   mockProcessStudents,
+  mockListAcademicMentorshipMappings,
+  mockListAcademicMentorshipTeacherMentees,
 } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockGetUserPermission: vi.fn(),
@@ -25,6 +27,8 @@ const {
     throw new Error("NOT_FOUND");
   }),
   mockProcessStudents: vi.fn(),
+  mockListAcademicMentorshipMappings: vi.fn(),
+  mockListAcademicMentorshipTeacherMentees: vi.fn(),
 }));
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
@@ -46,6 +50,10 @@ vi.mock("@/lib/permissions", async (importOriginal) => {
 vi.mock("@/lib/db", () => ({ query: mockQuery }));
 vi.mock("@/lib/school-student-list-data-issues", () => ({
   processStudents: mockProcessStudents,
+}));
+vi.mock("@/lib/academic-mentorship", () => ({
+  listAcademicMentorshipMappings: mockListAcademicMentorshipMappings,
+  listAcademicMentorshipTeacherMentees: mockListAcademicMentorshipTeacherMentees,
 }));
 vi.mock("next/link", () => ({
   __esModule: true,
@@ -302,6 +310,8 @@ describe("SchoolPage (server component)", () => {
     mockNotFound.mockImplementation(() => {
       throw new Error("NOT_FOUND");
     });
+    mockListAcademicMentorshipMappings.mockResolvedValue([]);
+    mockListAcademicMentorshipTeacherMentees.mockResolvedValue([]);
   });
 
   // --- Auth redirects ---
@@ -393,10 +403,13 @@ describe("SchoolPage (server component)", () => {
     // Only enrollment tab should be visible (passcode user gets none for other features)
     expect(screen.getByTestId("tab-enrollment")).toBeInTheDocument();
     expect(screen.queryByTestId("tab-curriculum")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tab-mentorship")).not.toBeInTheDocument();
     expect(screen.queryByTestId("tab-visits")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Curriculum Summary" })
     ).not.toBeInTheDocument();
+    expect(mockListAcademicMentorshipMappings).not.toHaveBeenCalled();
+    expect(mockListAcademicMentorshipTeacherMentees).not.toHaveBeenCalled();
   });
 
   // --- Google user permission checks ---
@@ -1190,8 +1203,7 @@ describe("SchoolPage (server component)", () => {
     await renderPage();
 
     const batchQuery = mockQuery.mock.calls.find(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (call: any[]) =>
+      (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("FROM batch b")
     );
     expect(batchQuery).toBeDefined();
@@ -1200,15 +1212,199 @@ describe("SchoolPage (server component)", () => {
 
   // --- Mentorship tab content ---
 
-  it("renders mentorship tab with coming soon message", async () => {
-    setupAdminDefaults();
+  it("renders Teacher current active Academic Mentorship Mentees as a flat list", async () => {
+    setupAdminDefaults({ id: 20 });
+    mockGetServerSession.mockResolvedValue(
+      googleSession({ user: { email: "teacher@avantifellows.org" } })
+    );
+    mockGetUserPermission.mockResolvedValue(
+      makePermission({ role: "teacher", email: "teacher@avantifellows.org" })
+    );
+    mockListAcademicMentorshipTeacherMentees.mockResolvedValue([
+      {
+        studentPkId: 201,
+        name: "Anaya Student",
+        studentId: "STU002",
+        grade: 10,
+        assignedDate: "2026-07-02",
+      },
+      {
+        studentPkId: 202,
+        name: "Ravi Student",
+        studentId: "STU001",
+        grade: 11,
+        assignedDate: "2026-07-01",
+      },
+    ]);
 
     await renderPage();
 
     expect(screen.getByTestId("tab-mentorship")).toBeInTheDocument();
+    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
+    expect(screen.getByText("Anaya Student")).toBeInTheDocument();
+    expect(screen.getByText("Ravi Student")).toBeInTheDocument();
+    expect(screen.queryByText("Manage mappings")).not.toBeInTheDocument();
+    expect(mockListAcademicMentorshipTeacherMentees).toHaveBeenCalledWith({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      mentorEmail: "teacher@avantifellows.org",
+    });
+    expect(mockListAcademicMentorshipMappings).not.toHaveBeenCalled();
+  });
+
+  it("renders Admin read-only Academic Mentorship overview with a prefilled Manage mappings link", async () => {
+    setupAdminDefaults({ id: 20, code: "SCH001" });
+    mockListAcademicMentorshipMappings.mockResolvedValue([
+      {
+        mentor: {
+          userId: 101,
+          name: "Anita Mentor",
+          email: "anita@avantifellows.org",
+        },
+        menteeCount: 1,
+        mappings: [
+          {
+            id: 1,
+            mentee: {
+              studentPkId: 201,
+              name: "Meena Student",
+              studentId: "STU001",
+              grade: 11,
+            },
+            assignedDate: "2026-07-01",
+            endedDate: null,
+            status: "active",
+          },
+        ],
+      },
+    ]);
+
+    await renderPage();
+
+    expect(screen.getByText("Anita Mentor")).toBeInTheDocument();
+    expect(screen.getByText("Meena Student")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Manage mappings" })).toHaveAttribute(
+      "href",
+      "/admin/academic-mentorship?school_code=SCH001&academic_year=2026-2027"
+    );
+    expect(mockListAcademicMentorshipMappings).toHaveBeenCalledWith({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      includeHistory: false,
+    });
+  });
+
+  it("renders Teacher empty state when no current active Mentees exist", async () => {
+    setupAdminDefaults({ id: 20 });
+    mockGetServerSession.mockResolvedValue(
+      googleSession({ user: { email: "teacher@avantifellows.org" } })
+    );
+    mockGetUserPermission.mockResolvedValue(
+      makePermission({ role: "teacher", email: "teacher@avantifellows.org" })
+    );
+    mockListAcademicMentorshipTeacherMentees.mockResolvedValue([]);
+
+    await renderPage();
+
     expect(
-      screen.getByText("Mentorship data coming soon.")
+      screen.getByText("No mentees assigned for this academic year.")
     ).toBeInTheDocument();
+  });
+
+  it("renders Program Manager read-only overview without a Manage mappings link", async () => {
+    setupAdminDefaults({ id: 20 });
+    mockGetUserPermission.mockResolvedValue(
+      makePermission({ role: "program_manager" })
+    );
+    mockListAcademicMentorshipMappings.mockResolvedValue([
+      {
+        mentor: { userId: 101, name: "Anita Mentor", email: null },
+        menteeCount: 1,
+        mappings: [
+          {
+            id: 1,
+            mentee: {
+              studentPkId: 201,
+              name: "Meena Student",
+              studentId: "STU001",
+              grade: 11,
+            },
+            assignedDate: "2026-07-01",
+            endedDate: null,
+            status: "active",
+          },
+        ],
+      },
+    ]);
+
+    await renderPage();
+
+    expect(screen.getByText("Anita Mentor")).toBeInTheDocument();
+    expect(screen.getByText("Meena Student")).toBeInTheDocument();
+    expect(screen.queryByText("Manage mappings")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Manage mappings link visible for read-only Program Admins", async () => {
+    setupAdminDefaults({ id: 20, code: "SCH001" });
+    mockGetUserPermission.mockResolvedValue(
+      makePermission({ role: "program_admin", read_only: true })
+    );
+
+    await renderPage();
+
+    expect(
+      screen.getByText("No active Academic Mentor-Mentee Mappings for this academic year.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Manage mappings" })).toHaveAttribute(
+      "href",
+      "/admin/academic-mentorship?school_code=SCH001&academic_year=2026-2027"
+    );
+  });
+
+  it("does not render mapping history on the School page Mentorship tab", async () => {
+    setupAdminDefaults({ id: 20 });
+    mockListAcademicMentorshipMappings.mockResolvedValue([
+      {
+        mentor: { userId: 101, name: "Anita Mentor", email: null },
+        menteeCount: 2,
+        mappings: [
+          {
+            id: 1,
+            mentee: {
+              studentPkId: 201,
+              name: "Meena Student",
+              studentId: "STU001",
+              grade: 11,
+            },
+            assignedDate: "2026-07-01",
+            endedDate: null,
+            status: "active",
+          },
+          {
+            id: 2,
+            mentee: {
+              studentPkId: 202,
+              name: "Historical Student",
+              studentId: "STU002",
+              grade: 12,
+            },
+            assignedDate: "2026-06-01",
+            endedDate: "2026-07-01",
+            status: "historical",
+          },
+        ],
+      },
+    ]);
+
+    await renderPage();
+
+    expect(screen.getByText("Meena Student")).toBeInTheDocument();
+    expect(screen.queryByText("Historical Student")).not.toBeInTheDocument();
+    expect(mockListAcademicMentorshipMappings).toHaveBeenCalledWith({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      includeHistory: false,
+    });
   });
 
   // --- level 2 region check with null school region ---

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
+  getAcademicMentorshipActorUserId,
   listAcademicMentorshipMappings,
   listAcademicMentorshipTeacherMentees,
   type AcademicMentorshipMappingGroup,
@@ -457,12 +458,16 @@ export default async function SchoolPage({ params }: PageProps) {
         academic_year: CURRENT_ACADEMIC_YEAR,
       }).toString()}`
     : undefined;
-  const teacherMentees =
+  const teacherMentorUserId =
     mentorshipAccess.canView && permission?.role === "teacher"
+      ? await getAcademicMentorshipActorUserId(permission.email, permission)
+      : null;
+  const teacherMentees =
+    teacherMentorUserId !== null
       ? await listAcademicMentorshipTeacherMentees({
           schoolId,
           academicYear: CURRENT_ACADEMIC_YEAR,
-          mentorEmail: permission.email,
+          mentorUserId: teacherMentorUserId,
         })
       : null;
   const mentorshipGroups =

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -4,6 +4,12 @@ import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
+  listAcademicMentorshipMappings,
+  listAcademicMentorshipTeacherMentees,
+  type AcademicMentorshipMappingGroup,
+  type AcademicMentorshipTeacherMentee,
+} from "@/lib/academic-mentorship";
+import {
   getResolvedPermission,
   getProgramContextSync,
   getFeatureAccess,
@@ -12,6 +18,7 @@ import {
   PROGRAM_IDS,
   PROGRAM_IDS_ORDERED,
 } from "@/lib/permissions";
+import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
 import { type Grade } from "@/components/StudentTable";
 import { getSchoolRoster } from "@/lib/school-students";
 import PageHeader from "@/components/PageHeader";
@@ -95,6 +102,134 @@ function getDistinctNVSStreams(batches: Batch[]): string[] {
 
 interface PageProps {
   params: Promise<{ udise: string }>;
+}
+
+function menteeMeta(grade: number | null, studentId: string | null): string {
+  return [
+    grade === null ? null : `Grade ${grade}`,
+    studentId ? `ID ${studentId}` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" | ");
+}
+
+function AcademicMentorshipFlatList({
+  mentees,
+}: {
+  mentees: AcademicMentorshipTeacherMentee[];
+}) {
+  if (mentees.length === 0) {
+    return (
+      <Card elevation="sm" className="p-6 text-sm text-text-muted">
+        No mentees assigned for this academic year.
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {mentees.map((mentee) => (
+        <Card key={mentee.studentPkId} elevation="sm" className="p-4">
+          <div className="font-semibold text-text-primary">{mentee.name}</div>
+          <div className="mt-1 text-sm text-text-muted">
+            {menteeMeta(mentee.grade, mentee.studentId) || "Student details unavailable"}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function AcademicMentorshipGroupedOverview({
+  groups,
+}: {
+  groups: AcademicMentorshipMappingGroup[];
+}) {
+  const activeGroups = groups
+    .map((group) => ({
+      ...group,
+      mappings: group.mappings.filter((mapping) => mapping.status === "active"),
+    }))
+    .filter((group) => group.mappings.length > 0);
+
+  if (activeGroups.length === 0) {
+    return (
+      <Card elevation="sm" className="p-6 text-sm text-text-muted">
+        No active Academic Mentor-Mentee Mappings for this academic year.
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {activeGroups.map((group) => (
+        <Card key={group.mentor.userId} elevation="sm" className="p-4">
+          <div className="flex flex-col gap-1 border-b border-border pb-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="font-bold text-text-primary">{group.mentor.name}</h3>
+              {group.mentor.email && (
+                <p className="text-sm text-text-muted">{group.mentor.email}</p>
+              )}
+            </div>
+            <div className="text-sm font-semibold text-text-muted">
+              {group.mappings.length} {group.mappings.length === 1 ? "Mentee" : "Mentees"}
+            </div>
+          </div>
+          <div className="mt-3 divide-y divide-border">
+            {group.mappings.map((mapping) => (
+              <div key={mapping.id} className="py-3 first:pt-0 last:pb-0">
+                <div className="font-medium text-text-primary">{mapping.mentee.name}</div>
+                <div className="mt-1 text-sm text-text-muted">
+                  {menteeMeta(mapping.mentee.grade, mapping.mentee.studentId) ||
+                    "Student details unavailable"}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function AcademicMentorshipSchoolTab({
+  mode,
+  mentees,
+  groups,
+  manageHref,
+}: {
+  mode: "teacher" | "overview";
+  mentees?: AcademicMentorshipTeacherMentee[];
+  groups?: AcademicMentorshipMappingGroup[];
+  manageHref?: string;
+}) {
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-bold uppercase tracking-wide text-text-primary">
+            Academic Mentorship
+          </h2>
+          <p className="text-sm text-text-muted">
+            Current academic year: {CURRENT_ACADEMIC_YEAR}
+          </p>
+        </div>
+        {manageHref && (
+          <Link
+            href={manageHref}
+            className="inline-flex min-h-10 items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover"
+          >
+            Manage mappings
+          </Link>
+        )}
+      </div>
+      {mode === "teacher" ? (
+        <AcademicMentorshipFlatList mentees={mentees ?? []} />
+      ) : (
+        <AcademicMentorshipGroupedOverview groups={groups ?? []} />
+      )}
+    </section>
+  );
 }
 
 export default async function SchoolPage({ params }: PageProps) {
@@ -313,10 +448,38 @@ export default async function SchoolPage({ params }: PageProps) {
     <PerformanceTab schoolUdise={school.udise_code || school.code} />
   );
 
+  const schoolId = Number(school.id);
+  const isAcademicMentorshipManager =
+    permission?.role === "admin" || permission?.role === "program_admin";
+  const mentorshipManageHref = isAcademicMentorshipManager
+    ? `/admin/academic-mentorship?${new URLSearchParams({
+        school_code: school.code,
+        academic_year: CURRENT_ACADEMIC_YEAR,
+      }).toString()}`
+    : undefined;
+  const teacherMentees =
+    mentorshipAccess.canView && permission?.role === "teacher"
+      ? await listAcademicMentorshipTeacherMentees({
+          schoolId,
+          academicYear: CURRENT_ACADEMIC_YEAR,
+          mentorEmail: permission.email,
+        })
+      : null;
+  const mentorshipGroups =
+    mentorshipAccess.canView && permission?.role !== "teacher"
+      ? await listAcademicMentorshipMappings({
+          schoolId,
+          academicYear: CURRENT_ACADEMIC_YEAR,
+          includeHistory: false,
+        })
+      : null;
   const mentorshipContent = (
-    <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-      <p className="text-gray-500">Mentorship data coming soon.</p>
-    </div>
+    <AcademicMentorshipSchoolTab
+      mode={permission?.role === "teacher" ? "teacher" : "overview"}
+      mentees={teacherMentees ?? undefined}
+      groups={mentorshipGroups ?? undefined}
+      manageHref={mentorshipManageHref}
+    />
   );
 
   const visitsContent = (

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -215,7 +215,7 @@ export default async function SchoolPage({ params }: PageProps) {
   const studentsAccess = getFeatureAccess(permission, "students", opts);
   const curriculumAccess = getFeatureAccess(permission, "curriculum", opts);
   const performanceAccess = getFeatureAccess(permission, "performance", opts);
-  const mentorshipAccess = getFeatureAccess(permission, "mentorship", opts);
+  const mentorshipAccess = getFeatureAccess(permission, "academic_mentorship", opts);
   const visitsAccess = getFeatureAccess(permission, "visits", opts);
   const quizSessionsAccess = getFeatureAccess(permission, "quiz_sessions", opts);
 

--- a/src/app/school/[udise]/page.tsx
+++ b/src/app/school/[udise]/page.tsx
@@ -24,7 +24,7 @@ import { type Grade } from "@/components/StudentTable";
 import { getSchoolRoster } from "@/lib/school-students";
 import PageHeader from "@/components/PageHeader";
 import SchoolTabs from "@/components/SchoolTabs";
-import { Card } from "@/components/ui";
+import { Badge, Card } from "@/components/ui";
 import CurriculumTab from "@/components/curriculum/CurriculumTab";
 import PerformanceTab from "@/components/PerformanceTab";
 import VisitsTab from "@/components/VisitsTab";
@@ -121,19 +121,31 @@ function AcademicMentorshipFlatList({
 }) {
   if (mentees.length === 0) {
     return (
-      <Card elevation="sm" className="p-6 text-sm text-text-muted">
-        No mentees assigned for this academic year.
+      <Card elevation="sm" className="border-dashed p-8 text-center text-sm text-text-muted">
+        <div className="font-semibold text-text-primary">
+          No mentees assigned for this academic year.
+        </div>
+        <p className="mt-1">Assigned Students will appear here once mappings are active.</p>
       </Card>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <div className="grid gap-3 md:grid-cols-2">
       {mentees.map((mentee) => (
         <Card key={mentee.studentPkId} elevation="sm" className="p-4">
-          <div className="font-semibold text-text-primary">{mentee.name}</div>
-          <div className="mt-1 text-sm text-text-muted">
-            {menteeMeta(mentee.grade, mentee.studentId) || "Student details unavailable"}
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="font-semibold text-text-primary">{mentee.name}</div>
+              <div className="mt-1 text-sm text-text-muted">
+                {menteeMeta(mentee.grade, mentee.studentId) || "Student details unavailable"}
+              </div>
+            </div>
+            {mentee.grade !== null ? (
+              <Badge variant="default" className="shrink-0 font-mono">
+                G{mentee.grade}
+              </Badge>
+            ) : null}
           </div>
         </Card>
       ))}
@@ -155,35 +167,49 @@ function AcademicMentorshipGroupedOverview({
 
   if (activeGroups.length === 0) {
     return (
-      <Card elevation="sm" className="p-6 text-sm text-text-muted">
-        No active Academic Mentor-Mentee Mappings for this academic year.
+      <Card elevation="sm" className="border-dashed p-8 text-center text-sm text-text-muted">
+        <div className="font-semibold text-text-primary">
+          No active Academic Mentor-Mentee Mappings for this academic year.
+        </div>
+        <p className="mt-1">Use the admin page to add mappings for the selected School.</p>
       </Card>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {activeGroups.map((group) => (
-        <Card key={group.mentor.userId} elevation="sm" className="p-4">
-          <div className="flex flex-col gap-1 border-b border-border pb-3 sm:flex-row sm:items-center sm:justify-between">
+        <Card key={group.mentor.userId} elevation="sm" className="overflow-hidden p-0">
+          <div className="flex flex-col gap-3 border-b border-border bg-bg-card-alt px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="font-bold text-text-primary">{group.mentor.name}</h3>
               {group.mentor.email && (
                 <p className="text-sm text-text-muted">{group.mentor.email}</p>
               )}
             </div>
-            <div className="text-sm font-semibold text-text-muted">
+            <Badge variant="accent" className="w-fit font-mono">
               {group.mappings.length} {group.mappings.length === 1 ? "Mentee" : "Mentees"}
-            </div>
+            </Badge>
           </div>
-          <div className="mt-3 divide-y divide-border">
+          <div className="divide-y divide-border">
             {group.mappings.map((mapping) => (
-              <div key={mapping.id} className="py-3 first:pt-0 last:pb-0">
-                <div className="font-medium text-text-primary">{mapping.mentee.name}</div>
-                <div className="mt-1 text-sm text-text-muted">
-                  {menteeMeta(mapping.mentee.grade, mapping.mentee.studentId) ||
-                    "Student details unavailable"}
+              <div
+                key={mapping.id}
+                className="grid gap-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+              >
+                <div>
+                  <div className="font-medium text-text-primary">{mapping.mentee.name}</div>
+                  <div className="mt-1 text-sm text-text-muted">
+                    {mapping.mentee.grade === null
+                      ? "Grade unavailable"
+                      : `Grade ${mapping.mentee.grade}`}
+                  </div>
                 </div>
+                {mapping.mentee.studentId ? (
+                  <span className="font-mono text-xs text-text-muted">
+                    {mapping.mentee.studentId}
+                  </span>
+                ) : null}
               </div>
             ))}
           </div>
@@ -206,19 +232,22 @@ function AcademicMentorshipSchoolTab({
 }) {
   return (
     <section className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col gap-3 border-b border-border pb-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-lg font-bold uppercase tracking-wide text-text-primary">
             Academic Mentorship
           </h2>
-          <p className="text-sm text-text-muted">
-            Current academic year: {CURRENT_ACADEMIC_YEAR}
-          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-text-muted">
+            <span>Current academic year: {CURRENT_ACADEMIC_YEAR}</span>
+            <Badge variant={mode === "teacher" ? "info" : "default"}>
+              {mode === "teacher" ? "My mentees" : "School overview"}
+            </Badge>
+          </div>
         </div>
         {manageHref && (
           <Link
             href={manageHref}
-            className="inline-flex min-h-10 items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover"
+            className="inline-flex min-h-10 w-fit items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover"
           >
             Manage mappings
           </Link>

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -450,6 +450,9 @@ describe("AcademicMentorshipManager", () => {
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
     await user.click(screen.getByRole("button", { name: "Upload CSV" }));
+    expect(
+      screen.getByText(/Change the academic year in the page dropdown before upload/)
+    ).toBeInTheDocument();
     await user.upload(
       screen.getByLabelText("CSV file"),
       new File(["mentor_email,student_id\nanita@x,\n"], "mappings.csv", {

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -463,7 +463,7 @@ describe("AcademicMentorshipManager", () => {
 
     expect(await screen.findByText("CSV upload has row errors")).toBeInTheDocument();
     expect(screen.getByText("Upload failed. 0 rows were saved.")).toBeInTheDocument();
-    expect(screen.getByText("student_id")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Error Value" })).toBeInTheDocument();
     expect(screen.getByText("student_id is required")).toBeInTheDocument();
     const errorLink = await screen.findByRole("link", { name: "Download error CSV" });
     expect(errorLink).toHaveAttribute(

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -40,6 +40,7 @@ describe("AcademicMentorshipManager", () => {
     render(<AcademicMentorshipManager {...baseProps} canEdit={false} />);
 
     expect(screen.queryByRole("button", { name: "Add Mapping" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reassign" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
     expect(screen.getByText("Meena Student")).toBeInTheDocument();
     expect(screen.getByText("Ravi Student")).toBeInTheDocument();
@@ -185,5 +186,105 @@ describe("AcademicMentorshipManager", () => {
     );
     expect(await screen.findByText("Mapping removed.")).toBeInTheDocument();
     expect(screen.getByText("No Academic Mentor-Mentee Mappings found.")).toBeInTheDocument();
+  });
+
+  it("reassigns active rows with confirmation and excludes the current Academic Mentor", async () => {
+    const user = userEvent.setup();
+    const confirmMock = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmMock);
+    const reassignedGroup = {
+      mentor: { userId: 102, name: "New Mentor", email: "new@avantifellows.org" },
+      menteeCount: 1,
+      mappings: [
+        {
+          id: 9,
+          mentee: activeGroup.mappings[0].mentee,
+          assignedDate: "2026-07-03",
+          endedDate: null,
+          status: "active" as const,
+        },
+      ],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("type=mentors")) {
+        return Promise.resolve(
+          Response.json({
+            options: [
+              { userId: 101, name: "Anita Mentor", email: "anita@avantifellows.org" },
+              { userId: 102, name: "New Mentor", email: "new@avantifellows.org" },
+            ],
+          })
+        );
+      }
+      if (init?.method === "PATCH") {
+        return Promise.resolve(Response.json({ success: true, mappingId: 9 }));
+      }
+      return Promise.resolve(Response.json({ groups: [reassignedGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    expect(screen.getAllByRole("button", { name: "Reassign" })).toHaveLength(1);
+    await user.click(screen.getByRole("button", { name: "Reassign" }));
+    await user.type(screen.getByLabelText("Search replacement mentor"), "Mentor");
+    expect(await screen.findByRole("option", { name: "New Mentor (new@avantifellows.org)" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" })).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Replacement Academic Mentor"), "102");
+    await user.click(screen.getByRole("button", { name: "Confirm Reassign" }));
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      "This will end the old Mapping and create a new Mapping."
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+          mentor_user_id: 102,
+        }),
+      })
+    );
+    expect(await screen.findByText("Mapping reassigned.")).toBeInTheDocument();
+    expect(await screen.findByText("New Mentor")).toBeInTheDocument();
+  });
+
+  it("shows reassignment conflicts and still refreshes the table", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("type=mentors")) {
+        return Promise.resolve(
+          Response.json({
+            options: [{ userId: 102, name: "New Mentor", email: "new@avantifellows.org" }],
+          })
+        );
+      }
+      if (init?.method === "PATCH") {
+        return Promise.resolve(
+          Response.json({ error: "Student already has a mentor mapped" }, { status: 409 })
+        );
+      }
+      return Promise.resolve(Response.json({ groups: [activeGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    await user.click(screen.getByRole("button", { name: "Reassign" }));
+    await user.type(screen.getByLabelText("Search replacement mentor"), "New");
+    await screen.findByRole("option", { name: "New Mentor (new@avantifellows.org)" });
+    await user.selectOptions(screen.getByLabelText("Replacement Academic Mentor"), "102");
+    await user.click(screen.getByRole("button", { name: "Confirm Reassign" }));
+
+    expect(await screen.findByText("Student already has a mentor mapped")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027&include_history=true"
+    );
   });
 });

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -436,7 +436,7 @@ describe("AcademicMentorshipManager", () => {
           Response.json(
             {
               error: "CSV upload has row errors",
-              errors: [{ rowNumber: 2, error: "student_id is required" }],
+              errors: [{ rowNumber: 2, field: "student_id", error: "student_id is required" }],
               errorCsv: "mentor_email,student_id,error_reason\nanita@x,,student_id is required\n",
             },
             { status: 422 }
@@ -459,6 +459,9 @@ describe("AcademicMentorshipManager", () => {
     await user.click(screen.getAllByRole("button", { name: "Upload CSV" }).at(-1)!);
 
     expect(await screen.findByText("CSV upload has row errors")).toBeInTheDocument();
+    expect(screen.getByText("Upload failed. 0 rows were saved.")).toBeInTheDocument();
+    expect(screen.getByText("student_id")).toBeInTheDocument();
+    expect(screen.getByText("student_id is required")).toBeInTheDocument();
     const errorLink = await screen.findByRole("link", { name: "Download error CSV" });
     expect(errorLink).toHaveAttribute(
       "download",

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -287,4 +287,93 @@ describe("AcademicMentorshipManager", () => {
       "/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027&include_history=true"
     );
   });
+
+  it("shows a CSV template link and refreshes after a successful upload", async () => {
+    const user = userEvent.setup();
+    const refreshedGroup = {
+      mentor: { userId: 103, name: "CSV Mentor", email: "csv@avantifellows.org" },
+      menteeCount: 1,
+      mappings: [
+        {
+          id: 31,
+          mentee: { studentPkId: 301, name: "CSV Student", studentId: "CSV001", grade: 11 },
+          assignedDate: "2026-07-04",
+          endedDate: null,
+          status: "active" as const,
+        },
+      ],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/academic-mentorship/mappings/import") {
+        return Promise.resolve(
+          Response.json({ success: true, insertedCount: 2 }, { status: 201 })
+        );
+      }
+      return Promise.resolve(Response.json({ groups: [refreshedGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    expect(screen.getByRole("link", { name: "Download CSV template" })).toHaveAttribute(
+      "href",
+      "/api/academic-mentorship/mappings/import?school_code=SCH001&academic_year=2026-2027"
+    );
+    await user.upload(
+      screen.getByLabelText("CSV file"),
+      new File(["mentor_email,student_id\ncsv@x,CSV001\n"], "mappings.csv", {
+        type: "text/csv",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings/import",
+      expect.objectContaining({ method: "POST" })
+    );
+    const uploadBody = (fetchMock.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(uploadBody.get("school_code")).toBe("SCH001");
+    expect(uploadBody.get("academic_year")).toBe("2026-2027");
+    expect(uploadBody.get("file")).toBeInstanceOf(File);
+    expect(await screen.findByText("Imported 2 mappings.")).toBeInTheDocument();
+    expect(await screen.findByText("CSV Student")).toBeInTheDocument();
+  });
+
+  it("shows upload row errors and exposes an error CSV download", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/academic-mentorship/mappings/import") {
+        return Promise.resolve(
+          Response.json(
+            {
+              error: "CSV upload has row errors",
+              errors: [{ rowNumber: 2, error: "student_id is required" }],
+              errorCsv: "mentor_email,student_id,error_reason\nanita@x,,student_id is required\n",
+            },
+            { status: 422 }
+          )
+        );
+      }
+      return Promise.resolve(Response.json({ groups: [activeGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    await user.upload(
+      screen.getByLabelText("CSV file"),
+      new File(["mentor_email,student_id\nanita@x,\n"], "mappings.csv", {
+        type: "text/csv",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
+
+    expect(await screen.findByText("CSV upload has row errors")).toBeInTheDocument();
+    const errorLink = await screen.findByRole("link", { name: "Download error CSV" });
+    expect(errorLink).toHaveAttribute(
+      "download",
+      "academic-mentorship-import-errors.csv"
+    );
+    expect(errorLink.getAttribute("href")).toContain("student_id%20is%20required");
+  });
 });

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -9,14 +9,26 @@ const activeGroup = {
   mappings: [
     {
       id: 7,
-      mentee: { studentPkId: 201, name: "Meena Student", studentId: "STU001", grade: 11 },
+      mentee: {
+        studentPkId: 201,
+        name: "Meena Student",
+        studentId: "STU001",
+        grade: 11,
+        programId: 64,
+      },
       assignedDate: "2026-07-01",
       endedDate: null,
       status: "active" as const,
     },
     {
       id: 8,
-      mentee: { studentPkId: 202, name: "Ravi Student", studentId: "STU002", grade: 12 },
+      mentee: {
+        studentPkId: 202,
+        name: "Ravi Student",
+        studentId: "STU002",
+        grade: 12,
+        programId: 64,
+      },
       assignedDate: "2026-06-01",
       endedDate: "2026-06-30",
       status: "historical" as const,
@@ -27,7 +39,9 @@ const activeGroup = {
 const baseProps = {
   schoolCode: "SCH001",
   academicYear: "2026-2027",
+  programId: null,
   includeHistory: true,
+  canUpload: true,
   initialGroups: [activeGroup],
 };
 
@@ -37,7 +51,7 @@ describe("AcademicMentorshipManager", () => {
   });
 
   it("hides mutation controls in view-only mode and for historical rows", () => {
-    render(<AcademicMentorshipManager {...baseProps} canEdit={false} />);
+    render(<AcademicMentorshipManager {...baseProps} canEdit={false} canUpload={false} />);
 
     expect(screen.queryByRole("button", { name: "Add Mapping" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Reassign" })).not.toBeInTheDocument();
@@ -53,7 +67,13 @@ describe("AcademicMentorshipManager", () => {
       mappings: [
         {
           id: 9,
-          mentee: { studentPkId: 203, name: "Fresh Student", studentId: "STU003", grade: 11 },
+          mentee: {
+            studentPkId: 203,
+            name: "Fresh Student",
+            studentId: "STU003",
+            grade: 11,
+            programId: 64,
+          },
           assignedDate: "2026-07-02",
           endedDate: null,
           status: "active" as const,
@@ -61,7 +81,7 @@ describe("AcademicMentorshipManager", () => {
       ],
     };
     const { rerender } = render(
-      <AcademicMentorshipManager {...baseProps} canEdit={false} />
+      <AcademicMentorshipManager {...baseProps} canEdit={false} canUpload={false} />
     );
 
     rerender(
@@ -70,6 +90,7 @@ describe("AcademicMentorshipManager", () => {
         includeHistory={false}
         initialGroups={[nextGroup]}
         canEdit={false}
+        canUpload={false}
       />
     );
 
@@ -87,7 +108,13 @@ describe("AcademicMentorshipManager", () => {
       mappings: [
         {
           id: 9,
-          mentee: { studentPkId: 203, name: "Fresh Student", studentId: "STU003", grade: 11 },
+          mentee: {
+            studentPkId: 203,
+            name: "Fresh Student",
+            studentId: "STU003",
+            grade: 11,
+            programId: 64,
+          },
           assignedDate: "2026-07-02",
           endedDate: null,
           status: "active" as const,
@@ -119,13 +146,22 @@ describe("AcademicMentorshipManager", () => {
 
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
-    await user.type(screen.getByLabelText("Search mentors"), "Anita");
-    await screen.findByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" });
-    await user.selectOptions(screen.getByLabelText("Academic Mentor"), "101");
-    await user.type(screen.getByLabelText("Search mentees"), "STU");
-    await screen.findByRole("option", { name: "Fresh Student (STU003)" });
-    await user.selectOptions(screen.getByLabelText("Mentee"), "203");
     await user.click(screen.getByRole("button", { name: "Add Mapping" }));
+    const mentorInput = screen.getByLabelText("Academic Mentor");
+    await user.type(mentorInput, "Anita");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentors"))
+    );
+    await user.clear(mentorInput);
+    await user.type(mentorInput, "Anita Mentor (anita@avantifellows.org)");
+    const menteeInput = screen.getByLabelText("Mentee");
+    await user.type(menteeInput, "STU");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentees"))
+    );
+    await user.clear(menteeInput);
+    await user.type(menteeInput, "Fresh Student (STU003)");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/academic-mentorship/mappings",
@@ -172,13 +208,22 @@ describe("AcademicMentorshipManager", () => {
 
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
-    await user.type(screen.getByLabelText("Search mentors"), "Anita");
-    await screen.findByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" });
-    await user.selectOptions(screen.getByLabelText("Academic Mentor"), "101");
-    await user.type(screen.getByLabelText("Search mentees"), "STU");
-    await screen.findByRole("option", { name: "Meena Student (STU001)" });
-    await user.selectOptions(screen.getByLabelText("Mentee"), "201");
     await user.click(screen.getByRole("button", { name: "Add Mapping" }));
+    const mentorInput = screen.getByLabelText("Academic Mentor");
+    await user.type(mentorInput, "Anita");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentors"))
+    );
+    await user.clear(mentorInput);
+    await user.type(mentorInput, "Anita Mentor (anita@avantifellows.org)");
+    const menteeInput = screen.getByLabelText("Mentee");
+    await user.type(menteeInput, "STU");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentees"))
+    );
+    await user.clear(menteeInput);
+    await user.type(menteeInput, "Meena Student (STU001)");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(await screen.findByText("Student already has a mentor mapped")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
@@ -221,10 +266,8 @@ describe("AcademicMentorshipManager", () => {
     expect(screen.getByText("No Academic Mentor-Mentee Mappings found.")).toBeInTheDocument();
   });
 
-  it("reassigns active rows with confirmation and excludes the current Academic Mentor", async () => {
+  it("reassigns active rows and excludes the current Academic Mentor", async () => {
     const user = userEvent.setup();
-    const confirmMock = vi.fn(() => true);
-    vi.stubGlobal("confirm", confirmMock);
     const reassignedGroup = {
       mentor: { userId: 102, name: "New Mentor", email: "new@avantifellows.org" },
       menteeCount: 1,
@@ -261,15 +304,18 @@ describe("AcademicMentorshipManager", () => {
 
     expect(screen.getAllByRole("button", { name: "Reassign" })).toHaveLength(1);
     await user.click(screen.getByRole("button", { name: "Reassign" }));
-    await user.type(screen.getByLabelText("Search replacement mentor"), "Mentor");
-    expect(await screen.findByRole("option", { name: "New Mentor (new@avantifellows.org)" })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" })).not.toBeInTheDocument();
-    await user.selectOptions(screen.getByLabelText("Replacement Academic Mentor"), "102");
+    const replacementInput = screen.getByLabelText("Replacement Academic Mentor");
+    await user.type(replacementInput, "Mentor");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentors"))
+    );
+    expect(
+      document.querySelector('option[value="Anita Mentor (anita@avantifellows.org)"]')
+    ).toBeNull();
+    await user.clear(replacementInput);
+    await user.type(replacementInput, "New Mentor (new@avantifellows.org)");
     await user.click(screen.getByRole("button", { name: "Confirm Reassign" }));
 
-    expect(confirmMock).toHaveBeenCalledWith(
-      "This will end the old Mapping and create a new Mapping."
-    );
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/academic-mentorship/mappings",
       expect.objectContaining({
@@ -288,7 +334,6 @@ describe("AcademicMentorshipManager", () => {
 
   it("shows reassignment conflicts and still refreshes the table", async () => {
     const user = userEvent.setup();
-    vi.stubGlobal("confirm", vi.fn(() => true));
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("type=mentors")) {
@@ -310,9 +355,13 @@ describe("AcademicMentorshipManager", () => {
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
     await user.click(screen.getByRole("button", { name: "Reassign" }));
-    await user.type(screen.getByLabelText("Search replacement mentor"), "New");
-    await screen.findByRole("option", { name: "New Mentor (new@avantifellows.org)" });
-    await user.selectOptions(screen.getByLabelText("Replacement Academic Mentor"), "102");
+    const replacementInput = screen.getByLabelText("Replacement Academic Mentor");
+    await user.type(replacementInput, "New");
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("type=mentors"))
+    );
+    await user.clear(replacementInput);
+    await user.type(replacementInput, "New Mentor (new@avantifellows.org)");
     await user.click(screen.getByRole("button", { name: "Confirm Reassign" }));
 
     expect(await screen.findByText("Student already has a mentor mapped")).toBeInTheDocument();
@@ -329,7 +378,13 @@ describe("AcademicMentorshipManager", () => {
       mappings: [
         {
           id: 31,
-          mentee: { studentPkId: 301, name: "CSV Student", studentId: "CSV001", grade: 11 },
+          mentee: {
+            studentPkId: 301,
+            name: "CSV Student",
+            studentId: "CSV001",
+            grade: 11,
+            programId: 64,
+          },
           assignedDate: "2026-07-04",
           endedDate: null,
           status: "active" as const,
@@ -348,17 +403,18 @@ describe("AcademicMentorshipManager", () => {
 
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
-    expect(screen.getByRole("link", { name: "Download CSV template" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Template" })).toHaveAttribute(
       "href",
       "/api/academic-mentorship/mappings/import?school_code=SCH001&academic_year=2026-2027"
     );
+    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
     await user.upload(
       screen.getByLabelText("CSV file"),
       new File(["mentor_email,student_id\ncsv@x,CSV001\n"], "mappings.csv", {
         type: "text/csv",
       })
     );
-    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
+    await user.click(screen.getAllByRole("button", { name: "Upload CSV" }).at(-1)!);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/academic-mentorship/mappings/import",
@@ -393,13 +449,14 @@ describe("AcademicMentorshipManager", () => {
 
     render(<AcademicMentorshipManager {...baseProps} canEdit />);
 
+    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
     await user.upload(
       screen.getByLabelText("CSV file"),
       new File(["mentor_email,student_id\nanita@x,\n"], "mappings.csv", {
         type: "text/csv",
       })
     );
-    await user.click(screen.getByRole("button", { name: "Upload CSV" }));
+    await user.click(screen.getAllByRole("button", { name: "Upload CSV" }).at(-1)!);
 
     expect(await screen.findByText("CSV upload has row errors")).toBeInTheDocument();
     const errorLink = await screen.findByRole("link", { name: "Download error CSV" });

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import AcademicMentorshipManager from "./AcademicMentorshipManager";
+
+const activeGroup = {
+  mentor: { userId: 101, name: "Anita Mentor", email: "anita@avantifellows.org" },
+  menteeCount: 2,
+  mappings: [
+    {
+      id: 7,
+      mentee: { studentPkId: 201, name: "Meena Student", studentId: "STU001", grade: 11 },
+      assignedDate: "2026-07-01",
+      endedDate: null,
+      status: "active" as const,
+    },
+    {
+      id: 8,
+      mentee: { studentPkId: 202, name: "Ravi Student", studentId: "STU002", grade: 12 },
+      assignedDate: "2026-06-01",
+      endedDate: "2026-06-30",
+      status: "historical" as const,
+    },
+  ],
+};
+
+const baseProps = {
+  schoolCode: "SCH001",
+  academicYear: "2026-2027",
+  includeHistory: true,
+  initialGroups: [activeGroup],
+};
+
+describe("AcademicMentorshipManager", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hides mutation controls in view-only mode and for historical rows", () => {
+    render(<AcademicMentorshipManager {...baseProps} canEdit={false} />);
+
+    expect(screen.queryByRole("button", { name: "Add Mapping" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    expect(screen.getByText("Meena Student")).toBeInTheDocument();
+    expect(screen.getByText("Ravi Student")).toBeInTheDocument();
+  });
+
+  it("adds a Mapping and refreshes the table", async () => {
+    const user = userEvent.setup();
+    const refreshedGroup = {
+      mentor: activeGroup.mentor,
+      menteeCount: 1,
+      mappings: [
+        {
+          id: 9,
+          mentee: { studentPkId: 203, name: "Fresh Student", studentId: "STU003", grade: 11 },
+          assignedDate: "2026-07-02",
+          endedDate: null,
+          status: "active" as const,
+        },
+      ],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("type=mentors")) {
+        return Promise.resolve(
+          Response.json({
+            options: [{ userId: 101, name: "Anita Mentor", email: "anita@avantifellows.org" }],
+          })
+        );
+      }
+      if (url.includes("type=mentees")) {
+        return Promise.resolve(
+          Response.json({
+            options: [{ studentPkId: 203, name: "Fresh Student", studentId: "STU003", grade: 11 }],
+          })
+        );
+      }
+      if (init?.method === "POST") {
+        return Promise.resolve(Response.json({ success: true, mappingId: 9 }, { status: 201 }));
+      }
+      return Promise.resolve(Response.json({ groups: [refreshedGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    await user.type(screen.getByLabelText("Search mentors"), "Anita");
+    await screen.findByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" });
+    await user.selectOptions(screen.getByLabelText("Academic Mentor"), "101");
+    await user.type(screen.getByLabelText("Search mentees"), "STU");
+    await screen.findByRole("option", { name: "Fresh Student (STU003)" });
+    await user.selectOptions(screen.getByLabelText("Mentee"), "203");
+    await user.click(screen.getByRole("button", { name: "Add Mapping" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mentor_user_id: 101,
+          student_id: 203,
+        }),
+      })
+    );
+    expect(await screen.findByText("Mapping added.")).toBeInTheDocument();
+    expect(await screen.findByText("Fresh Student")).toBeInTheDocument();
+  });
+
+  it("shows concurrent Mapping conflicts and still refreshes the table", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("type=mentors")) {
+        return Promise.resolve(
+          Response.json({
+            options: [{ userId: 101, name: "Anita Mentor", email: "anita@avantifellows.org" }],
+          })
+        );
+      }
+      if (url.includes("type=mentees")) {
+        return Promise.resolve(
+          Response.json({
+            options: [{ studentPkId: 201, name: "Meena Student", studentId: "STU001", grade: 11 }],
+          })
+        );
+      }
+      if (init?.method === "POST") {
+        return Promise.resolve(
+          Response.json({ error: "Student already has a mentor mapped" }, { status: 409 })
+        );
+      }
+      return Promise.resolve(Response.json({ groups: [activeGroup] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    await user.type(screen.getByLabelText("Search mentors"), "Anita");
+    await screen.findByRole("option", { name: "Anita Mentor (anita@avantifellows.org)" });
+    await user.selectOptions(screen.getByLabelText("Academic Mentor"), "101");
+    await user.type(screen.getByLabelText("Search mentees"), "STU");
+    await screen.findByRole("option", { name: "Meena Student (STU001)" });
+    await user.selectOptions(screen.getByLabelText("Mentee"), "201");
+    await user.click(screen.getByRole("button", { name: "Add Mapping" }));
+
+    expect(await screen.findByText("Student already has a mentor mapped")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings?school_code=SCH001&academic_year=2026-2027&include_history=true"
+    );
+  });
+
+  it("confirms removal, ends active rows only, and refreshes the table", async () => {
+    const user = userEvent.setup();
+    const confirmMock = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmMock);
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return Promise.resolve(Response.json({ success: true, mappingId: 7 }));
+      }
+      return Promise.resolve(Response.json({ groups: [] }));
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AcademicMentorshipManager {...baseProps} canEdit />);
+
+    expect(screen.getAllByRole("button", { name: "Remove" })).toHaveLength(1);
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      "This Student will no longer have an active Academic Mentor."
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/academic-mentorship/mappings",
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({
+          school_code: "SCH001",
+          academic_year: "2026-2027",
+          mapping_id: 7,
+        }),
+      })
+    );
+    expect(await screen.findByText("Mapping removed.")).toBeInTheDocument();
+    expect(screen.getByText("No Academic Mentor-Mentee Mappings found.")).toBeInTheDocument();
+  });
+});

--- a/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import AcademicMentorshipManager from "./AcademicMentorshipManager";
@@ -44,6 +44,39 @@ describe("AcademicMentorshipManager", () => {
     expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
     expect(screen.getByText("Meena Student")).toBeInTheDocument();
     expect(screen.getByText("Ravi Student")).toBeInTheDocument();
+  });
+
+  it("syncs displayed mappings when server props change", async () => {
+    const nextGroup = {
+      mentor: { userId: 102, name: "New Mentor", email: "new@avantifellows.org" },
+      menteeCount: 1,
+      mappings: [
+        {
+          id: 9,
+          mentee: { studentPkId: 203, name: "Fresh Student", studentId: "STU003", grade: 11 },
+          assignedDate: "2026-07-02",
+          endedDate: null,
+          status: "active" as const,
+        },
+      ],
+    };
+    const { rerender } = render(
+      <AcademicMentorshipManager {...baseProps} canEdit={false} />
+    );
+
+    rerender(
+      <AcademicMentorshipManager
+        {...baseProps}
+        includeHistory={false}
+        initialGroups={[nextGroup]}
+        canEdit={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fresh Student")).toBeInTheDocument();
+      expect(screen.queryByText("Ravi Student")).not.toBeInTheDocument();
+    });
   });
 
   it("adds a Mapping and refreshes the table", async () => {

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -40,6 +40,12 @@ type MenteeOption = {
   grade: number | null;
 };
 
+type Mapping = MappingGroup["mappings"][number];
+type ReassigningState = {
+  mappingId: number | string;
+  currentMentorUserId: number;
+} | null;
+
 interface AcademicMentorshipManagerProps {
   schoolCode: string;
   academicYear: string;
@@ -61,6 +67,234 @@ function apiError(payload: unknown, fallback: string): string {
   return typeof payload.error === "string" && payload.error.trim() ? payload.error : fallback;
 }
 
+function payloadErrorCsv(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || !("errorCsv" in payload)) return null;
+  return typeof payload.errorCsv === "string" ? payload.errorCsv : null;
+}
+
+function payloadInsertedCount(payload: unknown): number {
+  if (!payload || typeof payload !== "object" || !("insertedCount" in payload)) return 0;
+  return typeof payload.insertedCount === "number" ? payload.insertedCount : 0;
+}
+
+function MappingStatus({
+  mapping,
+  includeHistory,
+}: {
+  mapping: Mapping;
+  includeHistory: boolean;
+}) {
+  const active = mapping.status === "active";
+  return (
+    <div className="text-sm font-semibold text-text-primary">
+      <Badge variant={active ? "success" : "default"} className="w-fit">
+        {active ? "Active" : "Historical"}
+      </Badge>
+      {includeHistory && mapping.endedDate ? (
+        <span className="mt-1 block font-mono text-xs font-normal text-text-muted">
+          Ended {mapping.endedDate}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function MappingActions({
+  canEdit,
+  isActive,
+  busy,
+  mappingId,
+  mentorUserId,
+  onStartReassign,
+  onRemove,
+}: {
+  canEdit: boolean;
+  isActive: boolean;
+  busy: boolean;
+  mappingId: number | string;
+  mentorUserId: number;
+  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
+  onRemove: (mappingId: number | string) => void;
+}) {
+  if (!canEdit || !isActive) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => onStartReassign(mappingId, mentorUserId)}
+        disabled={busy}
+      >
+        <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+        Reassign
+      </Button>
+      <Button
+        type="button"
+        variant="danger-ghost"
+        size="sm"
+        onClick={() => onRemove(mappingId)}
+        disabled={busy}
+      >
+        <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
+        Remove
+      </Button>
+    </div>
+  );
+}
+
+function ReassignPanel({
+  currentMentorUserId,
+  replacementMentorSearch,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  busy,
+  onSearch,
+  onSelect,
+  onConfirm,
+  onCancel,
+}: {
+  currentMentorUserId: number;
+  replacementMentorSearch: string;
+  replacementMentorUserId: string;
+  replacementMentorOptions: MentorOption[];
+  busy: boolean;
+  onSearch: (value: string) => void;
+  onSelect: (value: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const options = replacementMentorOptions.filter(
+    (mentor) => mentor.userId !== currentMentorUserId
+  );
+
+  return (
+    <div className="grid gap-3 rounded-lg border border-border bg-bg-card-alt p-3 md:col-span-5 md:grid-cols-[1fr_1fr_auto_auto]">
+      <label className="grid gap-1 text-sm font-semibold text-text-primary">
+        Search replacement mentor
+        <Input
+          value={replacementMentorSearch}
+          onChange={(event) => onSearch(event.target.value)}
+        />
+      </label>
+      <label className="grid gap-1 text-sm font-semibold text-text-primary">
+        Replacement Academic Mentor
+        <Select
+          value={replacementMentorUserId}
+          onChange={(event) => onSelect(event.target.value)}
+          className="w-full min-w-0"
+        >
+          <option value="">Select mentor</option>
+          {options.map((mentor) => (
+            <option key={mentor.userId} value={mentor.userId}>
+              {mentor.name} ({mentor.email})
+            </option>
+          ))}
+        </Select>
+      </label>
+      <Button
+        type="button"
+        size="sm"
+        onClick={onConfirm}
+        disabled={busy}
+        className="self-end"
+      >
+        Confirm Reassign
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        disabled={busy}
+        className="self-end"
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+function MappingRow({
+  mapping,
+  mentorUserId,
+  includeHistory,
+  canEdit,
+  busy,
+  reassigning,
+  replacementMentorSearch,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  onStartReassign,
+  onRemove,
+  onReplacementMentorSearch,
+  onReplacementMentorSelect,
+  onConfirmReassign,
+  onCancelReassign,
+}: {
+  mapping: Mapping;
+  mentorUserId: number;
+  includeHistory: boolean;
+  canEdit: boolean;
+  busy: boolean;
+  reassigning: ReassigningState;
+  replacementMentorSearch: string;
+  replacementMentorUserId: string;
+  replacementMentorOptions: MentorOption[];
+  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
+  onRemove: (mappingId: number | string) => void;
+  onReplacementMentorSearch: (value: string) => void;
+  onReplacementMentorSelect: (value: string) => void;
+  onConfirmReassign: () => void;
+  onCancelReassign: () => void;
+}) {
+  const reassigningHere =
+    reassigning && String(reassigning.mappingId) === String(mapping.id)
+      ? reassigning.currentMentorUserId
+      : null;
+
+  return (
+    <div
+      className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center"
+    >
+      <div>
+        <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
+        <div className="font-mono text-xs text-text-muted">
+          {mapping.mentee.studentId ?? "No ID"}
+        </div>
+      </div>
+      <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
+      <div className="font-mono text-xs text-text-muted">{mapping.assignedDate}</div>
+      <MappingStatus mapping={mapping} includeHistory={includeHistory} />
+      <div className="md:flex md:justify-end">
+        <MappingActions
+          canEdit={canEdit}
+          isActive={mapping.status === "active"}
+          busy={busy}
+          mappingId={mapping.id}
+          mentorUserId={mentorUserId}
+          onStartReassign={onStartReassign}
+          onRemove={onRemove}
+        />
+      </div>
+      {reassigningHere ? (
+        <ReassignPanel
+          currentMentorUserId={reassigningHere}
+          replacementMentorSearch={replacementMentorSearch}
+          replacementMentorUserId={replacementMentorUserId}
+          replacementMentorOptions={replacementMentorOptions}
+          busy={busy}
+          onSearch={onReplacementMentorSearch}
+          onSelect={onReplacementMentorSelect}
+          onConfirm={onConfirmReassign}
+          onCancel={onCancelReassign}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 export default function AcademicMentorshipManager({
   schoolCode,
   academicYear,
@@ -75,10 +309,7 @@ export default function AcademicMentorshipManager({
   const [menteeSearch, setMenteeSearch] = useState("");
   const [mentorUserId, setMentorUserId] = useState("");
   const [studentPkId, setStudentPkId] = useState("");
-  const [reassigning, setReassigning] = useState<{
-    mappingId: number | string;
-    currentMentorUserId: number;
-  } | null>(null);
+  const [reassigning, setReassigning] = useState<ReassigningState>(null);
   const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
   const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
   const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
@@ -200,25 +431,12 @@ export default function AcademicMentorshipManager({
       });
       const payload = await readJson(response);
       if (!response.ok) {
-        if (
-          payload &&
-          typeof payload === "object" &&
-          "errorCsv" in payload &&
-          typeof payload.errorCsv === "string"
-        ) {
-          setErrorCsv(payload.errorCsv);
-        }
+        setErrorCsv(payloadErrorCsv(payload));
         setToast({ variant: "error", message: apiError(payload, "Failed to upload CSV") });
         return;
       }
       await refreshMappings();
-      const insertedCount =
-        payload &&
-        typeof payload === "object" &&
-        "insertedCount" in payload &&
-        typeof payload.insertedCount === "number"
-          ? payload.insertedCount
-          : 0;
+      const insertedCount = payloadInsertedCount(payload);
       setToast({
         variant: "success",
         message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
@@ -265,6 +483,11 @@ export default function AcademicMentorshipManager({
     setReplacementMentorOptions([]);
     setReplacementMentorSearch("");
     setReplacementMentorUserId("");
+  }
+
+  function searchReplacementMentors(value: string) {
+    setReplacementMentorSearch(value);
+    void loadReplacementMentors(value);
   }
 
   async function reassignMapping() {
@@ -459,111 +682,24 @@ export default function AcademicMentorshipManager({
                   <div className="text-right">Actions</div>
                 </div>
                 {group.mappings.map((mapping) => (
-                  <div
+                  <MappingRow
                     key={String(mapping.id)}
-                    className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center"
-                  >
-                    <div>
-                      <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
-                      <div className="font-mono text-xs text-text-muted">
-                        {mapping.mentee.studentId ?? "No ID"}
-                      </div>
-                    </div>
-                    <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
-                    <div className="font-mono text-xs text-text-muted">{mapping.assignedDate}</div>
-                    <div className="text-sm font-semibold text-text-primary">
-                      <Badge
-                        variant={mapping.status === "active" ? "success" : "default"}
-                        className="w-fit"
-                      >
-                        {mapping.status === "active" ? "Active" : "Historical"}
-                      </Badge>
-                      {includeHistory && mapping.endedDate ? (
-                        <span className="mt-1 block font-mono text-xs font-normal text-text-muted">
-                          Ended {mapping.endedDate}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="md:flex md:justify-end">
-                      {canEdit && mapping.status === "active" ? (
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => startReassign(mapping.id, group.mentor.userId)}
-                            disabled={busy}
-                          >
-                            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
-                            Reassign
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="danger-ghost"
-                            size="sm"
-                            onClick={() => void removeMapping(mapping.id)}
-                            disabled={busy}
-                          >
-                            <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
-                            Remove
-                          </Button>
-                        </div>
-                      ) : null}
-                    </div>
-                    {reassigning && String(reassigning.mappingId) === String(mapping.id) ? (
-                      <div className="grid gap-3 rounded-lg border border-border bg-bg-card-alt p-3 md:col-span-5 md:grid-cols-[1fr_1fr_auto_auto]">
-                        <label className="grid gap-1 text-sm font-semibold text-text-primary">
-                          Search replacement mentor
-                          <Input
-                            value={replacementMentorSearch}
-                            onChange={(event) => {
-                              const value = event.target.value;
-                              setReplacementMentorSearch(value);
-                              void loadReplacementMentors(value);
-                            }}
-                          />
-                        </label>
-                        <label className="grid gap-1 text-sm font-semibold text-text-primary">
-                          Replacement Academic Mentor
-                          <Select
-                            value={replacementMentorUserId}
-                            onChange={(event) => setReplacementMentorUserId(event.target.value)}
-                            className="w-full min-w-0"
-                          >
-                            <option value="">Select mentor</option>
-                            {replacementMentorOptions
-                              .filter(
-                                (mentor) => mentor.userId !== reassigning.currentMentorUserId
-                              )
-                              .map((mentor) => (
-                                <option key={mentor.userId} value={mentor.userId}>
-                                  {mentor.name} ({mentor.email})
-                                </option>
-                              ))}
-                          </Select>
-                        </label>
-                        <Button
-                          type="button"
-                          size="sm"
-                          onClick={() => void reassignMapping()}
-                          disabled={busy}
-                          className="self-end"
-                        >
-                          Confirm Reassign
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setReassigning(null)}
-                          disabled={busy}
-                          className="self-end"
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    ) : null}
-                  </div>
+                    mapping={mapping}
+                    mentorUserId={group.mentor.userId}
+                    includeHistory={includeHistory}
+                    canEdit={canEdit}
+                    busy={busy}
+                    reassigning={reassigning}
+                    replacementMentorSearch={replacementMentorSearch}
+                    replacementMentorUserId={replacementMentorUserId}
+                    replacementMentorOptions={replacementMentorOptions}
+                    onStartReassign={startReassign}
+                    onRemove={(mappingId) => void removeMapping(mappingId)}
+                    onReplacementMentorSearch={searchReplacementMentors}
+                    onReplacementMentorSelect={setReplacementMentorUserId}
+                    onConfirmReassign={() => void reassignMapping()}
+                    onCancelReassign={() => setReassigning(null)}
+                  />
                 ))}
               </div>
             </Card>

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -770,7 +770,9 @@ function CsvUploadModal({
       <div className="border-b border-border px-5 py-4">
         <h2 className="text-base font-bold text-text-primary">Upload CSV</h2>
         <p className="mt-1 text-sm text-text-muted">
-          CSV must contain mentor_email,student_id rows for {academicYear}.
+          CSV must contain mentor_email,student_id rows for{" "}
+          <strong className="font-bold text-text-primary">{academicYear}</strong>. Change the
+          academic year in the page dropdown before upload if this is not correct.
         </p>
       </div>
       <div className="grid max-h-[70vh] gap-4 overflow-y-auto px-5 py-4">

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -74,6 +74,13 @@ export default function AcademicMentorshipManager({
   const [menteeSearch, setMenteeSearch] = useState("");
   const [mentorUserId, setMentorUserId] = useState("");
   const [studentPkId, setStudentPkId] = useState("");
+  const [reassigning, setReassigning] = useState<{
+    mappingId: number | string;
+    currentMentorUserId: number;
+  } | null>(null);
+  const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
+  const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
+  const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ variant: "success" | "error"; message: string } | null>(null);
 
@@ -90,7 +97,10 @@ export default function AcademicMentorshipManager({
     }
   }
 
-  async function loadMentors(search: string) {
+  async function loadMentorOptions(
+    search: string,
+    setOptions: (options: MentorOption[]) => void
+  ) {
     const params = new URLSearchParams({
       type: "mentors",
       school_code: schoolCode,
@@ -99,8 +109,16 @@ export default function AcademicMentorshipManager({
     const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
     const payload = await readJson(response);
     if (response.ok && payload && typeof payload === "object" && "options" in payload) {
-      setMentorOptions((payload.options as MentorOption[]) ?? []);
+      setOptions((payload.options as MentorOption[]) ?? []);
     }
+  }
+
+  async function loadMentors(search: string) {
+    await loadMentorOptions(search, setMentorOptions);
+  }
+
+  async function loadReplacementMentors(search: string) {
+    await loadMentorOptions(search, setReplacementMentorOptions);
   }
 
   async function loadMentees(search: string) {
@@ -176,6 +194,50 @@ export default function AcademicMentorshipManager({
       setToast({ variant: "success", message: "Mapping removed." });
     } catch {
       setToast({ variant: "error", message: "Failed to remove Mapping" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startReassign(mappingId: number | string, currentMentorUserId: number) {
+    setReassigning({ mappingId, currentMentorUserId });
+    setReplacementMentorOptions([]);
+    setReplacementMentorSearch("");
+    setReplacementMentorUserId("");
+  }
+
+  async function reassignMapping() {
+    if (!reassigning || !replacementMentorUserId) {
+      setToast({ variant: "error", message: "Select a replacement Academic Mentor" });
+      return;
+    }
+    if (!window.confirm("This will end the old Mapping and create a new Mapping.")) {
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const response = await fetch("/api/academic-mentorship/mappings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          school_code: schoolCode,
+          academic_year: academicYear,
+          mapping_id: Number(reassigning.mappingId),
+          mentor_user_id: Number(replacementMentorUserId),
+        }),
+      });
+      const payload = await readJson(response);
+      await refreshMappings();
+      if (!response.ok) {
+        setToast({ variant: "error", message: apiError(payload, "Failed to reassign Mapping") });
+        return;
+      }
+      setReassigning(null);
+      setReplacementMentorUserId("");
+      setToast({ variant: "success", message: "Mapping reassigned." });
+    } catch {
+      setToast({ variant: "error", message: "Failed to reassign Mapping" });
     } finally {
       setBusy(false);
     }
@@ -267,7 +329,7 @@ export default function AcademicMentorshipManager({
                 {group.mappings.map((mapping) => (
                   <div
                     key={String(mapping.id)}
-                    className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px_90px]"
+                    className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px_160px]"
                   >
                     <div>
                       <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
@@ -285,17 +347,80 @@ export default function AcademicMentorshipManager({
                     </div>
                     <div>
                       {canEdit && mapping.status === "active" ? (
-                        <Button
-                          type="button"
-                          variant="danger-ghost"
-                          size="sm"
-                          onClick={() => void removeMapping(mapping.id)}
-                          disabled={busy}
-                        >
-                          Remove
-                        </Button>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => startReassign(mapping.id, group.mentor.userId)}
+                            disabled={busy}
+                          >
+                            Reassign
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="danger-ghost"
+                            size="sm"
+                            onClick={() => void removeMapping(mapping.id)}
+                            disabled={busy}
+                          >
+                            Remove
+                          </Button>
+                        </div>
                       ) : null}
                     </div>
+                    {reassigning && String(reassigning.mappingId) === String(mapping.id) ? (
+                      <div className="grid gap-3 rounded-lg border border-border bg-bg-card-alt p-3 md:col-span-5 md:grid-cols-[1fr_1fr_auto_auto]">
+                        <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                          Search replacement mentor
+                          <Input
+                            value={replacementMentorSearch}
+                            onChange={(event) => {
+                              const value = event.target.value;
+                              setReplacementMentorSearch(value);
+                              void loadReplacementMentors(value);
+                            }}
+                          />
+                        </label>
+                        <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                          Replacement Academic Mentor
+                          <Select
+                            value={replacementMentorUserId}
+                            onChange={(event) => setReplacementMentorUserId(event.target.value)}
+                          >
+                            <option value="">Select mentor</option>
+                            {replacementMentorOptions
+                              .filter(
+                                (mentor) => mentor.userId !== reassigning.currentMentorUserId
+                              )
+                              .map((mentor) => (
+                                <option key={mentor.userId} value={mentor.userId}>
+                                  {mentor.name} ({mentor.email})
+                                </option>
+                              ))}
+                          </Select>
+                        </label>
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => void reassignMapping()}
+                          disabled={busy}
+                          className="self-end"
+                        >
+                          Confirm Reassign
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setReassigning(null)}
+                          disabled={busy}
+                          className="self-end"
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -81,8 +81,15 @@ export default function AcademicMentorshipManager({
   const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
   const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
   const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [errorCsv, setErrorCsv] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ variant: "success" | "error"; message: string } | null>(null);
+  const templateParams = new URLSearchParams({
+    school_code: schoolCode,
+    academic_year: academicYear,
+  });
+  const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
 
   async function refreshMappings() {
     const params = new URLSearchParams({
@@ -164,6 +171,55 @@ export default function AcademicMentorshipManager({
       setToast({ variant: "success", message: "Mapping added." });
     } catch {
       setToast({ variant: "error", message: "Failed to add Mapping" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uploadCsv() {
+    if (!csvFile) {
+      setToast({ variant: "error", message: "Select a CSV file" });
+      return;
+    }
+
+    setBusy(true);
+    setErrorCsv(null);
+    try {
+      const formData = new FormData();
+      formData.set("school_code", schoolCode);
+      formData.set("academic_year", academicYear);
+      formData.set("file", csvFile);
+      const response = await fetch("/api/academic-mentorship/mappings/import", {
+        method: "POST",
+        body: formData,
+      });
+      const payload = await readJson(response);
+      if (!response.ok) {
+        if (
+          payload &&
+          typeof payload === "object" &&
+          "errorCsv" in payload &&
+          typeof payload.errorCsv === "string"
+        ) {
+          setErrorCsv(payload.errorCsv);
+        }
+        setToast({ variant: "error", message: apiError(payload, "Failed to upload CSV") });
+        return;
+      }
+      await refreshMappings();
+      const insertedCount =
+        payload &&
+        typeof payload === "object" &&
+        "insertedCount" in payload &&
+        typeof payload.insertedCount === "number"
+          ? payload.insertedCount
+          : 0;
+      setToast({
+        variant: "success",
+        message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
+      });
+    } catch {
+      setToast({ variant: "error", message: "Failed to upload CSV" });
     } finally {
       setBusy(false);
     }
@@ -307,6 +363,41 @@ export default function AcademicMentorshipManager({
             <Button type="button" onClick={() => void addMapping()} disabled={busy} className="self-end">
               Add Mapping
             </Button>
+          </div>
+          <div className="mt-4 grid gap-3 border-t border-border pt-4 md:grid-cols-[auto_1fr_auto_auto]">
+            <a
+              href={templateHref}
+              download="academic-mentorship-template.csv"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
+            >
+              Download CSV template
+            </a>
+            <label className="grid gap-1 text-sm font-semibold text-text-primary">
+              CSV file
+              <Input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(event) => setCsvFile(event.target.files?.[0] ?? null)}
+              />
+            </label>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => void uploadCsv()}
+              disabled={busy}
+              className="self-end"
+            >
+              Upload CSV
+            </Button>
+            {errorCsv ? (
+              <a
+                href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
+                download="academic-mentorship-import-errors.csv"
+                className="self-end text-sm font-bold text-accent hover:text-accent-hover"
+              >
+                Download error CSV
+              </a>
+            ) : null}
           </div>
         </Card>
       ) : null}

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -740,6 +740,13 @@ function AddMappingPanel({
   );
 }
 
+function csvUploadErrorValue(error: CsvUploadError, rows: CsvUploadRow[]): string {
+  const row = rows[error.rowNumber - 2];
+  if (!row) return "-";
+  if (error.field !== "mentor_email" && error.field !== "student_id") return "-";
+  return row[error.field] || "-";
+}
+
 function CsvUploadModal({
   open,
   academicYear,
@@ -828,7 +835,7 @@ function CsvUploadModal({
               <thead className="bg-danger/10 text-left text-xs font-bold uppercase tracking-wide text-danger">
                 <tr>
                   <th className="w-20 px-4 py-3">Row</th>
-                  <th className="w-40 px-4 py-3">Field</th>
+                  <th className="w-48 px-4 py-3">Error Value</th>
                   <th className="px-4 py-3">Reason</th>
                 </tr>
               </thead>
@@ -839,7 +846,7 @@ function CsvUploadModal({
                       {error.rowNumber}
                     </td>
                     <td className="border-t border-danger/20 px-4 py-3 font-mono text-text-primary">
-                      {error.field}
+                      {csvUploadErrorValue(error, csvRows)}
                     </td>
                     <td className="border-t border-danger/20 px-4 py-3 text-danger">
                       {error.error}

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -840,35 +840,15 @@ function MappingGroupsSection({
   );
 }
 
-export default function AcademicMentorshipManager({
+function useMappingGroupsState({
   schoolCode,
   academicYear,
   includeHistory,
-  canEdit,
   initialGroups,
 }: AcademicMentorshipManagerProps) {
   const groupsKey = `${schoolCode}:${academicYear}:${includeHistory}`;
   const [groupState, setGroupState] = useState({ key: groupsKey, groups: initialGroups });
   const groups = groupState.key === groupsKey ? groupState.groups : initialGroups;
-  const [mentorOptions, setMentorOptions] = useState<MentorOption[]>([]);
-  const [menteeOptions, setMenteeOptions] = useState<MenteeOption[]>([]);
-  const [mentorSearch, setMentorSearch] = useState("");
-  const [menteeSearch, setMenteeSearch] = useState("");
-  const [mentorUserId, setMentorUserId] = useState("");
-  const [studentPkId, setStudentPkId] = useState("");
-  const [reassigning, setReassigning] = useState<ReassigningState>(null);
-  const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
-  const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
-  const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
-  const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [errorCsv, setErrorCsv] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [toast, setToast] = useState<ToastState>(null);
-  const templateParams = new URLSearchParams({
-    school_code: schoolCode,
-    academic_year: academicYear,
-  });
-  const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
 
   async function refreshMappings() {
     setGroupState({
@@ -876,6 +856,19 @@ export default function AcademicMentorshipManager({
       groups: await fetchMappingGroups(schoolCode, academicYear, includeHistory),
     });
   }
+
+  return { groups, refreshMappings };
+}
+
+function useMentorshipOptionState(schoolCode: string, academicYear: string) {
+  const [mentorOptions, setMentorOptions] = useState<MentorOption[]>([]);
+  const [menteeOptions, setMenteeOptions] = useState<MenteeOption[]>([]);
+  const [mentorSearch, setMentorSearch] = useState("");
+  const [menteeSearch, setMenteeSearch] = useState("");
+  const [reassigning, setReassigning] = useState<ReassigningState>(null);
+  const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
+  const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
+  const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
 
   function startReassign(mappingId: number | string, currentMentorUserId: number) {
     setReassigning({ mappingId, currentMentorUserId });
@@ -904,6 +897,66 @@ export default function AcademicMentorshipManager({
       menteeOptionParams(schoolCode, academicYear, value)
     ).then(setMenteeOptions);
   }
+
+  return {
+    mentorOptions,
+    menteeOptions,
+    mentorSearch,
+    menteeSearch,
+    reassigning,
+    replacementMentorOptions,
+    replacementMentorSearch,
+    replacementMentorUserId,
+    setReassigning,
+    setReplacementMentorUserId,
+    startReassign,
+    searchReplacementMentors,
+    searchMentors,
+    searchMentees,
+  };
+}
+
+export default function AcademicMentorshipManager({
+  schoolCode,
+  academicYear,
+  includeHistory,
+  canEdit,
+  initialGroups,
+}: AcademicMentorshipManagerProps) {
+  const { groups, refreshMappings } = useMappingGroupsState({
+    schoolCode,
+    academicYear,
+    includeHistory,
+    canEdit,
+    initialGroups,
+  });
+  const {
+    mentorOptions,
+    menteeOptions,
+    mentorSearch,
+    menteeSearch,
+    reassigning,
+    replacementMentorOptions,
+    replacementMentorSearch,
+    replacementMentorUserId,
+    setReassigning,
+    setReplacementMentorUserId,
+    startReassign,
+    searchReplacementMentors,
+    searchMentors,
+    searchMentees,
+  } = useMentorshipOptionState(schoolCode, academicYear);
+  const [mentorUserId, setMentorUserId] = useState("");
+  const [studentPkId, setStudentPkId] = useState("");
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [errorCsv, setErrorCsv] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<ToastState>(null);
+  const templateParams = new URLSearchParams({
+    school_code: schoolCode,
+    academic_year: academicYear,
+  });
+  const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
 
   return (
     <>

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState } from "react";
+
+import Toast from "@/components/Toast";
+import { Button, Card, Input, Select } from "@/components/ui";
+
+type MappingGroup = {
+  mentor: {
+    userId: number;
+    name: string;
+    email: string | null;
+  };
+  menteeCount: number;
+  mappings: Array<{
+    id: number | string;
+    mentee: {
+      studentPkId: number;
+      name: string;
+      studentId: string | null;
+      grade: number | null;
+    };
+    assignedDate: string;
+    endedDate: string | null;
+    status: "active" | "historical";
+  }>;
+};
+
+type MentorOption = {
+  userId: number;
+  name: string;
+  email: string;
+};
+
+type MenteeOption = {
+  studentPkId: number;
+  name: string;
+  studentId: string | null;
+  grade: number | null;
+};
+
+interface AcademicMentorshipManagerProps {
+  schoolCode: string;
+  academicYear: string;
+  includeHistory: boolean;
+  canEdit: boolean;
+  initialGroups: MappingGroup[];
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function apiError(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== "object" || !("error" in payload)) return fallback;
+  return typeof payload.error === "string" && payload.error.trim() ? payload.error : fallback;
+}
+
+export default function AcademicMentorshipManager({
+  schoolCode,
+  academicYear,
+  includeHistory,
+  canEdit,
+  initialGroups,
+}: AcademicMentorshipManagerProps) {
+  const [groups, setGroups] = useState(initialGroups);
+  const [mentorOptions, setMentorOptions] = useState<MentorOption[]>([]);
+  const [menteeOptions, setMenteeOptions] = useState<MenteeOption[]>([]);
+  const [mentorSearch, setMentorSearch] = useState("");
+  const [menteeSearch, setMenteeSearch] = useState("");
+  const [mentorUserId, setMentorUserId] = useState("");
+  const [studentPkId, setStudentPkId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<{ variant: "success" | "error"; message: string } | null>(null);
+
+  async function refreshMappings() {
+    const params = new URLSearchParams({
+      school_code: schoolCode,
+      academic_year: academicYear,
+    });
+    if (includeHistory) params.set("include_history", "true");
+    const response = await fetch(`/api/academic-mentorship/mappings?${params.toString()}`);
+    const payload = await readJson(response);
+    if (response.ok && payload && typeof payload === "object" && "groups" in payload) {
+      setGroups((payload.groups as MappingGroup[]) ?? []);
+    }
+  }
+
+  async function loadMentors(search: string) {
+    const params = new URLSearchParams({
+      type: "mentors",
+      school_code: schoolCode,
+      q: search,
+    });
+    const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
+    const payload = await readJson(response);
+    if (response.ok && payload && typeof payload === "object" && "options" in payload) {
+      setMentorOptions((payload.options as MentorOption[]) ?? []);
+    }
+  }
+
+  async function loadMentees(search: string) {
+    const params = new URLSearchParams({
+      type: "mentees",
+      school_code: schoolCode,
+      academic_year: academicYear,
+      q: search,
+    });
+    const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
+    const payload = await readJson(response);
+    if (response.ok && payload && typeof payload === "object" && "options" in payload) {
+      setMenteeOptions((payload.options as MenteeOption[]) ?? []);
+    }
+  }
+
+  async function addMapping() {
+    if (!mentorUserId || !studentPkId) {
+      setToast({ variant: "error", message: "Select an Academic Mentor and Mentee" });
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const response = await fetch("/api/academic-mentorship/mappings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          school_code: schoolCode,
+          academic_year: academicYear,
+          mentor_user_id: Number(mentorUserId),
+          student_id: Number(studentPkId),
+        }),
+      });
+      const payload = await readJson(response);
+      await refreshMappings();
+      if (!response.ok) {
+        setToast({ variant: "error", message: apiError(payload, "Failed to add Mapping") });
+        return;
+      }
+      setMentorUserId("");
+      setStudentPkId("");
+      setToast({ variant: "success", message: "Mapping added." });
+    } catch {
+      setToast({ variant: "error", message: "Failed to add Mapping" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeMapping(mappingId: number | string) {
+    if (!window.confirm("This Student will no longer have an active Academic Mentor.")) {
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const response = await fetch("/api/academic-mentorship/mappings", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          school_code: schoolCode,
+          academic_year: academicYear,
+          mapping_id: Number(mappingId),
+        }),
+      });
+      const payload = await readJson(response);
+      await refreshMappings();
+      if (!response.ok) {
+        setToast({ variant: "error", message: apiError(payload, "Failed to remove Mapping") });
+        return;
+      }
+      setToast({ variant: "success", message: "Mapping removed." });
+    } catch {
+      setToast({ variant: "error", message: "Failed to remove Mapping" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      {toast ? (
+        <Toast
+          variant={toast.variant}
+          message={toast.message}
+          onDismiss={() => setToast(null)}
+        />
+      ) : null}
+
+      {canEdit ? (
+        <Card className="mt-4 p-4">
+          <div className="grid gap-3 lg:grid-cols-[1fr_1fr_auto]">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                Search mentors
+                <Input
+                  value={mentorSearch}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setMentorSearch(value);
+                    void loadMentors(value);
+                  }}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                Academic Mentor
+                <Select value={mentorUserId} onChange={(event) => setMentorUserId(event.target.value)}>
+                  <option value="">Select mentor</option>
+                  {mentorOptions.map((mentor) => (
+                    <option key={mentor.userId} value={mentor.userId}>
+                      {mentor.name} ({mentor.email})
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                Search mentees
+                <Input
+                  value={menteeSearch}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setMenteeSearch(value);
+                    void loadMentees(value);
+                  }}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+                Mentee
+                <Select value={studentPkId} onChange={(event) => setStudentPkId(event.target.value)}>
+                  <option value="">Select mentee</option>
+                  {menteeOptions.map((mentee) => (
+                    <option key={mentee.studentPkId} value={mentee.studentPkId}>
+                      {mentee.name} ({mentee.studentId ?? "no id"})
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            </div>
+            <Button type="button" onClick={() => void addMapping()} disabled={busy} className="self-end">
+              Add Mapping
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      <section className="mt-4 space-y-4">
+        {groups.length === 0 ? (
+          <Card className="p-6 text-sm text-text-muted">
+            No Academic Mentor-Mentee Mappings found.
+          </Card>
+        ) : (
+          groups.map((group) => (
+            <Card key={group.mentor.userId} className="p-0">
+              <div className="border-b border-border px-4 py-3">
+                <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
+                <p className="text-sm text-text-muted">
+                  {group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}
+                </p>
+              </div>
+              <div className="divide-y divide-border">
+                {group.mappings.map((mapping) => (
+                  <div
+                    key={String(mapping.id)}
+                    className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px_90px]"
+                  >
+                    <div>
+                      <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
+                      <div className="text-sm text-text-muted">{mapping.mentee.studentId}</div>
+                    </div>
+                    <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
+                    <div className="text-sm text-text-muted">{mapping.assignedDate}</div>
+                    <div className="text-sm font-semibold text-text-primary">
+                      {mapping.status === "active" ? "Active" : "Historical"}
+                      {includeHistory && mapping.endedDate ? (
+                        <span className="block font-normal text-text-muted">
+                          Ended {mapping.endedDate}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div>
+                      {canEdit && mapping.status === "active" ? (
+                        <Button
+                          type="button"
+                          variant="danger-ghost"
+                          size="sm"
+                          onClick={() => void removeMapping(mapping.id)}
+                          disabled={busy}
+                        >
+                          Remove
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          ))
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -11,6 +11,7 @@ import { Download, Plus, RotateCcw, Upload, XCircle } from "lucide-react";
 import Toast from "@/components/Toast";
 import { Badge, Button, Card, Input, Modal } from "@/components/ui";
 import type { AcademicMentorshipMappingGroup } from "@/lib/academic-mentorship";
+import { parseCsvText } from "@/lib/csv-parser";
 
 type MappingGroup = AcademicMentorshipMappingGroup;
 type Mapping = MappingGroup["mappings"][number];
@@ -35,6 +36,8 @@ type ReassigningState = {
   currentMentorUserId: number;
   menteeName: string;
 } | null;
+type CsvUploadRow = { mentor_email: string; student_id: string };
+type CsvUploadError = { rowNumber: number; field: string; error: string };
 
 interface AcademicMentorshipManagerProps {
   schoolCode: string;
@@ -69,6 +72,36 @@ function apiError(payload: unknown, fallback: string): string {
 function payloadErrorCsv(payload: unknown): string | null {
   if (!payload || typeof payload !== "object" || !("errorCsv" in payload)) return null;
   return typeof payload.errorCsv === "string" ? payload.errorCsv : null;
+}
+
+function valueAsRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function firstString(...values: unknown[]): string {
+  return values.find((value): value is string => typeof value === "string") ?? "";
+}
+
+function csvUploadError(error: unknown): CsvUploadError | null {
+  const row = valueAsRecord(error);
+  if (!row) return null;
+
+  const rowNumber = Number(row.rowNumber ?? row.row);
+  const message = firstString(row.error, row.message);
+  if (!Number.isFinite(rowNumber) || !message) return null;
+
+  return {
+    rowNumber,
+    field: firstString(row.field) || "-",
+    error: message,
+  };
+}
+
+function payloadCsvErrors(payload: unknown): CsvUploadError[] {
+  if (!payload || typeof payload !== "object" || !("errors" in payload)) return [];
+  const { errors } = payload as { errors?: unknown };
+  if (!Array.isArray(errors)) return [];
+  return errors.map(csvUploadError).filter((error): error is CsvUploadError => Boolean(error));
 }
 
 function payloadInsertedCount(payload: unknown): number {
@@ -251,17 +284,22 @@ async function uploadCsvAction(args: {
   refreshMappings: () => Promise<void>;
   setCsvOpen: StateSetter<boolean>;
   setCsvFile: StateSetter<File | null>;
+  setCsvRows: StateSetter<CsvUploadRow[]>;
+  setCsvErrors: StateSetter<CsvUploadError[]>;
+  setCsvFileError: StateSetter<string>;
   setErrorCsv: StateSetter<string | null>;
   setBusy: StateSetter<boolean>;
   setToast: StateSetter<ToastState>;
 }) {
   if (!args.csvFile) {
-    args.setToast({ variant: "error", message: "Select a CSV file" });
+    args.setCsvFileError("Choose a CSV file with at least one row");
     return;
   }
 
   args.setBusy(true);
   args.setErrorCsv(null);
+  args.setCsvErrors([]);
+  args.setCsvFileError("");
   try {
     const formData = new FormData();
     formData.set("school_code", args.schoolCode);
@@ -273,7 +311,12 @@ async function uploadCsvAction(args: {
     });
     const payload = await readJson(response);
     if (!response.ok) {
+      const rowErrors = payloadCsvErrors(payload);
       args.setErrorCsv(payloadErrorCsv(payload));
+      args.setCsvErrors(rowErrors);
+      args.setCsvFileError(
+        rowErrors.length > 0 ? "Upload failed. 0 rows were saved." : apiError(payload, "Failed to upload CSV")
+      );
       args.setToast({ variant: "error", message: apiError(payload, "Failed to upload CSV") });
       return;
     }
@@ -281,6 +324,9 @@ async function uploadCsvAction(args: {
     const insertedCount = payloadInsertedCount(payload);
     args.setCsvOpen(false);
     args.setCsvFile(null);
+    args.setCsvRows([]);
+    args.setCsvErrors([]);
+    args.setCsvFileError("");
     args.setToast({
       variant: "success",
       message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
@@ -574,7 +620,6 @@ function ActionBar({
   canEdit,
   canUpload,
   templateHref,
-  errorCsv,
   busy,
   onAdd,
   onUpload,
@@ -582,7 +627,6 @@ function ActionBar({
   canEdit: boolean;
   canUpload: boolean;
   templateHref: string;
-  errorCsv: string | null;
   busy: boolean;
   onAdd: () => void;
   onUpload: () => void;
@@ -615,15 +659,6 @@ function ActionBar({
           <Download className="h-4 w-4" aria-hidden="true" />
           Template
         </a>
-        {errorCsv ? (
-          <a
-            href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
-            download="academic-mentorship-import-errors.csv"
-            className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-2 text-sm font-bold text-accent hover:text-accent-hover"
-          >
-            Download error CSV
-          </a>
-        ) : null}
       </div>
     </Card>
   );
@@ -708,6 +743,11 @@ function AddMappingPanel({
 function CsvUploadModal({
   open,
   academicYear,
+  templateHref,
+  csvRows,
+  csvErrors,
+  csvFileError,
+  errorCsv,
   busy,
   onClose,
   onFile,
@@ -715,34 +755,118 @@ function CsvUploadModal({
 }: {
   open: boolean;
   academicYear: string;
+  templateHref: string;
+  csvRows: CsvUploadRow[];
+  csvErrors: CsvUploadError[];
+  csvFileError: string;
+  errorCsv: string | null;
   busy: boolean;
   onClose: () => void;
   onFile: (file: File | null) => void;
   onUpload: () => void;
 }) {
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal open={open} onClose={onClose} className="max-w-3xl">
       <div className="border-b border-border px-5 py-4">
         <h2 className="text-base font-bold text-text-primary">Upload CSV</h2>
         <p className="mt-1 text-sm text-text-muted">
-          Upload mentor_email,student_id rows for {academicYear}.
+          CSV must contain mentor_email,student_id rows for {academicYear}.
         </p>
       </div>
-      <div className="grid gap-4 px-5 py-4">
+      <div className="grid max-h-[70vh] gap-4 overflow-y-auto px-5 py-4">
+        <a
+          href={templateHref}
+          download="academic-mentorship-template.csv"
+          className="inline-flex min-h-10 w-fit items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-3 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          Download CSV template
+        </a>
         <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
           CSV file
           <Input
             type="file"
             accept=".csv,text/csv"
             onChange={(event) => onFile(event.target.files?.[0] ?? null)}
+            disabled={busy}
           />
         </label>
+        {csvFileError ? (
+          <div className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+            {csvFileError}
+          </div>
+        ) : null}
+        {csvRows.length > 0 ? (
+          <div className="overflow-hidden rounded-lg border border-border">
+            <table className="min-w-full table-fixed divide-y divide-border text-sm">
+              <thead className="bg-bg-card-alt text-left text-xs font-bold uppercase tracking-wide text-text-muted">
+                <tr>
+                  <th className="w-1/2 px-4 py-3">Mentor Email</th>
+                  <th className="w-1/2 px-4 py-3">Student ID</th>
+                </tr>
+              </thead>
+              <tbody>
+                {csvRows.map((row, index) => (
+                  <tr key={`${row.mentor_email}-${row.student_id}-${index}`}>
+                    <td className="border-t border-border px-4 py-3 text-text-primary">
+                      {row.mentor_email || "-"}
+                    </td>
+                    <td className="border-t border-border px-4 py-3 font-mono text-text-primary">
+                      {row.student_id || "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+        {csvErrors.length > 0 ? (
+          <div className="overflow-hidden rounded-lg border border-danger/30">
+            <table className="min-w-full table-fixed divide-y divide-danger/20 text-sm">
+              <thead className="bg-danger/10 text-left text-xs font-bold uppercase tracking-wide text-danger">
+                <tr>
+                  <th className="w-20 px-4 py-3">Row</th>
+                  <th className="w-40 px-4 py-3">Field</th>
+                  <th className="px-4 py-3">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {csvErrors.map((error, index) => (
+                  <tr key={`${error.rowNumber}-${error.field}-${index}`}>
+                    <td className="border-t border-danger/20 px-4 py-3 text-text-primary">
+                      {error.rowNumber}
+                    </td>
+                    <td className="border-t border-danger/20 px-4 py-3 font-mono text-text-primary">
+                      {error.field}
+                    </td>
+                    <td className="border-t border-danger/20 px-4 py-3 text-danger">
+                      {error.error}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+        {errorCsv ? (
+          <a
+            href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
+            download="academic-mentorship-import-errors.csv"
+            className="inline-flex min-h-10 w-fit items-center justify-center rounded-lg px-2 text-sm font-bold text-accent hover:text-accent-hover"
+          >
+            Download error CSV
+          </a>
+        ) : null}
       </div>
       <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
         <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
           Cancel
         </Button>
-        <Button type="button" onClick={onUpload} disabled={busy}>
+        <Button
+          type="button"
+          onClick={onUpload}
+          disabled={busy || csvRows.length === 0 || Boolean(csvFileError)}
+        >
           Upload CSV
         </Button>
       </div>
@@ -936,6 +1060,9 @@ export default function AcademicMentorshipManager({
   const [addOpen, setAddOpen] = useState(false);
   const [csvOpen, setCsvOpen] = useState(false);
   const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvRows, setCsvRows] = useState<CsvUploadRow[]>([]);
+  const [csvErrors, setCsvErrors] = useState<CsvUploadError[]>([]);
+  const [csvFileError, setCsvFileError] = useState("");
   const [errorCsv, setErrorCsv] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<ToastState>(null);
@@ -945,6 +1072,41 @@ export default function AcademicMentorshipManager({
   });
   const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
 
+  function closeCsvModal() {
+    setCsvOpen(false);
+    setCsvFile(null);
+    setCsvRows([]);
+    setCsvErrors([]);
+    setCsvFileError("");
+  }
+
+  async function handleCsvFile(file: File | null) {
+    setCsvFile(file);
+    setCsvRows([]);
+    setCsvErrors([]);
+    setCsvFileError("");
+    setErrorCsv(null);
+    if (!file) return;
+
+    try {
+      const parsed = parseCsvText(await file.text());
+      const requiredColumns = ["mentor_email", "student_id"];
+      const missingColumns = requiredColumns.filter((column) => !parsed.headers.includes(column));
+      if (missingColumns.length > 0) {
+        setCsvFileError(`Missing required columns: ${missingColumns.join(", ")}`);
+        return;
+      }
+      const rows = parsed.rows.map((row) => ({
+        mentor_email: row.mentor_email ?? "",
+        student_id: row.student_id ?? "",
+      }));
+      setCsvRows(rows);
+      if (rows.length === 0) setCsvFileError("Choose a CSV file with at least one row");
+    } catch {
+      setCsvFileError("Unable to parse CSV file");
+    }
+  }
+
   return (
     <>
       <ManagerToast toast={toast} onDismiss={() => setToast(null)} />
@@ -953,7 +1115,6 @@ export default function AcademicMentorshipManager({
         canEdit={canEdit}
         canUpload={canUpload}
         templateHref={templateHref}
-        errorCsv={errorCsv}
         busy={busy}
         onAdd={() => setAddOpen(true)}
         onUpload={() => setCsvOpen(true)}
@@ -994,9 +1155,16 @@ export default function AcademicMentorshipManager({
       <CsvUploadModal
         open={csvOpen && canUpload}
         academicYear={academicYear}
+        templateHref={templateHref}
+        csvRows={csvRows}
+        csvErrors={csvErrors}
+        csvFileError={csvFileError}
+        errorCsv={errorCsv}
         busy={busy}
-        onClose={() => setCsvOpen(false)}
-        onFile={setCsvFile}
+        onClose={closeCsvModal}
+        onFile={(file) => {
+          void handleCsvFile(file);
+        }}
         onUpload={() =>
           void uploadCsvAction({
             schoolCode,
@@ -1005,6 +1173,9 @@ export default function AcademicMentorshipManager({
             refreshMappings,
             setCsvOpen,
             setCsvFile,
+            setCsvRows,
+            setCsvErrors,
+            setCsvFileError,
             setErrorCsv,
             setBusy,
             setToast,

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Download, Plus, RotateCcw, Upload, XCircle } from "lucide-react";
 
 import Toast from "@/components/Toast";
-import { Button, Card, Input, Select } from "@/components/ui";
+import { Badge, Button, Card, Input, Select } from "@/components/ui";
 
 type MappingGroup = {
   mentor: {
@@ -314,10 +315,19 @@ export default function AcademicMentorshipManager({
       ) : null}
 
       {canEdit ? (
-        <Card className="mt-4 p-4">
-          <div className="grid gap-3 lg:grid-cols-[1fr_1fr_auto]">
+        <Card className="mt-4 overflow-hidden p-0">
+          <div className="border-b border-border bg-bg-card-alt px-4 py-3">
+            <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+              Assign mentee
+            </h2>
+            <p className="mt-1 text-sm text-text-muted">
+              Search before selecting so the dropdowns stay scoped to this School and year.
+            </p>
+          </div>
+
+          <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
             <div className="grid gap-2 sm:grid-cols-2">
-              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
                 Search mentors
                 <Input
                   value={mentorSearch}
@@ -328,9 +338,13 @@ export default function AcademicMentorshipManager({
                   }}
                 />
               </label>
-              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
                 Academic Mentor
-                <Select value={mentorUserId} onChange={(event) => setMentorUserId(event.target.value)}>
+                <Select
+                  value={mentorUserId}
+                  onChange={(event) => setMentorUserId(event.target.value)}
+                  className="w-full min-w-0"
+                >
                   <option value="">Select mentor</option>
                   {mentorOptions.map((mentor) => (
                     <option key={mentor.userId} value={mentor.userId}>
@@ -341,7 +355,7 @@ export default function AcademicMentorshipManager({
               </label>
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
-              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
                 Search mentees
                 <Input
                   value={menteeSearch}
@@ -352,9 +366,13 @@ export default function AcademicMentorshipManager({
                   }}
                 />
               </label>
-              <label className="grid gap-1 text-sm font-semibold text-text-primary">
+              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
                 Mentee
-                <Select value={studentPkId} onChange={(event) => setStudentPkId(event.target.value)}>
+                <Select
+                  value={studentPkId}
+                  onChange={(event) => setStudentPkId(event.target.value)}
+                  className="w-full min-w-0"
+                >
                   <option value="">Select mentee</option>
                   {menteeOptions.map((mentee) => (
                     <option key={mentee.studentPkId} value={mentee.studentPkId}>
@@ -365,18 +383,21 @@ export default function AcademicMentorshipManager({
               </label>
             </div>
             <Button type="button" onClick={() => void addMapping()} disabled={busy} className="self-end">
+              <Plus className="h-4 w-4" aria-hidden="true" />
               Add Mapping
             </Button>
           </div>
-          <div className="mt-4 grid gap-3 border-t border-border pt-4 md:grid-cols-[auto_1fr_auto_auto]">
+
+          <div className="grid gap-3 border-t border-border bg-bg-card-alt/60 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto_auto]">
             <a
               href={templateHref}
               download="academic-mentorship-template.csv"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
+              className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
             >
+              <Download className="h-4 w-4" aria-hidden="true" />
               Download CSV template
             </a>
-            <label className="grid gap-1 text-sm font-semibold text-text-primary">
+            <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
               CSV file
               <Input
                 type="file"
@@ -391,6 +412,7 @@ export default function AcademicMentorshipManager({
               disabled={busy}
               className="self-end"
             >
+              <Upload className="h-4 w-4" aria-hidden="true" />
               Upload CSV
             </Button>
             {errorCsv ? (
@@ -406,41 +428,63 @@ export default function AcademicMentorshipManager({
         </Card>
       ) : null}
 
-      <section className="mt-4 space-y-4">
+      <section className="mt-4 space-y-3">
         {groups.length === 0 ? (
-          <Card className="p-6 text-sm text-text-muted">
-            No Academic Mentor-Mentee Mappings found.
+          <Card className="border-dashed p-8 text-center text-sm text-text-muted">
+            <div className="font-semibold text-text-primary">
+              No Academic Mentor-Mentee Mappings found.
+            </div>
+            <p className="mt-1">Mappings will appear here after a manual add or CSV upload.</p>
           </Card>
         ) : (
           groups.map((group) => (
-            <Card key={group.mentor.userId} className="p-0">
-              <div className="border-b border-border px-4 py-3">
-                <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
-                <p className="text-sm text-text-muted">
+            <Card key={group.mentor.userId} className="overflow-hidden p-0">
+              <div className="flex flex-col gap-3 border-b border-border bg-bg-card-alt px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
+                  {group.mentor.email ? (
+                    <p className="text-sm text-text-muted">{group.mentor.email}</p>
+                  ) : null}
+                </div>
+                <Badge variant="accent" className="w-fit font-mono">
                   {group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}
-                </p>
+                </Badge>
               </div>
               <div className="divide-y divide-border">
+                <div className="hidden bg-bg-card px-4 py-2 text-xs font-bold uppercase tracking-wide text-text-muted md:grid md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px]">
+                  <div>Mentee</div>
+                  <div>Grade</div>
+                  <div>Assigned</div>
+                  <div>Status</div>
+                  <div className="text-right">Actions</div>
+                </div>
                 {group.mappings.map((mapping) => (
                   <div
                     key={String(mapping.id)}
-                    className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_120px_140px_120px_160px]"
+                    className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center"
                   >
                     <div>
                       <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
-                      <div className="text-sm text-text-muted">{mapping.mentee.studentId}</div>
+                      <div className="font-mono text-xs text-text-muted">
+                        {mapping.mentee.studentId ?? "No ID"}
+                      </div>
                     </div>
                     <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
-                    <div className="text-sm text-text-muted">{mapping.assignedDate}</div>
+                    <div className="font-mono text-xs text-text-muted">{mapping.assignedDate}</div>
                     <div className="text-sm font-semibold text-text-primary">
-                      {mapping.status === "active" ? "Active" : "Historical"}
+                      <Badge
+                        variant={mapping.status === "active" ? "success" : "default"}
+                        className="w-fit"
+                      >
+                        {mapping.status === "active" ? "Active" : "Historical"}
+                      </Badge>
                       {includeHistory && mapping.endedDate ? (
-                        <span className="block font-normal text-text-muted">
+                        <span className="mt-1 block font-mono text-xs font-normal text-text-muted">
                           Ended {mapping.endedDate}
                         </span>
                       ) : null}
                     </div>
-                    <div>
+                    <div className="md:flex md:justify-end">
                       {canEdit && mapping.status === "active" ? (
                         <div className="flex flex-wrap gap-2">
                           <Button
@@ -450,6 +494,7 @@ export default function AcademicMentorshipManager({
                             onClick={() => startReassign(mapping.id, group.mentor.userId)}
                             disabled={busy}
                           >
+                            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
                             Reassign
                           </Button>
                           <Button
@@ -459,6 +504,7 @@ export default function AcademicMentorshipManager({
                             onClick={() => void removeMapping(mapping.id)}
                             disabled={busy}
                           >
+                            <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
                             Remove
                           </Button>
                         </div>
@@ -482,6 +528,7 @@ export default function AcademicMentorshipManager({
                           <Select
                             value={replacementMentorUserId}
                             onChange={(event) => setReplacementMentorUserId(event.target.value)}
+                            className="w-full min-w-0"
                           >
                             <option value="">Select mentor</option>
                             {replacementMentorOptions

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1,31 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import { Download, Plus, RotateCcw, Upload, XCircle } from "lucide-react";
 
 import Toast from "@/components/Toast";
 import { Badge, Button, Card, Input, Select } from "@/components/ui";
+import type { AcademicMentorshipMappingGroup } from "@/lib/academic-mentorship";
 
-type MappingGroup = {
-  mentor: {
-    userId: number;
-    name: string;
-    email: string | null;
-  };
-  menteeCount: number;
-  mappings: Array<{
-    id: number | string;
-    mentee: {
-      studentPkId: number;
-      name: string;
-      studentId: string | null;
-      grade: number | null;
-    };
-    assignedDate: string;
-    endedDate: string | null;
-    status: "active" | "historical";
-  }>;
-};
+type MappingGroup = AcademicMentorshipMappingGroup;
 
 type MentorOption = {
   userId: number;
@@ -45,6 +27,39 @@ type ReassigningState = {
   mappingId: number | string;
   currentMentorUserId: number;
 } | null;
+type ToastState = { variant: "success" | "error"; message: string } | null;
+type StateSetter<T> = Dispatch<SetStateAction<T>>;
+
+interface MappingControls {
+  canEdit: boolean;
+  busy: boolean;
+  reassigning: ReassigningState;
+  replacementMentorSearch: string;
+  replacementMentorUserId: string;
+  replacementMentorOptions: MentorOption[];
+  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
+  onRemove: (mappingId: number | string) => void;
+  onReplacementMentorSearch: (value: string) => void;
+  onReplacementMentorSelect: (value: string) => void;
+  onConfirmReassign: () => void;
+  onCancelReassign: () => void;
+}
+
+interface MappingRowProps extends MappingControls {
+  mapping: Mapping;
+  mentorUserId: number;
+  includeHistory: boolean;
+}
+
+interface MappingGroupCardProps extends MappingControls {
+  group: MappingGroup;
+  includeHistory: boolean;
+}
+
+interface MappingGroupsSectionProps extends MappingControls {
+  groups: MappingGroup[];
+  includeHistory: boolean;
+}
 
 interface AcademicMentorshipManagerProps {
   schoolCode: string;
@@ -75,6 +90,228 @@ function payloadErrorCsv(payload: unknown): string | null {
 function payloadInsertedCount(payload: unknown): number {
   if (!payload || typeof payload !== "object" || !("insertedCount" in payload)) return 0;
   return typeof payload.insertedCount === "number" ? payload.insertedCount : 0;
+}
+
+function payloadGroups(payload: unknown): MappingGroup[] {
+  if (!payload || typeof payload !== "object" || !("groups" in payload)) return [];
+  const { groups } = payload as { groups?: unknown };
+  return Array.isArray(groups) ? (groups as MappingGroup[]) : [];
+}
+
+function payloadOptions<T>(payload: unknown): T[] {
+  if (!payload || typeof payload !== "object" || !("options" in payload)) return [];
+  const { options } = payload as { options?: unknown };
+  return Array.isArray(options) ? (options as T[]) : [];
+}
+
+async function fetchMappingGroups(
+  schoolCode: string,
+  academicYear: string,
+  includeHistory: boolean
+): Promise<MappingGroup[]> {
+  const params = new URLSearchParams({
+    school_code: schoolCode,
+    academic_year: academicYear,
+  });
+  if (includeHistory) params.set("include_history", "true");
+
+  const response = await fetch(`/api/academic-mentorship/mappings?${params.toString()}`);
+  return response.ok ? payloadGroups(await readJson(response)) : [];
+}
+
+async function fetchOptions<T>(params: URLSearchParams): Promise<T[]> {
+  const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
+  return response.ok ? payloadOptions<T>(await readJson(response)) : [];
+}
+
+async function mappingJsonMutation(
+  method: "POST" | "DELETE" | "PATCH",
+  body: Record<string, unknown>
+): Promise<{ response: Response; payload: unknown }> {
+  const response = await fetch("/api/academic-mentorship/mappings", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { response, payload: await readJson(response) };
+}
+
+function mentorOptionParams(schoolCode: string, search: string): URLSearchParams {
+  return new URLSearchParams({
+    type: "mentors",
+    school_code: schoolCode,
+    q: search,
+  });
+}
+
+function menteeOptionParams(
+  schoolCode: string,
+  academicYear: string,
+  search: string
+): URLSearchParams {
+  return new URLSearchParams({
+    type: "mentees",
+    school_code: schoolCode,
+    academic_year: academicYear,
+    q: search,
+  });
+}
+
+async function addMappingAction(args: {
+  schoolCode: string;
+  academicYear: string;
+  mentorUserId: string;
+  studentPkId: string;
+  refreshMappings: () => Promise<void>;
+  setMentorUserId: StateSetter<string>;
+  setStudentPkId: StateSetter<string>;
+  setBusy: StateSetter<boolean>;
+  setToast: StateSetter<ToastState>;
+}) {
+  if (!args.mentorUserId || !args.studentPkId) {
+    args.setToast({ variant: "error", message: "Select an Academic Mentor and Mentee" });
+    return;
+  }
+
+  args.setBusy(true);
+  try {
+    const { response, payload } = await mappingJsonMutation("POST", {
+      school_code: args.schoolCode,
+      academic_year: args.academicYear,
+      mentor_user_id: Number(args.mentorUserId),
+      student_id: Number(args.studentPkId),
+    });
+    await args.refreshMappings();
+    if (!response.ok) {
+      args.setToast({ variant: "error", message: apiError(payload, "Failed to add Mapping") });
+      return;
+    }
+    args.setMentorUserId("");
+    args.setStudentPkId("");
+    args.setToast({ variant: "success", message: "Mapping added." });
+  } catch {
+    args.setToast({ variant: "error", message: "Failed to add Mapping" });
+  } finally {
+    args.setBusy(false);
+  }
+}
+
+async function uploadCsvAction(args: {
+  schoolCode: string;
+  academicYear: string;
+  csvFile: File | null;
+  refreshMappings: () => Promise<void>;
+  setErrorCsv: StateSetter<string | null>;
+  setBusy: StateSetter<boolean>;
+  setToast: StateSetter<ToastState>;
+}) {
+  if (!args.csvFile) {
+    args.setToast({ variant: "error", message: "Select a CSV file" });
+    return;
+  }
+
+  args.setBusy(true);
+  args.setErrorCsv(null);
+  try {
+    const formData = new FormData();
+    formData.set("school_code", args.schoolCode);
+    formData.set("academic_year", args.academicYear);
+    formData.set("file", args.csvFile);
+    const response = await fetch("/api/academic-mentorship/mappings/import", {
+      method: "POST",
+      body: formData,
+    });
+    const payload = await readJson(response);
+    if (!response.ok) {
+      args.setErrorCsv(payloadErrorCsv(payload));
+      args.setToast({ variant: "error", message: apiError(payload, "Failed to upload CSV") });
+      return;
+    }
+    await args.refreshMappings();
+    const insertedCount = payloadInsertedCount(payload);
+    args.setToast({
+      variant: "success",
+      message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
+    });
+  } catch {
+    args.setToast({ variant: "error", message: "Failed to upload CSV" });
+  } finally {
+    args.setBusy(false);
+  }
+}
+
+async function removeMappingAction(args: {
+  schoolCode: string;
+  academicYear: string;
+  mappingId: number | string;
+  refreshMappings: () => Promise<void>;
+  setBusy: StateSetter<boolean>;
+  setToast: StateSetter<ToastState>;
+}) {
+  if (!window.confirm("This Student will no longer have an active Academic Mentor.")) {
+    return;
+  }
+
+  args.setBusy(true);
+  try {
+    const { response, payload } = await mappingJsonMutation("DELETE", {
+      school_code: args.schoolCode,
+      academic_year: args.academicYear,
+      mapping_id: Number(args.mappingId),
+    });
+    await args.refreshMappings();
+    if (!response.ok) {
+      args.setToast({ variant: "error", message: apiError(payload, "Failed to remove Mapping") });
+      return;
+    }
+    args.setToast({ variant: "success", message: "Mapping removed." });
+  } catch {
+    args.setToast({ variant: "error", message: "Failed to remove Mapping" });
+  } finally {
+    args.setBusy(false);
+  }
+}
+
+async function reassignMappingAction(args: {
+  schoolCode: string;
+  academicYear: string;
+  reassigning: ReassigningState;
+  replacementMentorUserId: string;
+  refreshMappings: () => Promise<void>;
+  setReassigning: StateSetter<ReassigningState>;
+  setReplacementMentorUserId: StateSetter<string>;
+  setBusy: StateSetter<boolean>;
+  setToast: StateSetter<ToastState>;
+}) {
+  if (!args.reassigning || !args.replacementMentorUserId) {
+    args.setToast({ variant: "error", message: "Select a replacement Academic Mentor" });
+    return;
+  }
+  if (!window.confirm("This will end the old Mapping and create a new Mapping.")) {
+    return;
+  }
+
+  args.setBusy(true);
+  try {
+    const { response, payload } = await mappingJsonMutation("PATCH", {
+      school_code: args.schoolCode,
+      academic_year: args.academicYear,
+      mapping_id: Number(args.reassigning.mappingId),
+      mentor_user_id: Number(args.replacementMentorUserId),
+    });
+    await args.refreshMappings();
+    if (!response.ok) {
+      args.setToast({ variant: "error", message: apiError(payload, "Failed to reassign Mapping") });
+      return;
+    }
+    args.setReassigning(null);
+    args.setReplacementMentorUserId("");
+    args.setToast({ variant: "success", message: "Mapping reassigned." });
+  } catch {
+    args.setToast({ variant: "error", message: "Failed to reassign Mapping" });
+  } finally {
+    args.setBusy(false);
+  }
 }
 
 function MappingStatus({
@@ -216,6 +453,57 @@ function ReassignPanel({
   );
 }
 
+function reassigningMentorId(
+  reassigning: ReassigningState,
+  mappingId: number | string
+): number | null {
+  if (!reassigning) return null;
+  return String(reassigning.mappingId) === String(mappingId)
+    ? reassigning.currentMentorUserId
+    : null;
+}
+
+function MappingReassignPanel({
+  reassigning,
+  mappingId,
+  replacementMentorSearch,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  busy,
+  onReplacementMentorSearch,
+  onReplacementMentorSelect,
+  onConfirmReassign,
+  onCancelReassign,
+}: {
+  reassigning: ReassigningState;
+  mappingId: number | string;
+  replacementMentorSearch: string;
+  replacementMentorUserId: string;
+  replacementMentorOptions: MentorOption[];
+  busy: boolean;
+  onReplacementMentorSearch: (value: string) => void;
+  onReplacementMentorSelect: (value: string) => void;
+  onConfirmReassign: () => void;
+  onCancelReassign: () => void;
+}) {
+  const currentMentorUserId = reassigningMentorId(reassigning, mappingId);
+  if (currentMentorUserId === null) return null;
+
+  return (
+    <ReassignPanel
+      currentMentorUserId={currentMentorUserId}
+      replacementMentorSearch={replacementMentorSearch}
+      replacementMentorUserId={replacementMentorUserId}
+      replacementMentorOptions={replacementMentorOptions}
+      busy={busy}
+      onSearch={onReplacementMentorSearch}
+      onSelect={onReplacementMentorSelect}
+      onConfirm={onConfirmReassign}
+      onCancel={onCancelReassign}
+    />
+  );
+}
+
 function MappingRow({
   mapping,
   mentorUserId,
@@ -232,28 +520,7 @@ function MappingRow({
   onReplacementMentorSelect,
   onConfirmReassign,
   onCancelReassign,
-}: {
-  mapping: Mapping;
-  mentorUserId: number;
-  includeHistory: boolean;
-  canEdit: boolean;
-  busy: boolean;
-  reassigning: ReassigningState;
-  replacementMentorSearch: string;
-  replacementMentorUserId: string;
-  replacementMentorOptions: MentorOption[];
-  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
-  onRemove: (mappingId: number | string) => void;
-  onReplacementMentorSearch: (value: string) => void;
-  onReplacementMentorSelect: (value: string) => void;
-  onConfirmReassign: () => void;
-  onCancelReassign: () => void;
-}) {
-  const reassigningHere =
-    reassigning && String(reassigning.mappingId) === String(mapping.id)
-      ? reassigning.currentMentorUserId
-      : null;
-
+}: MappingRowProps) {
   return (
     <div
       className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center"
@@ -278,20 +545,298 @@ function MappingRow({
           onRemove={onRemove}
         />
       </div>
-      {reassigningHere ? (
-        <ReassignPanel
-          currentMentorUserId={reassigningHere}
+      <MappingReassignPanel
+        reassigning={reassigning}
+        mappingId={mapping.id}
+        replacementMentorSearch={replacementMentorSearch}
+        replacementMentorUserId={replacementMentorUserId}
+        replacementMentorOptions={replacementMentorOptions}
+        busy={busy}
+        onReplacementMentorSearch={onReplacementMentorSearch}
+        onReplacementMentorSelect={onReplacementMentorSelect}
+        onConfirmReassign={onConfirmReassign}
+        onCancelReassign={onCancelReassign}
+      />
+    </div>
+  );
+}
+
+function ManagerToast({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastState;
+  onDismiss: () => void;
+}) {
+  if (!toast) return null;
+  return (
+    <Toast
+      variant={toast.variant}
+      message={toast.message}
+      onDismiss={onDismiss}
+    />
+  );
+}
+
+function AssignmentCard({
+  canEdit,
+  mentorSearch,
+  mentorUserId,
+  mentorOptions,
+  menteeSearch,
+  studentPkId,
+  menteeOptions,
+  busy,
+  templateHref,
+  errorCsv,
+  onMentorSearch,
+  onMentorSelect,
+  onMenteeSearch,
+  onMenteeSelect,
+  onAddMapping,
+  onCsvFile,
+  onUploadCsv,
+}: {
+  canEdit: boolean;
+  mentorSearch: string;
+  mentorUserId: string;
+  mentorOptions: MentorOption[];
+  menteeSearch: string;
+  studentPkId: string;
+  menteeOptions: MenteeOption[];
+  busy: boolean;
+  templateHref: string;
+  errorCsv: string | null;
+  onMentorSearch: (value: string) => void;
+  onMentorSelect: (value: string) => void;
+  onMenteeSearch: (value: string) => void;
+  onMenteeSelect: (value: string) => void;
+  onAddMapping: () => void;
+  onCsvFile: (file: File | null) => void;
+  onUploadCsv: () => void;
+}) {
+  if (!canEdit) return null;
+
+  return (
+    <Card className="mt-4 overflow-hidden p-0">
+      <div className="border-b border-border bg-bg-card-alt px-4 py-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+          Assign mentee
+        </h2>
+        <p className="mt-1 text-sm text-text-muted">
+          Search before selecting so the dropdowns stay scoped to this School and year.
+        </p>
+      </div>
+
+      <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+            Search mentors
+            <Input
+              value={mentorSearch}
+              onChange={(event) => onMentorSearch(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+            Academic Mentor
+            <Select
+              value={mentorUserId}
+              onChange={(event) => onMentorSelect(event.target.value)}
+              className="w-full min-w-0"
+            >
+              <option value="">Select mentor</option>
+              {mentorOptions.map((mentor) => (
+                <option key={mentor.userId} value={mentor.userId}>
+                  {mentor.name} ({mentor.email})
+                </option>
+              ))}
+            </Select>
+          </label>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+            Search mentees
+            <Input
+              value={menteeSearch}
+              onChange={(event) => onMenteeSearch(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+            Mentee
+            <Select
+              value={studentPkId}
+              onChange={(event) => onMenteeSelect(event.target.value)}
+              className="w-full min-w-0"
+            >
+              <option value="">Select mentee</option>
+              {menteeOptions.map((mentee) => (
+                <option key={mentee.studentPkId} value={mentee.studentPkId}>
+                  {mentee.name} ({mentee.studentId ?? "no id"})
+                </option>
+              ))}
+            </Select>
+          </label>
+        </div>
+        <Button type="button" onClick={onAddMapping} disabled={busy} className="self-end">
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          Add Mapping
+        </Button>
+      </div>
+
+      <div className="grid gap-3 border-t border-border bg-bg-card-alt/60 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto_auto]">
+        <a
+          href={templateHref}
+          download="academic-mentorship-template.csv"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          Download CSV template
+        </a>
+        <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+          CSV file
+          <Input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(event) => onCsvFile(event.target.files?.[0] ?? null)}
+          />
+        </label>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onUploadCsv}
+          disabled={busy}
+          className="self-end"
+        >
+          <Upload className="h-4 w-4" aria-hidden="true" />
+          Upload CSV
+        </Button>
+        {errorCsv ? (
+          <a
+            href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
+            download="academic-mentorship-import-errors.csv"
+            className="self-end text-sm font-bold text-accent hover:text-accent-hover"
+          >
+            Download error CSV
+          </a>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function MappingGroupCard({
+  group,
+  includeHistory,
+  canEdit,
+  busy,
+  reassigning,
+  replacementMentorSearch,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  onStartReassign,
+  onRemove,
+  onReplacementMentorSearch,
+  onReplacementMentorSelect,
+  onConfirmReassign,
+  onCancelReassign,
+}: MappingGroupCardProps) {
+  return (
+    <Card className="overflow-hidden p-0">
+      <div className="flex flex-col gap-3 border-b border-border bg-bg-card-alt px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
+          {group.mentor.email ? (
+            <p className="text-sm text-text-muted">{group.mentor.email}</p>
+          ) : null}
+        </div>
+        <Badge variant="accent" className="w-fit font-mono">
+          {group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}
+        </Badge>
+      </div>
+      <div className="divide-y divide-border">
+        <div className="hidden bg-bg-card px-4 py-2 text-xs font-bold uppercase tracking-wide text-text-muted md:grid md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px]">
+          <div>Mentee</div>
+          <div>Grade</div>
+          <div>Assigned</div>
+          <div>Status</div>
+          <div className="text-right">Actions</div>
+        </div>
+        {group.mappings.map((mapping) => (
+          <MappingRow
+            key={String(mapping.id)}
+            mapping={mapping}
+            mentorUserId={group.mentor.userId}
+            includeHistory={includeHistory}
+            canEdit={canEdit}
+            busy={busy}
+            reassigning={reassigning}
+            replacementMentorSearch={replacementMentorSearch}
+            replacementMentorUserId={replacementMentorUserId}
+            replacementMentorOptions={replacementMentorOptions}
+            onStartReassign={onStartReassign}
+            onRemove={onRemove}
+            onReplacementMentorSearch={onReplacementMentorSearch}
+            onReplacementMentorSelect={onReplacementMentorSelect}
+            onConfirmReassign={onConfirmReassign}
+            onCancelReassign={onCancelReassign}
+          />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function MappingGroupsSection({
+  groups,
+  includeHistory,
+  canEdit,
+  busy,
+  reassigning,
+  replacementMentorSearch,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  onStartReassign,
+  onRemove,
+  onReplacementMentorSearch,
+  onReplacementMentorSelect,
+  onConfirmReassign,
+  onCancelReassign,
+}: MappingGroupsSectionProps) {
+  if (groups.length === 0) {
+    return (
+      <section className="mt-4 space-y-3">
+        <Card className="border-dashed p-8 text-center text-sm text-text-muted">
+          <div className="font-semibold text-text-primary">
+            No Academic Mentor-Mentee Mappings found.
+          </div>
+          <p className="mt-1">Mappings will appear here after a manual add or CSV upload.</p>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mt-4 space-y-3">
+      {groups.map((group) => (
+        <MappingGroupCard
+          key={group.mentor.userId}
+          group={group}
+          includeHistory={includeHistory}
+          canEdit={canEdit}
+          busy={busy}
+          reassigning={reassigning}
           replacementMentorSearch={replacementMentorSearch}
           replacementMentorUserId={replacementMentorUserId}
           replacementMentorOptions={replacementMentorOptions}
-          busy={busy}
-          onSearch={onReplacementMentorSearch}
-          onSelect={onReplacementMentorSelect}
-          onConfirm={onConfirmReassign}
-          onCancel={onCancelReassign}
+          onStartReassign={onStartReassign}
+          onRemove={onRemove}
+          onReplacementMentorSearch={onReplacementMentorSearch}
+          onReplacementMentorSelect={onReplacementMentorSelect}
+          onConfirmReassign={onConfirmReassign}
+          onCancelReassign={onCancelReassign}
         />
-      ) : null}
-    </div>
+      ))}
+    </section>
   );
 }
 
@@ -302,7 +847,9 @@ export default function AcademicMentorshipManager({
   canEdit,
   initialGroups,
 }: AcademicMentorshipManagerProps) {
-  const [groups, setGroups] = useState(initialGroups);
+  const groupsKey = `${schoolCode}:${academicYear}:${includeHistory}`;
+  const [groupState, setGroupState] = useState({ key: groupsKey, groups: initialGroups });
+  const groups = groupState.key === groupsKey ? groupState.groups : initialGroups;
   const [mentorOptions, setMentorOptions] = useState<MentorOption[]>([]);
   const [menteeOptions, setMenteeOptions] = useState<MenteeOption[]>([]);
   const [mentorSearch, setMentorSearch] = useState("");
@@ -316,166 +863,18 @@ export default function AcademicMentorshipManager({
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [errorCsv, setErrorCsv] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [toast, setToast] = useState<{ variant: "success" | "error"; message: string } | null>(null);
+  const [toast, setToast] = useState<ToastState>(null);
   const templateParams = new URLSearchParams({
     school_code: schoolCode,
     academic_year: academicYear,
   });
   const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
 
-  useEffect(() => {
-    setGroups(initialGroups);
-  }, [schoolCode, academicYear, includeHistory, initialGroups]);
-
   async function refreshMappings() {
-    const params = new URLSearchParams({
-      school_code: schoolCode,
-      academic_year: academicYear,
+    setGroupState({
+      key: groupsKey,
+      groups: await fetchMappingGroups(schoolCode, academicYear, includeHistory),
     });
-    if (includeHistory) params.set("include_history", "true");
-    const response = await fetch(`/api/academic-mentorship/mappings?${params.toString()}`);
-    const payload = await readJson(response);
-    if (response.ok && payload && typeof payload === "object" && "groups" in payload) {
-      setGroups((payload.groups as MappingGroup[]) ?? []);
-    }
-  }
-
-  async function loadMentorOptions(
-    search: string,
-    setOptions: (options: MentorOption[]) => void
-  ) {
-    const params = new URLSearchParams({
-      type: "mentors",
-      school_code: schoolCode,
-      q: search,
-    });
-    const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
-    const payload = await readJson(response);
-    if (response.ok && payload && typeof payload === "object" && "options" in payload) {
-      setOptions((payload.options as MentorOption[]) ?? []);
-    }
-  }
-
-  async function loadMentors(search: string) {
-    await loadMentorOptions(search, setMentorOptions);
-  }
-
-  async function loadReplacementMentors(search: string) {
-    await loadMentorOptions(search, setReplacementMentorOptions);
-  }
-
-  async function loadMentees(search: string) {
-    const params = new URLSearchParams({
-      type: "mentees",
-      school_code: schoolCode,
-      academic_year: academicYear,
-      q: search,
-    });
-    const response = await fetch(`/api/academic-mentorship/options?${params.toString()}`);
-    const payload = await readJson(response);
-    if (response.ok && payload && typeof payload === "object" && "options" in payload) {
-      setMenteeOptions((payload.options as MenteeOption[]) ?? []);
-    }
-  }
-
-  async function addMapping() {
-    if (!mentorUserId || !studentPkId) {
-      setToast({ variant: "error", message: "Select an Academic Mentor and Mentee" });
-      return;
-    }
-
-    setBusy(true);
-    try {
-      const response = await fetch("/api/academic-mentorship/mappings", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          school_code: schoolCode,
-          academic_year: academicYear,
-          mentor_user_id: Number(mentorUserId),
-          student_id: Number(studentPkId),
-        }),
-      });
-      const payload = await readJson(response);
-      await refreshMappings();
-      if (!response.ok) {
-        setToast({ variant: "error", message: apiError(payload, "Failed to add Mapping") });
-        return;
-      }
-      setMentorUserId("");
-      setStudentPkId("");
-      setToast({ variant: "success", message: "Mapping added." });
-    } catch {
-      setToast({ variant: "error", message: "Failed to add Mapping" });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function uploadCsv() {
-    if (!csvFile) {
-      setToast({ variant: "error", message: "Select a CSV file" });
-      return;
-    }
-
-    setBusy(true);
-    setErrorCsv(null);
-    try {
-      const formData = new FormData();
-      formData.set("school_code", schoolCode);
-      formData.set("academic_year", academicYear);
-      formData.set("file", csvFile);
-      const response = await fetch("/api/academic-mentorship/mappings/import", {
-        method: "POST",
-        body: formData,
-      });
-      const payload = await readJson(response);
-      if (!response.ok) {
-        setErrorCsv(payloadErrorCsv(payload));
-        setToast({ variant: "error", message: apiError(payload, "Failed to upload CSV") });
-        return;
-      }
-      await refreshMappings();
-      const insertedCount = payloadInsertedCount(payload);
-      setToast({
-        variant: "success",
-        message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
-      });
-    } catch {
-      setToast({ variant: "error", message: "Failed to upload CSV" });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function removeMapping(mappingId: number | string) {
-    if (!window.confirm("This Student will no longer have an active Academic Mentor.")) {
-      return;
-    }
-
-    setBusy(true);
-    try {
-      const response = await fetch("/api/academic-mentorship/mappings", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          school_code: schoolCode,
-          academic_year: academicYear,
-          mapping_id: Number(mappingId),
-        }),
-      });
-      const payload = await readJson(response);
-      await refreshMappings();
-      if (!response.ok) {
-        setToast({ variant: "error", message: apiError(payload, "Failed to remove Mapping") });
-        return;
-      }
-      setToast({ variant: "success", message: "Mapping removed." });
-    } catch {
-      setToast({ variant: "error", message: "Failed to remove Mapping" });
-    } finally {
-      setBusy(false);
-    }
   }
 
   function startReassign(mappingId: number | string, currentMentorUserId: number) {
@@ -487,225 +886,108 @@ export default function AcademicMentorshipManager({
 
   function searchReplacementMentors(value: string) {
     setReplacementMentorSearch(value);
-    void loadReplacementMentors(value);
+    void fetchOptions<MentorOption>(mentorOptionParams(schoolCode, value)).then(
+      setReplacementMentorOptions
+    );
   }
 
-  async function reassignMapping() {
-    if (!reassigning || !replacementMentorUserId) {
-      setToast({ variant: "error", message: "Select a replacement Academic Mentor" });
-      return;
-    }
-    if (!window.confirm("This will end the old Mapping and create a new Mapping.")) {
-      return;
-    }
+  function searchMentors(value: string) {
+    setMentorSearch(value);
+    void fetchOptions<MentorOption>(mentorOptionParams(schoolCode, value)).then(
+      setMentorOptions
+    );
+  }
 
-    setBusy(true);
-    try {
-      const response = await fetch("/api/academic-mentorship/mappings", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          school_code: schoolCode,
-          academic_year: academicYear,
-          mapping_id: Number(reassigning.mappingId),
-          mentor_user_id: Number(replacementMentorUserId),
-        }),
-      });
-      const payload = await readJson(response);
-      await refreshMappings();
-      if (!response.ok) {
-        setToast({ variant: "error", message: apiError(payload, "Failed to reassign Mapping") });
-        return;
-      }
-      setReassigning(null);
-      setReplacementMentorUserId("");
-      setToast({ variant: "success", message: "Mapping reassigned." });
-    } catch {
-      setToast({ variant: "error", message: "Failed to reassign Mapping" });
-    } finally {
-      setBusy(false);
-    }
+  function searchMentees(value: string) {
+    setMenteeSearch(value);
+    void fetchOptions<MenteeOption>(
+      menteeOptionParams(schoolCode, academicYear, value)
+    ).then(setMenteeOptions);
   }
 
   return (
     <>
-      {toast ? (
-        <Toast
-          variant={toast.variant}
-          message={toast.message}
-          onDismiss={() => setToast(null)}
-        />
-      ) : null}
+      <ManagerToast toast={toast} onDismiss={() => setToast(null)} />
 
-      {canEdit ? (
-        <Card className="mt-4 overflow-hidden p-0">
-          <div className="border-b border-border bg-bg-card-alt px-4 py-3">
-            <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
-              Assign mentee
-            </h2>
-            <p className="mt-1 text-sm text-text-muted">
-              Search before selecting so the dropdowns stay scoped to this School and year.
-            </p>
-          </div>
+      <AssignmentCard
+        canEdit={canEdit}
+        mentorSearch={mentorSearch}
+        mentorUserId={mentorUserId}
+        mentorOptions={mentorOptions}
+        menteeSearch={menteeSearch}
+        studentPkId={studentPkId}
+        menteeOptions={menteeOptions}
+        busy={busy}
+        templateHref={templateHref}
+        errorCsv={errorCsv}
+        onMentorSearch={searchMentors}
+        onMentorSelect={setMentorUserId}
+        onMenteeSearch={searchMentees}
+        onMenteeSelect={setStudentPkId}
+        onAddMapping={() =>
+          void addMappingAction({
+            schoolCode,
+            academicYear,
+            mentorUserId,
+            studentPkId,
+            refreshMappings,
+            setMentorUserId,
+            setStudentPkId,
+            setBusy,
+            setToast,
+          })
+        }
+        onCsvFile={setCsvFile}
+        onUploadCsv={() =>
+          void uploadCsvAction({
+            schoolCode,
+            academicYear,
+            csvFile,
+            refreshMappings,
+            setErrorCsv,
+            setBusy,
+            setToast,
+          })
+        }
+      />
 
-          <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-            <div className="grid gap-2 sm:grid-cols-2">
-              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-                Search mentors
-                <Input
-                  value={mentorSearch}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    setMentorSearch(value);
-                    void loadMentors(value);
-                  }}
-                />
-              </label>
-              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-                Academic Mentor
-                <Select
-                  value={mentorUserId}
-                  onChange={(event) => setMentorUserId(event.target.value)}
-                  className="w-full min-w-0"
-                >
-                  <option value="">Select mentor</option>
-                  {mentorOptions.map((mentor) => (
-                    <option key={mentor.userId} value={mentor.userId}>
-                      {mentor.name} ({mentor.email})
-                    </option>
-                  ))}
-                </Select>
-              </label>
-            </div>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-                Search mentees
-                <Input
-                  value={menteeSearch}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    setMenteeSearch(value);
-                    void loadMentees(value);
-                  }}
-                />
-              </label>
-              <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-                Mentee
-                <Select
-                  value={studentPkId}
-                  onChange={(event) => setStudentPkId(event.target.value)}
-                  className="w-full min-w-0"
-                >
-                  <option value="">Select mentee</option>
-                  {menteeOptions.map((mentee) => (
-                    <option key={mentee.studentPkId} value={mentee.studentPkId}>
-                      {mentee.name} ({mentee.studentId ?? "no id"})
-                    </option>
-                  ))}
-                </Select>
-              </label>
-            </div>
-            <Button type="button" onClick={() => void addMapping()} disabled={busy} className="self-end">
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              Add Mapping
-            </Button>
-          </div>
-
-          <div className="grid gap-3 border-t border-border bg-bg-card-alt/60 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto_auto]">
-            <a
-              href={templateHref}
-              download="academic-mentorship-template.csv"
-              className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
-            >
-              <Download className="h-4 w-4" aria-hidden="true" />
-              Download CSV template
-            </a>
-            <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-              CSV file
-              <Input
-                type="file"
-                accept=".csv,text/csv"
-                onChange={(event) => setCsvFile(event.target.files?.[0] ?? null)}
-              />
-            </label>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => void uploadCsv()}
-              disabled={busy}
-              className="self-end"
-            >
-              <Upload className="h-4 w-4" aria-hidden="true" />
-              Upload CSV
-            </Button>
-            {errorCsv ? (
-              <a
-                href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
-                download="academic-mentorship-import-errors.csv"
-                className="self-end text-sm font-bold text-accent hover:text-accent-hover"
-              >
-                Download error CSV
-              </a>
-            ) : null}
-          </div>
-        </Card>
-      ) : null}
-
-      <section className="mt-4 space-y-3">
-        {groups.length === 0 ? (
-          <Card className="border-dashed p-8 text-center text-sm text-text-muted">
-            <div className="font-semibold text-text-primary">
-              No Academic Mentor-Mentee Mappings found.
-            </div>
-            <p className="mt-1">Mappings will appear here after a manual add or CSV upload.</p>
-          </Card>
-        ) : (
-          groups.map((group) => (
-            <Card key={group.mentor.userId} className="overflow-hidden p-0">
-              <div className="flex flex-col gap-3 border-b border-border bg-bg-card-alt px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="font-bold text-text-primary">{group.mentor.name}</h2>
-                  {group.mentor.email ? (
-                    <p className="text-sm text-text-muted">{group.mentor.email}</p>
-                  ) : null}
-                </div>
-                <Badge variant="accent" className="w-fit font-mono">
-                  {group.menteeCount} mentee{group.menteeCount === 1 ? "" : "s"}
-                </Badge>
-              </div>
-              <div className="divide-y divide-border">
-                <div className="hidden bg-bg-card px-4 py-2 text-xs font-bold uppercase tracking-wide text-text-muted md:grid md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px]">
-                  <div>Mentee</div>
-                  <div>Grade</div>
-                  <div>Assigned</div>
-                  <div>Status</div>
-                  <div className="text-right">Actions</div>
-                </div>
-                {group.mappings.map((mapping) => (
-                  <MappingRow
-                    key={String(mapping.id)}
-                    mapping={mapping}
-                    mentorUserId={group.mentor.userId}
-                    includeHistory={includeHistory}
-                    canEdit={canEdit}
-                    busy={busy}
-                    reassigning={reassigning}
-                    replacementMentorSearch={replacementMentorSearch}
-                    replacementMentorUserId={replacementMentorUserId}
-                    replacementMentorOptions={replacementMentorOptions}
-                    onStartReassign={startReassign}
-                    onRemove={(mappingId) => void removeMapping(mappingId)}
-                    onReplacementMentorSearch={searchReplacementMentors}
-                    onReplacementMentorSelect={setReplacementMentorUserId}
-                    onConfirmReassign={() => void reassignMapping()}
-                    onCancelReassign={() => setReassigning(null)}
-                  />
-                ))}
-              </div>
-            </Card>
-          ))
-        )}
-      </section>
+      <MappingGroupsSection
+        groups={groups}
+        includeHistory={includeHistory}
+        canEdit={canEdit}
+        busy={busy}
+        reassigning={reassigning}
+        replacementMentorSearch={replacementMentorSearch}
+        replacementMentorUserId={replacementMentorUserId}
+        replacementMentorOptions={replacementMentorOptions}
+        onStartReassign={startReassign}
+        onRemove={(mappingId) =>
+          void removeMappingAction({
+            schoolCode,
+            academicYear,
+            mappingId,
+            refreshMappings,
+            setBusy,
+            setToast,
+          })
+        }
+        onReplacementMentorSearch={searchReplacementMentors}
+        onReplacementMentorSelect={setReplacementMentorUserId}
+        onConfirmReassign={() =>
+          void reassignMappingAction({
+            schoolCode,
+            academicYear,
+            reassigning,
+            replacementMentorUserId,
+            refreshMappings,
+            setReassigning,
+            setReplacementMentorUserId,
+            setBusy,
+            setToast,
+          })
+        }
+        onCancelReassign={() => setReassigning(null)}
+      />
     </>
   );
 }

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import Toast from "@/components/Toast";
 import { Button, Card, Input, Select } from "@/components/ui";
@@ -90,6 +90,10 @@ export default function AcademicMentorshipManager({
     academic_year: academicYear,
   });
   const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
+
+  useEffect(() => {
+    setGroups(initialGroups);
+  }, [schoolCode, academicYear, includeHistory, initialGroups]);
 
   async function refreshMappings() {
     const params = new URLSearchParams({

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1018,6 +1018,72 @@ function useMentorshipOptionState(
   };
 }
 
+function useCsvUploadState() {
+  const [open, setCsvOpen] = useState(false);
+  const [file, setCsvFile] = useState<File | null>(null);
+  const [rows, setCsvRows] = useState<CsvUploadRow[]>([]);
+  const [errors, setCsvErrors] = useState<CsvUploadError[]>([]);
+  const [fileError, setCsvFileError] = useState("");
+  const [errorCsv, setErrorCsv] = useState<string | null>(null);
+
+  function resetCsvData() {
+    setCsvRows([]);
+    setCsvErrors([]);
+    setCsvFileError("");
+    setErrorCsv(null);
+  }
+
+  function close() {
+    setCsvOpen(false);
+    setCsvFile(null);
+    resetCsvData();
+  }
+
+  async function selectFile(nextFile: File | null) {
+    setCsvFile(nextFile);
+    resetCsvData();
+    if (!nextFile) return;
+
+    try {
+      const parsed = parseCsvText(await nextFile.text());
+      const requiredColumns = ["mentor_email", "student_id"];
+      const missingColumns = requiredColumns.filter((column) => !parsed.headers.includes(column));
+      if (missingColumns.length > 0) {
+        setCsvFileError(`Missing required columns: ${missingColumns.join(", ")}`);
+        return;
+      }
+      const parsedRows = parsed.rows.map((row) => ({
+        mentor_email: row.mentor_email ?? "",
+        student_id: row.student_id ?? "",
+      }));
+      setCsvRows(parsedRows);
+      if (parsedRows.length === 0) setCsvFileError("Choose a CSV file with at least one row");
+    } catch {
+      setCsvFileError("Unable to parse CSV file");
+    }
+  }
+
+  return {
+    open,
+    file,
+    rows,
+    errors,
+    fileError,
+    errorCsv,
+    openModal: () => setCsvOpen(true),
+    close,
+    selectFile,
+    actionSetters: {
+      setCsvOpen,
+      setCsvFile,
+      setCsvRows,
+      setCsvErrors,
+      setCsvFileError,
+      setErrorCsv,
+    },
+  };
+}
+
 export default function AcademicMentorshipManager({
   schoolCode,
   academicYear,
@@ -1058,12 +1124,7 @@ export default function AcademicMentorshipManager({
   const [mentorUserId, setMentorUserId] = useState("");
   const [studentPkId, setStudentPkId] = useState("");
   const [addOpen, setAddOpen] = useState(false);
-  const [csvOpen, setCsvOpen] = useState(false);
-  const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [csvRows, setCsvRows] = useState<CsvUploadRow[]>([]);
-  const [csvErrors, setCsvErrors] = useState<CsvUploadError[]>([]);
-  const [csvFileError, setCsvFileError] = useState("");
-  const [errorCsv, setErrorCsv] = useState<string | null>(null);
+  const csvUpload = useCsvUploadState();
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<ToastState>(null);
   const templateParams = new URLSearchParams({
@@ -1071,41 +1132,6 @@ export default function AcademicMentorshipManager({
     academic_year: academicYear,
   });
   const templateHref = `/api/academic-mentorship/mappings/import?${templateParams.toString()}`;
-
-  function closeCsvModal() {
-    setCsvOpen(false);
-    setCsvFile(null);
-    setCsvRows([]);
-    setCsvErrors([]);
-    setCsvFileError("");
-  }
-
-  async function handleCsvFile(file: File | null) {
-    setCsvFile(file);
-    setCsvRows([]);
-    setCsvErrors([]);
-    setCsvFileError("");
-    setErrorCsv(null);
-    if (!file) return;
-
-    try {
-      const parsed = parseCsvText(await file.text());
-      const requiredColumns = ["mentor_email", "student_id"];
-      const missingColumns = requiredColumns.filter((column) => !parsed.headers.includes(column));
-      if (missingColumns.length > 0) {
-        setCsvFileError(`Missing required columns: ${missingColumns.join(", ")}`);
-        return;
-      }
-      const rows = parsed.rows.map((row) => ({
-        mentor_email: row.mentor_email ?? "",
-        student_id: row.student_id ?? "",
-      }));
-      setCsvRows(rows);
-      if (rows.length === 0) setCsvFileError("Choose a CSV file with at least one row");
-    } catch {
-      setCsvFileError("Unable to parse CSV file");
-    }
-  }
 
   return (
     <>
@@ -1117,7 +1143,7 @@ export default function AcademicMentorshipManager({
         templateHref={templateHref}
         busy={busy}
         onAdd={() => setAddOpen(true)}
-        onUpload={() => setCsvOpen(true)}
+        onUpload={csvUpload.openModal}
       />
 
       <AddMappingPanel
@@ -1153,30 +1179,25 @@ export default function AcademicMentorshipManager({
       />
 
       <CsvUploadModal
-        open={csvOpen && canUpload}
+        open={csvUpload.open && canUpload}
         academicYear={academicYear}
         templateHref={templateHref}
-        csvRows={csvRows}
-        csvErrors={csvErrors}
-        csvFileError={csvFileError}
-        errorCsv={errorCsv}
+        csvRows={csvUpload.rows}
+        csvErrors={csvUpload.errors}
+        csvFileError={csvUpload.fileError}
+        errorCsv={csvUpload.errorCsv}
         busy={busy}
-        onClose={closeCsvModal}
+        onClose={csvUpload.close}
         onFile={(file) => {
-          void handleCsvFile(file);
+          void csvUpload.selectFile(file);
         }}
         onUpload={() =>
           void uploadCsvAction({
             schoolCode,
             academicYear,
-            csvFile,
+            csvFile: csvUpload.file,
             refreshMappings,
-            setCsvOpen,
-            setCsvFile,
-            setCsvRows,
-            setCsvErrors,
-            setCsvFileError,
-            setErrorCsv,
+            ...csvUpload.actionSetters,
             setBusy,
             setToast,
           })

--- a/src/components/academic-mentorship/AcademicMentorshipManager.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipManager.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useId,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { Download, Plus, RotateCcw, Upload, XCircle } from "lucide-react";
 
 import Toast from "@/components/Toast";
-import { Badge, Button, Card, Input, Select } from "@/components/ui";
+import { Badge, Button, Card, Input, Modal } from "@/components/ui";
 import type { AcademicMentorshipMappingGroup } from "@/lib/academic-mentorship";
 
 type MappingGroup = AcademicMentorshipMappingGroup;
+type Mapping = MappingGroup["mappings"][number];
+type ToastState = { variant: "success" | "error"; message: string } | null;
+type StateSetter<T> = Dispatch<SetStateAction<T>>;
 
 type MentorOption = {
   userId: number;
@@ -22,51 +30,27 @@ type MenteeOption = {
   grade: number | null;
 };
 
-type Mapping = MappingGroup["mappings"][number];
 type ReassigningState = {
   mappingId: number | string;
   currentMentorUserId: number;
+  menteeName: string;
 } | null;
-type ToastState = { variant: "success" | "error"; message: string } | null;
-type StateSetter<T> = Dispatch<SetStateAction<T>>;
-
-interface MappingControls {
-  canEdit: boolean;
-  busy: boolean;
-  reassigning: ReassigningState;
-  replacementMentorSearch: string;
-  replacementMentorUserId: string;
-  replacementMentorOptions: MentorOption[];
-  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
-  onRemove: (mappingId: number | string) => void;
-  onReplacementMentorSearch: (value: string) => void;
-  onReplacementMentorSelect: (value: string) => void;
-  onConfirmReassign: () => void;
-  onCancelReassign: () => void;
-}
-
-interface MappingRowProps extends MappingControls {
-  mapping: Mapping;
-  mentorUserId: number;
-  includeHistory: boolean;
-}
-
-interface MappingGroupCardProps extends MappingControls {
-  group: MappingGroup;
-  includeHistory: boolean;
-}
-
-interface MappingGroupsSectionProps extends MappingControls {
-  groups: MappingGroup[];
-  includeHistory: boolean;
-}
 
 interface AcademicMentorshipManagerProps {
   schoolCode: string;
   academicYear: string;
+  programId: number | null;
   includeHistory: boolean;
   canEdit: boolean;
+  canUpload: boolean;
   initialGroups: MappingGroup[];
+}
+
+interface MappingControls {
+  canEdit: boolean;
+  busy: boolean;
+  onStartReassign: (mapping: Mapping, currentMentorUserId: number) => void;
+  onRemove: (mappingId: number | string) => void;
 }
 
 async function readJson(response: Response): Promise<unknown> {
@@ -107,13 +91,15 @@ function payloadOptions<T>(payload: unknown): T[] {
 async function fetchMappingGroups(
   schoolCode: string,
   academicYear: string,
-  includeHistory: boolean
+  includeHistory: boolean,
+  programId: number | null
 ): Promise<MappingGroup[]> {
   const params = new URLSearchParams({
     school_code: schoolCode,
     academic_year: academicYear,
   });
   if (includeHistory) params.set("include_history", "true");
+  if (programId !== null) params.set("program_id", String(programId));
 
   const response = await fetch(`/api/academic-mentorship/mappings?${params.toString()}`);
   return response.ok ? payloadGroups(await readJson(response)) : [];
@@ -136,6 +122,14 @@ async function mappingJsonMutation(
   return { response, payload: await readJson(response) };
 }
 
+function mentorLabel(mentor: MentorOption): string {
+  return `${mentor.name} (${mentor.email})`;
+}
+
+function menteeLabel(mentee: MenteeOption): string {
+  return `${mentee.name} (${mentee.studentId ?? "no id"})`;
+}
+
 function mentorOptionParams(schoolCode: string, search: string): URLSearchParams {
   return new URLSearchParams({
     type: "mentors",
@@ -147,14 +141,62 @@ function mentorOptionParams(schoolCode: string, search: string): URLSearchParams
 function menteeOptionParams(
   schoolCode: string,
   academicYear: string,
+  programId: number | null,
   search: string
 ): URLSearchParams {
-  return new URLSearchParams({
+  const params = new URLSearchParams({
     type: "mentees",
     school_code: schoolCode,
     academic_year: academicYear,
     q: search,
   });
+  if (programId !== null) params.set("program_id", String(programId));
+  return params;
+}
+
+function SearchablePicker<T>({
+  label,
+  value,
+  options,
+  placeholder,
+  getLabel,
+  getValue,
+  onSearch,
+  onSelect,
+}: {
+  label: string;
+  value: string;
+  options: T[];
+  placeholder: string;
+  getLabel: (option: T) => string;
+  getValue: (option: T) => string;
+  onSearch: (value: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  const listId = useId();
+  function handleValue(nextValue: string) {
+    onSearch(nextValue);
+    const selected = options.find((option) => getLabel(option) === nextValue);
+    onSelect(selected ? getValue(selected) : "");
+  }
+
+  return (
+    <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+      {label}
+      <Input
+        value={value}
+        list={listId}
+        placeholder={placeholder}
+        onFocus={() => onSearch(value)}
+        onChange={(event) => handleValue(event.target.value)}
+      />
+      <datalist id={listId}>
+        {options.map((option) => (
+          <option key={getValue(option)} value={getLabel(option)} />
+        ))}
+      </datalist>
+    </label>
+  );
 }
 
 async function addMappingAction(args: {
@@ -163,8 +205,11 @@ async function addMappingAction(args: {
   mentorUserId: string;
   studentPkId: string;
   refreshMappings: () => Promise<void>;
+  setMentorInput: StateSetter<string>;
   setMentorUserId: StateSetter<string>;
+  setMenteeInput: StateSetter<string>;
   setStudentPkId: StateSetter<string>;
+  setAddOpen: StateSetter<boolean>;
   setBusy: StateSetter<boolean>;
   setToast: StateSetter<ToastState>;
 }) {
@@ -186,8 +231,11 @@ async function addMappingAction(args: {
       args.setToast({ variant: "error", message: apiError(payload, "Failed to add Mapping") });
       return;
     }
+    args.setMentorInput("");
     args.setMentorUserId("");
+    args.setMenteeInput("");
     args.setStudentPkId("");
+    args.setAddOpen(false);
     args.setToast({ variant: "success", message: "Mapping added." });
   } catch {
     args.setToast({ variant: "error", message: "Failed to add Mapping" });
@@ -201,6 +249,8 @@ async function uploadCsvAction(args: {
   academicYear: string;
   csvFile: File | null;
   refreshMappings: () => Promise<void>;
+  setCsvOpen: StateSetter<boolean>;
+  setCsvFile: StateSetter<File | null>;
   setErrorCsv: StateSetter<string | null>;
   setBusy: StateSetter<boolean>;
   setToast: StateSetter<ToastState>;
@@ -229,6 +279,8 @@ async function uploadCsvAction(args: {
     }
     await args.refreshMappings();
     const insertedCount = payloadInsertedCount(payload);
+    args.setCsvOpen(false);
+    args.setCsvFile(null);
     args.setToast({
       variant: "success",
       message: `Imported ${insertedCount} mapping${insertedCount === 1 ? "" : "s"}.`,
@@ -280,14 +332,12 @@ async function reassignMappingAction(args: {
   refreshMappings: () => Promise<void>;
   setReassigning: StateSetter<ReassigningState>;
   setReplacementMentorUserId: StateSetter<string>;
+  setReplacementMentorInput: StateSetter<string>;
   setBusy: StateSetter<boolean>;
   setToast: StateSetter<ToastState>;
 }) {
   if (!args.reassigning || !args.replacementMentorUserId) {
     args.setToast({ variant: "error", message: "Select a replacement Academic Mentor" });
-    return;
-  }
-  if (!window.confirm("This will end the old Mapping and create a new Mapping.")) {
     return;
   }
 
@@ -306,12 +356,24 @@ async function reassignMappingAction(args: {
     }
     args.setReassigning(null);
     args.setReplacementMentorUserId("");
+    args.setReplacementMentorInput("");
     args.setToast({ variant: "success", message: "Mapping reassigned." });
   } catch {
     args.setToast({ variant: "error", message: "Failed to reassign Mapping" });
   } finally {
     args.setBusy(false);
   }
+}
+
+function ManagerToast({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastState;
+  onDismiss: () => void;
+}) {
+  if (!toast) return null;
+  return <Toast variant={toast.variant} message={toast.message} onDismiss={onDismiss} />;
 }
 
 function MappingStatus({
@@ -340,7 +402,7 @@ function MappingActions({
   canEdit,
   isActive,
   busy,
-  mappingId,
+  mapping,
   mentorUserId,
   onStartReassign,
   onRemove,
@@ -348,20 +410,20 @@ function MappingActions({
   canEdit: boolean;
   isActive: boolean;
   busy: boolean;
-  mappingId: number | string;
+  mapping: Mapping;
   mentorUserId: number;
-  onStartReassign: (mappingId: number | string, currentMentorUserId: number) => void;
+  onStartReassign: (mapping: Mapping, currentMentorUserId: number) => void;
   onRemove: (mappingId: number | string) => void;
 }) {
   if (!canEdit || !isActive) return null;
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap justify-end gap-2">
       <Button
         type="button"
         variant="ghost"
         size="sm"
-        onClick={() => onStartReassign(mappingId, mentorUserId)}
+        onClick={() => onStartReassign(mapping, mentorUserId)}
         disabled={busy}
       >
         <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
@@ -371,7 +433,7 @@ function MappingActions({
         type="button"
         variant="danger-ghost"
         size="sm"
-        onClick={() => onRemove(mappingId)}
+        onClick={() => onRemove(mapping.id)}
         disabled={busy}
       >
         <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
@@ -381,150 +443,21 @@ function MappingActions({
   );
 }
 
-function ReassignPanel({
-  currentMentorUserId,
-  replacementMentorSearch,
-  replacementMentorUserId,
-  replacementMentorOptions,
-  busy,
-  onSearch,
-  onSelect,
-  onConfirm,
-  onCancel,
-}: {
-  currentMentorUserId: number;
-  replacementMentorSearch: string;
-  replacementMentorUserId: string;
-  replacementMentorOptions: MentorOption[];
-  busy: boolean;
-  onSearch: (value: string) => void;
-  onSelect: (value: string) => void;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
-  const options = replacementMentorOptions.filter(
-    (mentor) => mentor.userId !== currentMentorUserId
-  );
-
-  return (
-    <div className="grid gap-3 rounded-lg border border-border bg-bg-card-alt p-3 md:col-span-5 md:grid-cols-[1fr_1fr_auto_auto]">
-      <label className="grid gap-1 text-sm font-semibold text-text-primary">
-        Search replacement mentor
-        <Input
-          value={replacementMentorSearch}
-          onChange={(event) => onSearch(event.target.value)}
-        />
-      </label>
-      <label className="grid gap-1 text-sm font-semibold text-text-primary">
-        Replacement Academic Mentor
-        <Select
-          value={replacementMentorUserId}
-          onChange={(event) => onSelect(event.target.value)}
-          className="w-full min-w-0"
-        >
-          <option value="">Select mentor</option>
-          {options.map((mentor) => (
-            <option key={mentor.userId} value={mentor.userId}>
-              {mentor.name} ({mentor.email})
-            </option>
-          ))}
-        </Select>
-      </label>
-      <Button
-        type="button"
-        size="sm"
-        onClick={onConfirm}
-        disabled={busy}
-        className="self-end"
-      >
-        Confirm Reassign
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        onClick={onCancel}
-        disabled={busy}
-        className="self-end"
-      >
-        Cancel
-      </Button>
-    </div>
-  );
-}
-
-function reassigningMentorId(
-  reassigning: ReassigningState,
-  mappingId: number | string
-): number | null {
-  if (!reassigning) return null;
-  return String(reassigning.mappingId) === String(mappingId)
-    ? reassigning.currentMentorUserId
-    : null;
-}
-
-function MappingReassignPanel({
-  reassigning,
-  mappingId,
-  replacementMentorSearch,
-  replacementMentorUserId,
-  replacementMentorOptions,
-  busy,
-  onReplacementMentorSearch,
-  onReplacementMentorSelect,
-  onConfirmReassign,
-  onCancelReassign,
-}: {
-  reassigning: ReassigningState;
-  mappingId: number | string;
-  replacementMentorSearch: string;
-  replacementMentorUserId: string;
-  replacementMentorOptions: MentorOption[];
-  busy: boolean;
-  onReplacementMentorSearch: (value: string) => void;
-  onReplacementMentorSelect: (value: string) => void;
-  onConfirmReassign: () => void;
-  onCancelReassign: () => void;
-}) {
-  const currentMentorUserId = reassigningMentorId(reassigning, mappingId);
-  if (currentMentorUserId === null) return null;
-
-  return (
-    <ReassignPanel
-      currentMentorUserId={currentMentorUserId}
-      replacementMentorSearch={replacementMentorSearch}
-      replacementMentorUserId={replacementMentorUserId}
-      replacementMentorOptions={replacementMentorOptions}
-      busy={busy}
-      onSearch={onReplacementMentorSearch}
-      onSelect={onReplacementMentorSelect}
-      onConfirm={onConfirmReassign}
-      onCancel={onCancelReassign}
-    />
-  );
-}
-
 function MappingRow({
   mapping,
   mentorUserId,
   includeHistory,
   canEdit,
   busy,
-  reassigning,
-  replacementMentorSearch,
-  replacementMentorUserId,
-  replacementMentorOptions,
   onStartReassign,
   onRemove,
-  onReplacementMentorSearch,
-  onReplacementMentorSelect,
-  onConfirmReassign,
-  onCancelReassign,
-}: MappingRowProps) {
+}: {
+  mapping: Mapping;
+  mentorUserId: number;
+  includeHistory: boolean;
+} & MappingControls) {
   return (
-    <div
-      className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center"
-    >
+    <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.6fr)_90px_120px_110px_220px] md:items-center">
       <div>
         <div className="font-semibold text-text-primary">{mapping.mentee.name}</div>
         <div className="font-mono text-xs text-text-muted">
@@ -534,193 +467,16 @@ function MappingRow({
       <div className="text-sm text-text-muted">Grade {mapping.mentee.grade ?? "-"}</div>
       <div className="font-mono text-xs text-text-muted">{mapping.assignedDate}</div>
       <MappingStatus mapping={mapping} includeHistory={includeHistory} />
-      <div className="md:flex md:justify-end">
-        <MappingActions
-          canEdit={canEdit}
-          isActive={mapping.status === "active"}
-          busy={busy}
-          mappingId={mapping.id}
-          mentorUserId={mentorUserId}
-          onStartReassign={onStartReassign}
-          onRemove={onRemove}
-        />
-      </div>
-      <MappingReassignPanel
-        reassigning={reassigning}
-        mappingId={mapping.id}
-        replacementMentorSearch={replacementMentorSearch}
-        replacementMentorUserId={replacementMentorUserId}
-        replacementMentorOptions={replacementMentorOptions}
+      <MappingActions
+        canEdit={canEdit}
+        isActive={mapping.status === "active"}
         busy={busy}
-        onReplacementMentorSearch={onReplacementMentorSearch}
-        onReplacementMentorSelect={onReplacementMentorSelect}
-        onConfirmReassign={onConfirmReassign}
-        onCancelReassign={onCancelReassign}
+        mapping={mapping}
+        mentorUserId={mentorUserId}
+        onStartReassign={onStartReassign}
+        onRemove={onRemove}
       />
     </div>
-  );
-}
-
-function ManagerToast({
-  toast,
-  onDismiss,
-}: {
-  toast: ToastState;
-  onDismiss: () => void;
-}) {
-  if (!toast) return null;
-  return (
-    <Toast
-      variant={toast.variant}
-      message={toast.message}
-      onDismiss={onDismiss}
-    />
-  );
-}
-
-function AssignmentCard({
-  canEdit,
-  mentorSearch,
-  mentorUserId,
-  mentorOptions,
-  menteeSearch,
-  studentPkId,
-  menteeOptions,
-  busy,
-  templateHref,
-  errorCsv,
-  onMentorSearch,
-  onMentorSelect,
-  onMenteeSearch,
-  onMenteeSelect,
-  onAddMapping,
-  onCsvFile,
-  onUploadCsv,
-}: {
-  canEdit: boolean;
-  mentorSearch: string;
-  mentorUserId: string;
-  mentorOptions: MentorOption[];
-  menteeSearch: string;
-  studentPkId: string;
-  menteeOptions: MenteeOption[];
-  busy: boolean;
-  templateHref: string;
-  errorCsv: string | null;
-  onMentorSearch: (value: string) => void;
-  onMentorSelect: (value: string) => void;
-  onMenteeSearch: (value: string) => void;
-  onMenteeSelect: (value: string) => void;
-  onAddMapping: () => void;
-  onCsvFile: (file: File | null) => void;
-  onUploadCsv: () => void;
-}) {
-  if (!canEdit) return null;
-
-  return (
-    <Card className="mt-4 overflow-hidden p-0">
-      <div className="border-b border-border bg-bg-card-alt px-4 py-3">
-        <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
-          Assign mentee
-        </h2>
-        <p className="mt-1 text-sm text-text-muted">
-          Search before selecting so the dropdowns stay scoped to this School and year.
-        </p>
-      </div>
-
-      <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-        <div className="grid gap-2 sm:grid-cols-2">
-          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-            Search mentors
-            <Input
-              value={mentorSearch}
-              onChange={(event) => onMentorSearch(event.target.value)}
-            />
-          </label>
-          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-            Academic Mentor
-            <Select
-              value={mentorUserId}
-              onChange={(event) => onMentorSelect(event.target.value)}
-              className="w-full min-w-0"
-            >
-              <option value="">Select mentor</option>
-              {mentorOptions.map((mentor) => (
-                <option key={mentor.userId} value={mentor.userId}>
-                  {mentor.name} ({mentor.email})
-                </option>
-              ))}
-            </Select>
-          </label>
-        </div>
-        <div className="grid gap-2 sm:grid-cols-2">
-          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-            Search mentees
-            <Input
-              value={menteeSearch}
-              onChange={(event) => onMenteeSearch(event.target.value)}
-            />
-          </label>
-          <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-            Mentee
-            <Select
-              value={studentPkId}
-              onChange={(event) => onMenteeSelect(event.target.value)}
-              className="w-full min-w-0"
-            >
-              <option value="">Select mentee</option>
-              {menteeOptions.map((mentee) => (
-                <option key={mentee.studentPkId} value={mentee.studentPkId}>
-                  {mentee.name} ({mentee.studentId ?? "no id"})
-                </option>
-              ))}
-            </Select>
-          </label>
-        </div>
-        <Button type="button" onClick={onAddMapping} disabled={busy} className="self-end">
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          Add Mapping
-        </Button>
-      </div>
-
-      <div className="grid gap-3 border-t border-border bg-bg-card-alt/60 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto_auto]">
-        <a
-          href={templateHref}
-          download="academic-mentorship-template.csv"
-          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
-        >
-          <Download className="h-4 w-4" aria-hidden="true" />
-          Download CSV template
-        </a>
-        <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
-          CSV file
-          <Input
-            type="file"
-            accept=".csv,text/csv"
-            onChange={(event) => onCsvFile(event.target.files?.[0] ?? null)}
-          />
-        </label>
-        <Button
-          type="button"
-          variant="secondary"
-          onClick={onUploadCsv}
-          disabled={busy}
-          className="self-end"
-        >
-          <Upload className="h-4 w-4" aria-hidden="true" />
-          Upload CSV
-        </Button>
-        {errorCsv ? (
-          <a
-            href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
-            download="academic-mentorship-import-errors.csv"
-            className="self-end text-sm font-bold text-accent hover:text-accent-hover"
-          >
-            Download error CSV
-          </a>
-        ) : null}
-      </div>
-    </Card>
   );
 }
 
@@ -729,17 +485,12 @@ function MappingGroupCard({
   includeHistory,
   canEdit,
   busy,
-  reassigning,
-  replacementMentorSearch,
-  replacementMentorUserId,
-  replacementMentorOptions,
   onStartReassign,
   onRemove,
-  onReplacementMentorSearch,
-  onReplacementMentorSelect,
-  onConfirmReassign,
-  onCancelReassign,
-}: MappingGroupCardProps) {
+}: {
+  group: MappingGroup;
+  includeHistory: boolean;
+} & MappingControls) {
   return (
     <Card className="overflow-hidden p-0">
       <div className="flex flex-col gap-3 border-b border-border bg-bg-card-alt px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
@@ -769,16 +520,8 @@ function MappingGroupCard({
             includeHistory={includeHistory}
             canEdit={canEdit}
             busy={busy}
-            reassigning={reassigning}
-            replacementMentorSearch={replacementMentorSearch}
-            replacementMentorUserId={replacementMentorUserId}
-            replacementMentorOptions={replacementMentorOptions}
             onStartReassign={onStartReassign}
             onRemove={onRemove}
-            onReplacementMentorSearch={onReplacementMentorSearch}
-            onReplacementMentorSelect={onReplacementMentorSelect}
-            onConfirmReassign={onConfirmReassign}
-            onCancelReassign={onCancelReassign}
           />
         ))}
       </div>
@@ -791,17 +534,12 @@ function MappingGroupsSection({
   includeHistory,
   canEdit,
   busy,
-  reassigning,
-  replacementMentorSearch,
-  replacementMentorUserId,
-  replacementMentorOptions,
   onStartReassign,
   onRemove,
-  onReplacementMentorSearch,
-  onReplacementMentorSelect,
-  onConfirmReassign,
-  onCancelReassign,
-}: MappingGroupsSectionProps) {
+}: {
+  groups: MappingGroup[];
+  includeHistory: boolean;
+} & MappingControls) {
   if (groups.length === 0) {
     return (
       <section className="mt-4 space-y-3">
@@ -824,90 +562,330 @@ function MappingGroupsSection({
           includeHistory={includeHistory}
           canEdit={canEdit}
           busy={busy}
-          reassigning={reassigning}
-          replacementMentorSearch={replacementMentorSearch}
-          replacementMentorUserId={replacementMentorUserId}
-          replacementMentorOptions={replacementMentorOptions}
           onStartReassign={onStartReassign}
           onRemove={onRemove}
-          onReplacementMentorSearch={onReplacementMentorSearch}
-          onReplacementMentorSelect={onReplacementMentorSelect}
-          onConfirmReassign={onConfirmReassign}
-          onCancelReassign={onCancelReassign}
         />
       ))}
     </section>
   );
 }
 
+function ActionBar({
+  canEdit,
+  canUpload,
+  templateHref,
+  errorCsv,
+  busy,
+  onAdd,
+  onUpload,
+}: {
+  canEdit: boolean;
+  canUpload: boolean;
+  templateHref: string;
+  errorCsv: string | null;
+  busy: boolean;
+  onAdd: () => void;
+  onUpload: () => void;
+}) {
+  if (!canUpload) return null;
+
+  return (
+    <Card className="mt-4 flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-sm text-text-muted">
+        {canEdit
+          ? "Add mappings manually or upload a CSV for the selected academic year."
+          : "Manual edits are disabled for this year. Use CSV upload for backfill."}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {canEdit ? (
+          <Button type="button" onClick={onAdd} disabled={busy}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Add Mapping
+          </Button>
+        ) : null}
+        <Button type="button" variant="secondary" onClick={onUpload} disabled={busy}>
+          <Upload className="h-4 w-4" aria-hidden="true" />
+          Upload CSV
+        </Button>
+        <a
+          href={templateHref}
+          download="academic-mentorship-template.csv"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-border bg-bg-card px-4 text-sm font-medium text-text-primary shadow-sm hover:bg-hover-bg"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          Template
+        </a>
+        {errorCsv ? (
+          <a
+            href={`data:text/csv;charset=utf-8,${encodeURIComponent(errorCsv)}`}
+            download="academic-mentorship-import-errors.csv"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-2 text-sm font-bold text-accent hover:text-accent-hover"
+          >
+            Download error CSV
+          </a>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function AddMappingPanel({
+  open,
+  mentorInput,
+  mentorUserId,
+  mentorOptions,
+  menteeInput,
+  studentPkId,
+  menteeOptions,
+  busy,
+  onMentorSearch,
+  onMentorSelect,
+  onMenteeSearch,
+  onMenteeSelect,
+  onSubmit,
+  onCancel,
+}: {
+  open: boolean;
+  mentorInput: string;
+  mentorUserId: string;
+  mentorOptions: MentorOption[];
+  menteeInput: string;
+  studentPkId: string;
+  menteeOptions: MenteeOption[];
+  busy: boolean;
+  onMentorSearch: (value: string) => void;
+  onMentorSelect: (value: string) => void;
+  onMenteeSearch: (value: string) => void;
+  onMenteeSelect: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <Card className="mt-3 overflow-hidden p-0">
+      <div className="border-b border-border bg-bg-card-alt px-4 py-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-text-primary">
+          Add Mapping
+        </h2>
+      </div>
+      <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] lg:items-end">
+        <SearchablePicker
+          label="Academic Mentor"
+          value={mentorInput}
+          options={mentorOptions}
+          placeholder="Search mentor name or email"
+          getLabel={mentorLabel}
+          getValue={(mentor) => String(mentor.userId)}
+          onSearch={onMentorSearch}
+          onSelect={onMentorSelect}
+        />
+        <SearchablePicker
+          label="Mentee"
+          value={menteeInput}
+          options={menteeOptions}
+          placeholder="Search student name or ID"
+          getLabel={menteeLabel}
+          getValue={(mentee) => String(mentee.studentPkId)}
+          onSearch={onMenteeSearch}
+          onSelect={onMenteeSelect}
+        />
+        <Button
+          type="button"
+          onClick={onSubmit}
+          disabled={busy || !mentorUserId || !studentPkId}
+        >
+          Submit
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function CsvUploadModal({
+  open,
+  academicYear,
+  busy,
+  onClose,
+  onFile,
+  onUpload,
+}: {
+  open: boolean;
+  academicYear: string;
+  busy: boolean;
+  onClose: () => void;
+  onFile: (file: File | null) => void;
+  onUpload: () => void;
+}) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div className="border-b border-border px-5 py-4">
+        <h2 className="text-base font-bold text-text-primary">Upload CSV</h2>
+        <p className="mt-1 text-sm text-text-muted">
+          Upload mentor_email,student_id rows for {academicYear}.
+        </p>
+      </div>
+      <div className="grid gap-4 px-5 py-4">
+        <label className="grid gap-1.5 text-sm font-semibold text-text-primary">
+          CSV file
+          <Input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(event) => onFile(event.target.files?.[0] ?? null)}
+          />
+        </label>
+      </div>
+      <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
+        <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button type="button" onClick={onUpload} disabled={busy}>
+          Upload CSV
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+function ReassignModal({
+  reassigning,
+  replacementMentorInput,
+  replacementMentorUserId,
+  replacementMentorOptions,
+  busy,
+  onSearch,
+  onSelect,
+  onConfirm,
+  onCancel,
+}: {
+  reassigning: ReassigningState;
+  replacementMentorInput: string;
+  replacementMentorUserId: string;
+  replacementMentorOptions: MentorOption[];
+  busy: boolean;
+  onSearch: (value: string) => void;
+  onSelect: (value: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const options = replacementMentorOptions.filter(
+    (mentor) => mentor.userId !== reassigning?.currentMentorUserId
+  );
+
+  return (
+    <Modal open={reassigning !== null} onClose={onCancel}>
+      <div className="border-b border-border px-5 py-4">
+        <h2 className="text-base font-bold text-text-primary">Reassign Mentee</h2>
+        <p className="mt-1 text-sm text-text-muted">
+          {reassigning ? `Select a new mentor for ${reassigning.menteeName}.` : ""}
+        </p>
+      </div>
+      <div className="px-5 py-4">
+        <SearchablePicker
+          label="Replacement Academic Mentor"
+          value={replacementMentorInput}
+          options={options}
+          placeholder="Search mentor name or email"
+          getLabel={mentorLabel}
+          getValue={(mentor) => String(mentor.userId)}
+          onSearch={onSearch}
+          onSelect={onSelect}
+        />
+      </div>
+      <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button type="button" onClick={onConfirm} disabled={busy || !replacementMentorUserId}>
+          Confirm Reassign
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
 function useMappingGroupsState({
   schoolCode,
   academicYear,
+  programId,
   includeHistory,
   initialGroups,
 }: AcademicMentorshipManagerProps) {
-  const groupsKey = `${schoolCode}:${academicYear}:${includeHistory}`;
+  const groupsKey = `${schoolCode}:${academicYear}:${programId ?? "all"}:${includeHistory}`;
   const [groupState, setGroupState] = useState({ key: groupsKey, groups: initialGroups });
   const groups = groupState.key === groupsKey ? groupState.groups : initialGroups;
 
   async function refreshMappings() {
     setGroupState({
       key: groupsKey,
-      groups: await fetchMappingGroups(schoolCode, academicYear, includeHistory),
+      groups: await fetchMappingGroups(schoolCode, academicYear, includeHistory, programId),
     });
   }
 
   return { groups, refreshMappings };
 }
 
-function useMentorshipOptionState(schoolCode: string, academicYear: string) {
+function useMentorshipOptionState(
+  schoolCode: string,
+  academicYear: string,
+  programId: number | null
+) {
   const [mentorOptions, setMentorOptions] = useState<MentorOption[]>([]);
   const [menteeOptions, setMenteeOptions] = useState<MenteeOption[]>([]);
-  const [mentorSearch, setMentorSearch] = useState("");
-  const [menteeSearch, setMenteeSearch] = useState("");
+  const [mentorInput, setMentorInput] = useState("");
+  const [menteeInput, setMenteeInput] = useState("");
   const [reassigning, setReassigning] = useState<ReassigningState>(null);
   const [replacementMentorOptions, setReplacementMentorOptions] = useState<MentorOption[]>([]);
-  const [replacementMentorSearch, setReplacementMentorSearch] = useState("");
+  const [replacementMentorInput, setReplacementMentorInput] = useState("");
   const [replacementMentorUserId, setReplacementMentorUserId] = useState("");
 
-  function startReassign(mappingId: number | string, currentMentorUserId: number) {
-    setReassigning({ mappingId, currentMentorUserId });
-    setReplacementMentorOptions([]);
-    setReplacementMentorSearch("");
-    setReplacementMentorUserId("");
-  }
-
   function searchReplacementMentors(value: string) {
-    setReplacementMentorSearch(value);
+    setReplacementMentorInput(value);
     void fetchOptions<MentorOption>(mentorOptionParams(schoolCode, value)).then(
       setReplacementMentorOptions
     );
   }
 
+  function startReassign(mapping: Mapping, currentMentorUserId: number) {
+    setReassigning({
+      mappingId: mapping.id,
+      currentMentorUserId,
+      menteeName: mapping.mentee.name,
+    });
+    setReplacementMentorUserId("");
+    searchReplacementMentors("");
+  }
+
   function searchMentors(value: string) {
-    setMentorSearch(value);
+    setMentorInput(value);
     void fetchOptions<MentorOption>(mentorOptionParams(schoolCode, value)).then(
       setMentorOptions
     );
   }
 
   function searchMentees(value: string) {
-    setMenteeSearch(value);
+    setMenteeInput(value);
     void fetchOptions<MenteeOption>(
-      menteeOptionParams(schoolCode, academicYear, value)
+      menteeOptionParams(schoolCode, academicYear, programId, value)
     ).then(setMenteeOptions);
   }
 
   return {
     mentorOptions,
     menteeOptions,
-    mentorSearch,
-    menteeSearch,
+    mentorInput,
+    menteeInput,
     reassigning,
     replacementMentorOptions,
-    replacementMentorSearch,
+    replacementMentorInput,
     replacementMentorUserId,
+    setMentorInput,
+    setMenteeInput,
     setReassigning,
+    setReplacementMentorInput,
     setReplacementMentorUserId,
     startReassign,
     searchReplacementMentors,
@@ -919,35 +897,44 @@ function useMentorshipOptionState(schoolCode: string, academicYear: string) {
 export default function AcademicMentorshipManager({
   schoolCode,
   academicYear,
+  programId,
   includeHistory,
   canEdit,
+  canUpload,
   initialGroups,
 }: AcademicMentorshipManagerProps) {
   const { groups, refreshMappings } = useMappingGroupsState({
     schoolCode,
     academicYear,
+    programId,
     includeHistory,
     canEdit,
+    canUpload,
     initialGroups,
   });
   const {
     mentorOptions,
     menteeOptions,
-    mentorSearch,
-    menteeSearch,
+    mentorInput,
+    menteeInput,
     reassigning,
     replacementMentorOptions,
-    replacementMentorSearch,
+    replacementMentorInput,
     replacementMentorUserId,
+    setMentorInput,
+    setMenteeInput,
     setReassigning,
+    setReplacementMentorInput,
     setReplacementMentorUserId,
     startReassign,
     searchReplacementMentors,
     searchMentors,
     searchMentees,
-  } = useMentorshipOptionState(schoolCode, academicYear);
+  } = useMentorshipOptionState(schoolCode, academicYear, programId);
   const [mentorUserId, setMentorUserId] = useState("");
   const [studentPkId, setStudentPkId] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
+  const [csvOpen, setCsvOpen] = useState(false);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [errorCsv, setErrorCsv] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -962,41 +949,62 @@ export default function AcademicMentorshipManager({
     <>
       <ManagerToast toast={toast} onDismiss={() => setToast(null)} />
 
-      <AssignmentCard
+      <ActionBar
         canEdit={canEdit}
-        mentorSearch={mentorSearch}
+        canUpload={canUpload}
+        templateHref={templateHref}
+        errorCsv={errorCsv}
+        busy={busy}
+        onAdd={() => setAddOpen(true)}
+        onUpload={() => setCsvOpen(true)}
+      />
+
+      <AddMappingPanel
+        open={addOpen && canEdit}
+        mentorInput={mentorInput}
         mentorUserId={mentorUserId}
         mentorOptions={mentorOptions}
-        menteeSearch={menteeSearch}
+        menteeInput={menteeInput}
         studentPkId={studentPkId}
         menteeOptions={menteeOptions}
         busy={busy}
-        templateHref={templateHref}
-        errorCsv={errorCsv}
         onMentorSearch={searchMentors}
         onMentorSelect={setMentorUserId}
         onMenteeSearch={searchMentees}
         onMenteeSelect={setStudentPkId}
-        onAddMapping={() =>
+        onSubmit={() =>
           void addMappingAction({
             schoolCode,
             academicYear,
             mentorUserId,
             studentPkId,
             refreshMappings,
+            setMentorInput,
             setMentorUserId,
+            setMenteeInput,
             setStudentPkId,
+            setAddOpen,
             setBusy,
             setToast,
           })
         }
-        onCsvFile={setCsvFile}
-        onUploadCsv={() =>
+        onCancel={() => setAddOpen(false)}
+      />
+
+      <CsvUploadModal
+        open={csvOpen && canUpload}
+        academicYear={academicYear}
+        busy={busy}
+        onClose={() => setCsvOpen(false)}
+        onFile={setCsvFile}
+        onUpload={() =>
           void uploadCsvAction({
             schoolCode,
             academicYear,
             csvFile,
             refreshMappings,
+            setCsvOpen,
+            setCsvFile,
             setErrorCsv,
             setBusy,
             setToast,
@@ -1004,15 +1012,36 @@ export default function AcademicMentorshipManager({
         }
       />
 
+      <ReassignModal
+        reassigning={reassigning}
+        replacementMentorInput={replacementMentorInput}
+        replacementMentorUserId={replacementMentorUserId}
+        replacementMentorOptions={replacementMentorOptions}
+        busy={busy}
+        onSearch={searchReplacementMentors}
+        onSelect={setReplacementMentorUserId}
+        onConfirm={() =>
+          void reassignMappingAction({
+            schoolCode,
+            academicYear,
+            reassigning,
+            replacementMentorUserId,
+            refreshMappings,
+            setReassigning,
+            setReplacementMentorUserId,
+            setReplacementMentorInput,
+            setBusy,
+            setToast,
+          })
+        }
+        onCancel={() => setReassigning(null)}
+      />
+
       <MappingGroupsSection
         groups={groups}
         includeHistory={includeHistory}
         canEdit={canEdit}
         busy={busy}
-        reassigning={reassigning}
-        replacementMentorSearch={replacementMentorSearch}
-        replacementMentorUserId={replacementMentorUserId}
-        replacementMentorOptions={replacementMentorOptions}
         onStartReassign={startReassign}
         onRemove={(mappingId) =>
           void removeMappingAction({
@@ -1024,22 +1053,6 @@ export default function AcademicMentorshipManager({
             setToast,
           })
         }
-        onReplacementMentorSearch={searchReplacementMentors}
-        onReplacementMentorSelect={setReplacementMentorUserId}
-        onConfirmReassign={() =>
-          void reassignMappingAction({
-            schoolCode,
-            academicYear,
-            reassigning,
-            replacementMentorUserId,
-            refreshMappings,
-            setReassigning,
-            setReplacementMentorUserId,
-            setBusy,
-            setToast,
-          })
-        }
-        onCancelReassign={() => setReassigning(null)}
       />
     </>
   );

--- a/src/components/academic-mentorship/AcademicMentorshipSelectionForm.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipSelectionForm.test.tsx
@@ -13,15 +13,18 @@ const props = {
     { id: 1, name: "JNV COE" },
     { id: 64, name: "JNV NVS" },
   ],
+  programSchoolLinks: [
+    { programId: 1, schoolId: 20 },
+    { programId: 64, schoolId: 21 },
+  ],
   schools: [
     { id: 20, code: "59525", name: "JNV Adilabad", region: "Telangana" },
+    { id: 21, code: "24701", name: "JNV Chandigarh", region: "Chandigarh" },
   ],
 };
 
 describe("AcademicMentorshipSelectionForm", () => {
-  it("resets School and submits when Program changes", async () => {
-    const requestSubmit = vi.fn();
-    HTMLFormElement.prototype.requestSubmit = requestSubmit;
+  it("filters School options and resets School when Program changes", async () => {
     const user = userEvent.setup();
 
     render(<AcademicMentorshipSelectionForm {...props} />);
@@ -30,6 +33,9 @@ describe("AcademicMentorshipSelectionForm", () => {
     await user.selectOptions(screen.getByLabelText("Program"), "1");
 
     expect(screen.getByLabelText("School")).toHaveValue("");
-    expect(requestSubmit).toHaveBeenCalledOnce();
+    expect(screen.getByRole("option", { name: "JNV Adilabad (59525)" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "JNV Chandigarh (24701)" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/academic-mentorship/AcademicMentorshipSelectionForm.test.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipSelectionForm.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import AcademicMentorshipSelectionForm from "./AcademicMentorshipSelectionForm";
+
+const props = {
+  academicYears: ["2026-2027", "2025-2026"],
+  selectedAcademicYear: "2026-2027",
+  selectedSchoolCode: "59525",
+  selectedProgramId: null,
+  includeHistory: false,
+  programs: [
+    { id: 1, name: "JNV COE" },
+    { id: 64, name: "JNV NVS" },
+  ],
+  schools: [
+    { id: 20, code: "59525", name: "JNV Adilabad", region: "Telangana" },
+  ],
+};
+
+describe("AcademicMentorshipSelectionForm", () => {
+  it("resets School and submits when Program changes", async () => {
+    const requestSubmit = vi.fn();
+    HTMLFormElement.prototype.requestSubmit = requestSubmit;
+    const user = userEvent.setup();
+
+    render(<AcademicMentorshipSelectionForm {...props} />);
+
+    expect(screen.getByLabelText("School")).toHaveValue("59525");
+    await user.selectOptions(screen.getByLabelText("Program"), "1");
+
+    expect(screen.getByLabelText("School")).toHaveValue("");
+    expect(requestSubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRef } from "react";
+
+import { Card } from "@/components/ui";
+import type {
+  AcademicMentorshipProgram,
+  AcademicMentorshipSchool,
+} from "@/lib/academic-mentorship";
+
+interface AcademicMentorshipSelectionFormProps {
+  academicYears: string[];
+  selectedAcademicYear: string;
+  selectedSchoolCode: string;
+  selectedProgramId: number | null;
+  includeHistory: boolean;
+  programs: AcademicMentorshipProgram[];
+  schools: AcademicMentorshipSchool[];
+}
+
+export default function AcademicMentorshipSelectionForm({
+  academicYears,
+  selectedAcademicYear,
+  selectedSchoolCode,
+  selectedProgramId,
+  includeHistory,
+  programs,
+  schools,
+}: AcademicMentorshipSelectionFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const schoolRef = useRef<HTMLSelectElement>(null);
+
+  function submitProgramFilter() {
+    if (schoolRef.current) schoolRef.current.value = "";
+    formRef.current?.requestSubmit();
+  }
+
+  return (
+    <Card className="overflow-hidden p-4">
+      <form
+        ref={formRef}
+        action="/admin/academic-mentorship"
+        className="grid min-w-0 gap-3 lg:grid-cols-[220px_minmax(0,1fr)_220px_auto] lg:items-end"
+      >
+        <label
+          className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary"
+          htmlFor="program_id"
+        >
+          Program
+          <select
+            id="program_id"
+            name="program_id"
+            defaultValue={selectedProgramId ?? ""}
+            onChange={submitProgramFilter}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            <option value="">All programs</option>
+            {programs.map((program) => (
+              <option key={program.id} value={program.id}>
+                {program.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label
+          className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary"
+          htmlFor="school_code"
+        >
+          School
+          <select
+            ref={schoolRef}
+            id="school_code"
+            name="school_code"
+            defaultValue={selectedSchoolCode}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            <option value="">Select a School</option>
+            {schools.map((school) => (
+              <option key={`${school.id}-${school.code}`} value={school.code}>
+                {school.name} ({school.code})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label
+          className="grid min-w-0 gap-1.5 text-sm font-semibold text-text-primary"
+          htmlFor="academic_year"
+        >
+          Academic year
+          <select
+            id="academic_year"
+            name="academic_year"
+            defaultValue={selectedAcademicYear}
+            className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+          >
+            {!academicYears.includes(selectedAcademicYear) && (
+              <option value={selectedAcademicYear}>{selectedAcademicYear}</option>
+            )}
+            {academicYears.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </select>
+        </label>
+        {includeHistory && <input type="hidden" name="include_history" value="true" />}
+        <button className="min-h-[44px] rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white hover:bg-accent-hover">
+          Apply
+        </button>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { Card } from "@/components/ui";
 import type {
   AcademicMentorshipProgram,
+  AcademicMentorshipProgramSchoolLink,
   AcademicMentorshipSchool,
 } from "@/lib/academic-mentorship";
 
@@ -15,6 +16,7 @@ interface AcademicMentorshipSelectionFormProps {
   selectedProgramId: number | null;
   includeHistory: boolean;
   programs: AcademicMentorshipProgram[];
+  programSchoolLinks: AcademicMentorshipProgramSchoolLink[];
   schools: AcademicMentorshipSchool[];
 }
 
@@ -25,20 +27,32 @@ export default function AcademicMentorshipSelectionForm({
   selectedProgramId,
   includeHistory,
   programs,
+  programSchoolLinks,
   schools,
 }: AcademicMentorshipSelectionFormProps) {
-  const formRef = useRef<HTMLFormElement>(null);
   const schoolRef = useRef<HTMLSelectElement>(null);
+  const [programId, setProgramId] = useState(
+    selectedProgramId === null ? "" : String(selectedProgramId)
+  );
+  const filteredSchools = useMemo(() => {
+    if (!programId) return schools;
+    const selectedProgramId = Number(programId);
+    const schoolIds = new Set(
+      programSchoolLinks
+        .filter((link) => link.programId === selectedProgramId)
+        .map((link) => link.schoolId)
+    );
+    return schools.filter((school) => schoolIds.has(school.id));
+  }, [programId, programSchoolLinks, schools]);
 
-  function submitProgramFilter() {
+  function handleProgramChange(nextProgramId: string) {
+    setProgramId(nextProgramId);
     if (schoolRef.current) schoolRef.current.value = "";
-    formRef.current?.requestSubmit();
   }
 
   return (
     <Card className="overflow-hidden p-4">
       <form
-        ref={formRef}
         action="/admin/academic-mentorship"
         className="grid min-w-0 gap-3 lg:grid-cols-[220px_minmax(0,1fr)_220px_auto] lg:items-end"
       >
@@ -50,8 +64,8 @@ export default function AcademicMentorshipSelectionForm({
           <select
             id="program_id"
             name="program_id"
-            defaultValue={selectedProgramId ?? ""}
-            onChange={submitProgramFilter}
+            value={programId}
+            onChange={(event) => handleProgramChange(event.target.value)}
             className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
           >
             <option value="">All programs</option>
@@ -75,7 +89,7 @@ export default function AcademicMentorshipSelectionForm({
             className="min-h-[44px] w-full min-w-0 max-w-full rounded-lg border-2 border-border bg-bg-card px-3 py-2 text-sm font-normal focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
           >
             <option value="">Select a School</option>
-            {schools.map((school) => (
+            {filteredSchools.map((school) => (
               <option key={`${school.id}-${school.code}`} value={school.code}>
                 {school.name} ({school.code})
               </option>

--- a/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
+++ b/src/components/academic-mentorship/AcademicMentorshipSelectionForm.tsx
@@ -42,7 +42,7 @@ export default function AcademicMentorshipSelectionForm({
         .filter((link) => link.programId === selectedProgramId)
         .map((link) => link.schoolId)
     );
-    return schools.filter((school) => schoolIds.has(school.id));
+    return schools.filter((school) => schoolIds.has(Number(school.id)));
   }, [programId, programSchoolLinks, schools]);
 
   function handleProgramChange(nextProgramId: string) {

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -10,6 +10,7 @@ import {
   createAcademicMentorshipMapping,
   importAcademicMentorshipMappingsFromCsv,
   endAcademicMentorshipMapping,
+  listAccessibleAcademicMentorshipSchools,
   listAcademicMentorshipMenteeOptions,
   listAcademicMentorshipMentorOptions,
   listAcademicMentorshipMappings,
@@ -115,6 +116,60 @@ describe("requireAcademicMentorshipAccess", () => {
         ]),
       ])
     );
+  });
+
+  it("normalizes School IDs returned as strings by pg", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "admin@avantifellows.org",
+          level: 3,
+          role: "admin",
+          school_codes: null,
+          regions: null,
+          program_ids: null,
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: "20", code: "SCH001", name: "Mapped School", region: "North" },
+      ]);
+
+    const result = await requireAcademicMentorshipAccess(
+      { user: { email: "admin@avantifellows.org" } },
+      "view",
+      { schoolCode: "SCH001" }
+    );
+
+    expect(result.ok && result.school?.id).toBe(20);
+  });
+});
+
+describe("listAccessibleAcademicMentorshipSchools", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("normalizes School IDs returned as strings by pg", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { id: "20", code: "SCH001", name: "Mapped School", region: "North" },
+    ]);
+
+    const schools = await listAccessibleAcademicMentorshipSchools({
+      email: "admin@avantifellows.org",
+      level: 3,
+      role: "admin",
+      school_codes: null,
+      regions: null,
+      program_ids: null,
+      read_only: false,
+      user_id: null,
+    });
+
+    expect(schools).toEqual([
+      { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+    ]);
   });
 });
 

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -216,19 +216,16 @@ describe("listAcademicMentorshipTeacherMentees", () => {
     const mentees = await listAcademicMentorshipTeacherMentees({
       schoolId: 20,
       academicYear: "2026-2027",
-      mentorEmail: "teacher@avantifellows.org",
+      mentorUserId: 101,
     });
 
     const sql = String(mockQuery.mock.calls[0][0]);
     expect(sql).toContain("m.academic_year = $2");
-    expect(sql).toContain("LOWER(mentor.email) = LOWER($3)");
+    expect(sql).toContain("m.mentor_user_id = $3");
+    expect(sql).not.toContain("LOWER(mentor.email)");
     expect(sql).toContain("m.ended_at IS NULL");
     expect(sql).toContain("ORDER BY gr.number ASC");
-    expect(mockQuery.mock.calls[0][1]).toEqual([
-      20,
-      "2026-2027",
-      "teacher@avantifellows.org",
-    ]);
+    expect(mockQuery.mock.calls[0][1]).toEqual([20, "2026-2027", 101]);
     expect(mentees).toEqual([
       {
         studentPkId: 202,
@@ -309,7 +306,8 @@ describe("listAcademicMentorshipMenteeOptions", () => {
 
     const sql = String(mockQuery.mock.calls[0][0]);
     expect(sql).toContain("g.type = 'school'");
-    expect(sql).toContain("er_grade.academic_year = $2");
+    expect(sql).toContain("er.academic_year = $2");
+    expect(sql).not.toContain("er_grade.is_current = true");
     expect(sql).toContain("status IS DISTINCT FROM 'dropout'");
     expect(sql).toContain("active_mapping.id IS NULL");
     expect(sql).toContain("st.student_id ILIKE $3");

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -574,10 +574,10 @@ describe("importAcademicMentorshipMappingsFromCsv", () => {
     expect(result).toMatchObject({
       type: "rows",
       errors: [
-        { rowNumber: 2, error: "student_id is required" },
-        { rowNumber: 3, error: "Duplicate student_id STU001 in rows 3, 4" },
-        { rowNumber: 4, error: "Duplicate student_id STU001 in rows 3, 4" },
-        { rowNumber: 5, error: "mentor_email is required" },
+        { rowNumber: 2, field: "student_id", error: "student_id is required" },
+        { rowNumber: 3, field: "student_id", error: "Duplicate student_id STU001 in rows 3, 4" },
+        { rowNumber: 4, field: "student_id", error: "Duplicate student_id STU001 in rows 3, 4" },
+        { rowNumber: 5, field: "mentor_email", error: "mentor_email is required" },
       ],
     });
     if (!result.ok && result.type === "rows") {

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -214,7 +214,9 @@ describe("listAcademicMentorshipMappings", () => {
       includeHistory: false,
     });
 
-    expect(String(mockQuery.mock.calls[0][0])).toContain("m.ended_at IS NULL");
+    const sql = String(mockQuery.mock.calls[0][0]);
+    expect(sql).toContain("AT TIME ZONE 'Asia/Kolkata'");
+    expect(sql).toContain("m.ended_at IS NULL");
     expect(groups).toEqual([
       {
         mentor: {
@@ -279,6 +281,7 @@ describe("listAcademicMentorshipTeacherMentees", () => {
     });
 
     const sql = String(mockQuery.mock.calls[0][0]);
+    expect(sql).toContain("AT TIME ZONE 'Asia/Kolkata'");
     expect(sql).toContain("m.academic_year = $2");
     expect(sql).toContain("m.mentor_user_id = $3");
     expect(sql).not.toContain("LOWER(mentor.email)");

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./db", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "./db";
+import {
+  listAcademicMentorshipMappings,
+  requireAcademicMentorshipAccess,
+} from "./academic-mentorship";
+import { PROGRAM_IDS } from "./constants";
+
+const mockQuery = vi.mocked(query);
+
+describe("requireAcademicMentorshipAccess", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("denies passcode users before database access", async () => {
+    const result = await requireAcademicMentorshipAccess(
+      { user: { email: "70705@passcode.local" }, isPasscodeUser: true },
+      "view"
+    );
+
+    expect(result).toEqual({ ok: false, status: 403, error: "Forbidden" });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("allows NVS-only program_admin edit access through the Academic Mentorship wildcard allowlist", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "pa@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.NVS],
+        read_only: false,
+        user_id: null,
+      },
+    ]);
+
+    const result = await requireAcademicMentorshipAccess(
+      { user: { email: "pa@avantifellows.org" } },
+      "edit"
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.canEdit).toBe(true);
+  });
+
+  it("downgrades read_only program_admin to view-only", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        email: "readonly@avantifellows.org",
+        level: 3,
+        role: "program_admin",
+        school_codes: null,
+        regions: null,
+        program_ids: [PROGRAM_IDS.COE],
+        read_only: true,
+        user_id: null,
+      },
+    ]);
+
+    const result = await requireAcademicMentorshipAccess(
+      { user: { email: "readonly@avantifellows.org" } },
+      "view"
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.canEdit).toBe(false);
+  });
+
+  it("denies access to a selected School outside the resolved scope", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          email: "pa@avantifellows.org",
+          level: 1,
+          role: "program_admin",
+          school_codes: ["SCH001"],
+          regions: null,
+          program_ids: [PROGRAM_IDS.COE],
+          read_only: false,
+          user_id: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 20, code: "SCH002", name: "Other School", region: "North" },
+      ]);
+
+    const result = await requireAcademicMentorshipAccess(
+      { user: { email: "pa@avantifellows.org" } },
+      "view",
+      { schoolCode: "SCH002" }
+    );
+
+    expect(result).toEqual({ ok: false, status: 403, error: "Forbidden" });
+    expect(mockQuery.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          expect.stringContaining("academic_mentorship_mentor_mentee_mappings"),
+        ]),
+      ])
+    );
+  });
+});
+
+describe("listAcademicMentorshipMappings", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("groups active mappings by Academic Mentor by default", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        id: 1,
+        mentor_user_id: 101,
+        mentor_name: "Anita Mentor",
+        mentor_email: "anita@avantifellows.org",
+        student_pk_id: 201,
+        mentee_name: "Meena Student",
+        mentee_student_id: "STU001",
+        mentee_grade: 11,
+        assigned_date: "2026-07-01",
+        ended_date: null,
+      },
+      {
+        id: 2,
+        mentor_user_id: 101,
+        mentor_name: "Anita Mentor",
+        mentor_email: "anita@avantifellows.org",
+        student_pk_id: 202,
+        mentee_name: "Ravi Student",
+        mentee_student_id: "STU002",
+        mentee_grade: 12,
+        assigned_date: "2026-07-02",
+        ended_date: null,
+      },
+    ]);
+
+    const groups = await listAcademicMentorshipMappings({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      includeHistory: false,
+    });
+
+    expect(String(mockQuery.mock.calls[0][0])).toContain("m.ended_at IS NULL");
+    expect(groups).toEqual([
+      {
+        mentor: {
+          userId: 101,
+          name: "Anita Mentor",
+          email: "anita@avantifellows.org",
+        },
+        menteeCount: 2,
+        mappings: [
+          {
+            id: 1,
+            mentee: {
+              studentPkId: 201,
+              name: "Meena Student",
+              studentId: "STU001",
+              grade: 11,
+            },
+            assignedDate: "2026-07-01",
+            endedDate: null,
+            status: "active",
+          },
+          {
+            id: 2,
+            mentee: {
+              studentPkId: 202,
+              name: "Ravi Student",
+              studentId: "STU002",
+              grade: 12,
+            },
+            assignedDate: "2026-07-02",
+            endedDate: null,
+            status: "active",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -2,20 +2,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./db", () => ({
   query: vi.fn(),
+  withTransaction: vi.fn(),
 }));
 
-import { query } from "./db";
+import { query, withTransaction } from "./db";
 import {
   createAcademicMentorshipMapping,
   endAcademicMentorshipMapping,
   listAcademicMentorshipMenteeOptions,
   listAcademicMentorshipMentorOptions,
   listAcademicMentorshipMappings,
+  reassignAcademicMentorshipMapping,
   requireAcademicMentorshipAccess,
 } from "./academic-mentorship";
 import { PROGRAM_IDS } from "./constants";
 
 const mockQuery = vi.mocked(query);
+const mockWithTransaction = vi.mocked(withTransaction);
 
 describe("requireAcademicMentorshipAccess", () => {
   beforeEach(() => {
@@ -336,5 +339,89 @@ describe("endAcademicMentorshipMapping", () => {
     expect(String(mockQuery.mock.calls[0][0])).toContain("ended_by_user_id = $4");
     expect(String(mockQuery.mock.calls[0][0])).toContain("ended_at IS NULL");
     expect(mockQuery.mock.calls[0][1]).toEqual([7, 20, "2026-2027", 501]);
+  });
+});
+
+describe("reassignAcademicMentorshipMapping", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("ends the old active Mapping and inserts the replacement Mapping in one transaction", async () => {
+    const txQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ student_id: 201, mentor_user_id: 101 }] })
+      .mockResolvedValueOnce({ rows: [{ student_pk_id: 201, program_id: 64 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 7 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 9 }] });
+    mockQuery.mockResolvedValueOnce([{ user_id: 102 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const result = await reassignAcademicMentorshipMapping({
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      mappingId: 7,
+      replacementMentorUserId: 102,
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({ ok: true, mappingId: 9 });
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+    expect(String(txQuery.mock.calls[0][0])).toContain("FOR UPDATE");
+    expect(txQuery.mock.calls[0][1]).toEqual([7, 20, "2026-2027"]);
+    expect(String(txQuery.mock.calls[2][0])).toContain("ended_at = now()");
+    expect(txQuery.mock.calls[2][1]).toEqual([7, 20, "2026-2027", 501]);
+    expect(String(txQuery.mock.calls[3][0])).toContain(
+      "INSERT INTO academic_mentorship_mentor_mentee_mappings"
+    );
+    expect(txQuery.mock.calls[3][1]).toEqual([
+      20,
+      "2026-2027",
+      102,
+      201,
+      64,
+      501,
+    ]);
+  });
+
+  it("maps replacement insert races to a conflict inside the transaction", async () => {
+    const duplicateError = new Error("duplicate key value violates unique constraint");
+    Object.assign(duplicateError, { code: "23505" });
+    const txQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ student_id: 201, mentor_user_id: 101 }] })
+      .mockResolvedValueOnce({ rows: [{ student_pk_id: 201, program_id: null }] })
+      .mockResolvedValueOnce({ rows: [{ id: 7 }] })
+      .mockRejectedValueOnce(duplicateError);
+    mockQuery.mockResolvedValueOnce([{ user_id: 102 }]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const result = await reassignAcademicMentorshipMapping({
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      mappingId: 7,
+      replacementMentorUserId: 102,
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "Student already has a mentor mapped",
+    });
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+    expect(String(txQuery.mock.calls[2][0])).toContain("ended_at = now()");
+    expect(String(txQuery.mock.calls[3][0])).toContain(
+      "INSERT INTO academic_mentorship_mentor_mentee_mappings"
+    );
   });
 });

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -6,6 +6,10 @@ vi.mock("./db", () => ({
 
 import { query } from "./db";
 import {
+  createAcademicMentorshipMapping,
+  endAcademicMentorshipMapping,
+  listAcademicMentorshipMenteeOptions,
+  listAcademicMentorshipMentorOptions,
   listAcademicMentorshipMappings,
   requireAcademicMentorshipAccess,
 } from "./academic-mentorship";
@@ -185,5 +189,152 @@ describe("listAcademicMentorshipMappings", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("listAcademicMentorshipMentorOptions", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns searchable completed Staff Management Teachers with effective access to the selected School", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        user_id: 101,
+        name: "Anita Mentor",
+        email: "anita@avantifellows.org",
+      },
+    ]);
+
+    const mentors = await listAcademicMentorshipMentorOptions({
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      search: "anita",
+    });
+
+    const sql = String(mockQuery.mock.calls[0][0]);
+    expect(sql).toContain("up.role = 'teacher'");
+    expect(sql).toContain("up.revoked_at IS NULL");
+    expect(sql).toContain("t.is_af_teacher = true");
+    expect(sql).toContain("t.exit_date IS NULL");
+    expect(sql).toContain("cp.deleted_at IS NULL");
+    expect(sql).toContain("ILIKE $4");
+    expect(mockQuery.mock.calls[0][1]).toEqual([
+      "SCH001",
+      "North",
+      20,
+      "%anita%",
+    ]);
+    expect(mentors).toEqual([
+      {
+        userId: 101,
+        name: "Anita Mentor",
+        email: "anita@avantifellows.org",
+      },
+    ]);
+  });
+});
+
+describe("listAcademicMentorshipMenteeOptions", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns searchable active unassigned Students from the selected School roster", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        student_pk_id: 201,
+        name: "Meena Student",
+        student_id: "STU001",
+        grade: 11,
+        program_id: 64,
+      },
+    ]);
+
+    const mentees = await listAcademicMentorshipMenteeOptions({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      search: "mee",
+    });
+
+    const sql = String(mockQuery.mock.calls[0][0]);
+    expect(sql).toContain("g.type = 'school'");
+    expect(sql).toContain("er_grade.academic_year = $2");
+    expect(sql).toContain("status IS DISTINCT FROM 'dropout'");
+    expect(sql).toContain("active_mapping.id IS NULL");
+    expect(sql).toContain("st.student_id ILIKE $3");
+    expect(mockQuery.mock.calls[0][1]).toEqual([20, "2026-2027", "%mee%"]);
+    expect(mentees).toEqual([
+      {
+        studentPkId: 201,
+        name: "Meena Student",
+        studentId: "STU001",
+        grade: 11,
+        programId: 64,
+      },
+    ]);
+  });
+});
+
+describe("createAcademicMentorshipMapping", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("creates an active Mapping with actor audit and the Mentee roster Program", async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ user_id: 101 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ student_pk_id: 201, program_id: 64 }])
+      .mockResolvedValueOnce([{ id: 7 }]);
+
+    const result = await createAcademicMentorshipMapping({
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      mentorUserId: 101,
+      studentPkId: 201,
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({ ok: true, mappingId: 7 });
+    const insertCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(String(insertCall?.[0])).toContain("assigned_at");
+    expect(String(insertCall?.[0])).toContain("assigned_by_user_id");
+    expect(insertCall?.[1]).toEqual([
+      20,
+      "2026-2027",
+      101,
+      201,
+      64,
+      501,
+    ]);
+  });
+});
+
+describe("endAcademicMentorshipMapping", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("ends only an active Mapping and records the actor", async () => {
+    mockQuery.mockResolvedValueOnce([{ id: 7 }]);
+
+    const result = await endAcademicMentorshipMapping({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      mappingId: 7,
+      endedByUserId: 501,
+    });
+
+    expect(result).toEqual({ ok: true, mappingId: 7 });
+    expect(String(mockQuery.mock.calls[0][0])).toContain("ended_at = now()");
+    expect(String(mockQuery.mock.calls[0][0])).toContain("ended_by_user_id = $4");
+    expect(String(mockQuery.mock.calls[0][0])).toContain("ended_at IS NULL");
+    expect(mockQuery.mock.calls[0][1]).toEqual([7, 20, "2026-2027", 501]);
   });
 });

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -555,6 +555,16 @@ describe("importAcademicMentorshipMappingsFromCsv", () => {
   });
 
   it("returns row-level errors with duplicate spreadsheet row numbers and preserves extra CSV columns", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        { email: "anita@avantifellows.org", user_id: 101 },
+        { email: "meena@avantifellows.org", user_id: 102 },
+      ])
+      .mockResolvedValueOnce([
+        { student_id: "STU001", student_pk_id: 201, program_id: 64, active_mapping_id: null },
+        { student_id: "STU002", student_pk_id: 202, program_id: 64, active_mapping_id: null },
+      ]);
+
     const result = await importAcademicMentorshipMappingsFromCsv({
       csvText: [
         "mentor_email,student_id,notes",
@@ -585,7 +595,64 @@ describe("importAcademicMentorshipMappingsFromCsv", () => {
       expect(result.errorCsv).toContain("anita@avantifellows.org,,missing student,student_id is required");
       expect(result.errorCsv).toContain('meena@avantifellows.org, STU001 ,second duplicate,"Duplicate student_id STU001 in rows 3, 4"');
     }
-    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps lookup validation errors when the same CSV also has duplicate student ids", async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ email: "anita@avantifellows.org", user_id: 101 }])
+      .mockResolvedValueOnce([
+        { student_id: "STU001", student_pk_id: 201, program_id: 64, active_mapping_id: null },
+        { student_id: "STU002", student_pk_id: 202, program_id: 64, active_mapping_id: 301 },
+      ]);
+
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: [
+        "mentor_email,student_id",
+        "anita@avantifellows.org,OUTSIDE",
+        "anita@avantifellows.org,STU001",
+        "anita@avantifellows.org,STU002",
+        "missing@avantifellows.org,STU003",
+        "anita@avantifellows.org,STU001",
+      ].join("\n"),
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toMatchObject({
+      type: "rows",
+      errors: expect.arrayContaining([
+        {
+          rowNumber: 2,
+          field: "student_id",
+          error: "student_id is not an eligible Mentee for this School and academic year",
+        },
+        {
+          rowNumber: 3,
+          field: "student_id",
+          error: "Duplicate student_id STU001 in rows 3, 6",
+        },
+        { rowNumber: 4, field: "student_id", error: "Student already has a mentor mapped" },
+        {
+          rowNumber: 5,
+          field: "mentor_email",
+          error: "mentor_email is not an eligible Academic Mentor for this School",
+        },
+        {
+          rowNumber: 5,
+          field: "student_id",
+          error: "student_id is not an eligible Mentee for this School and academic year",
+        },
+        {
+          rowNumber: 6,
+          field: "student_id",
+          error: "Duplicate student_id STU001 in rows 3, 6",
+        },
+      ]),
+    });
     expect(mockWithTransaction).not.toHaveBeenCalled();
   });
 

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -13,6 +13,7 @@ import {
   listAcademicMentorshipMenteeOptions,
   listAcademicMentorshipMentorOptions,
   listAcademicMentorshipMappings,
+  listAcademicMentorshipTeacherMentees,
   reassignAcademicMentorshipMapping,
   requireAcademicMentorshipAccess,
 } from "./academic-mentorship";
@@ -191,6 +192,50 @@ describe("listAcademicMentorshipMappings", () => {
             status: "active",
           },
         ],
+      },
+    ]);
+  });
+});
+
+describe("listAcademicMentorshipTeacherMentees", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns only the signed-in Teacher's active current-year Mentees sorted for the School page", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        student_pk_id: 202,
+        mentee_name: "Anaya Student",
+        mentee_student_id: "STU002",
+        mentee_grade: 10,
+        assigned_date: "2026-07-02",
+      },
+    ]);
+
+    const mentees = await listAcademicMentorshipTeacherMentees({
+      schoolId: 20,
+      academicYear: "2026-2027",
+      mentorEmail: "teacher@avantifellows.org",
+    });
+
+    const sql = String(mockQuery.mock.calls[0][0]);
+    expect(sql).toContain("m.academic_year = $2");
+    expect(sql).toContain("LOWER(mentor.email) = LOWER($3)");
+    expect(sql).toContain("m.ended_at IS NULL");
+    expect(sql).toContain("ORDER BY gr.number ASC");
+    expect(mockQuery.mock.calls[0][1]).toEqual([
+      20,
+      "2026-2027",
+      "teacher@avantifellows.org",
+    ]);
+    expect(mentees).toEqual([
+      {
+        studentPkId: 202,
+        name: "Anaya Student",
+        studentId: "STU002",
+        grade: 10,
+        assignedDate: "2026-07-02",
       },
     ]);
   });

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -8,6 +8,7 @@ vi.mock("./db", () => ({
 import { query, withTransaction } from "./db";
 import {
   createAcademicMentorshipMapping,
+  importAcademicMentorshipMappingsFromCsv,
   endAcademicMentorshipMapping,
   listAcademicMentorshipMenteeOptions,
   listAcademicMentorshipMentorOptions,
@@ -423,5 +424,197 @@ describe("reassignAcademicMentorshipMapping", () => {
     expect(String(txQuery.mock.calls[3][0])).toContain(
       "INSERT INTO academic_mentorship_mentor_mentee_mappings"
     );
+  });
+});
+
+describe("importAcademicMentorshipMappingsFromCsv", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("returns a file-level error when required CSV headers are missing", async () => {
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: "mentor_email,name\nanita@avantifellows.org,Meena\n",
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      type: "file",
+      error: "CSV must include mentor_email and student_id headers",
+    });
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns row-level errors with duplicate spreadsheet row numbers and preserves extra CSV columns", async () => {
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: [
+        "mentor_email,student_id,notes",
+        "anita@avantifellows.org,,missing student",
+        "anita@avantifellows.org,STU001,first duplicate",
+        "meena@avantifellows.org, STU001 ,second duplicate",
+        ",STU002,missing mentor",
+      ].join("\n"),
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({
+      type: "rows",
+      errors: [
+        { rowNumber: 2, error: "student_id is required" },
+        { rowNumber: 3, error: "Duplicate student_id STU001 in rows 3, 4" },
+        { rowNumber: 4, error: "Duplicate student_id STU001 in rows 3, 4" },
+        { rowNumber: 5, error: "mentor_email is required" },
+      ],
+    });
+    if (!result.ok && result.type === "rows") {
+      expect(result.errorCsv).toContain("mentor_email,student_id,notes,error_reason");
+      expect(result.errorCsv).toContain("anita@avantifellows.org,,missing student,student_id is required");
+      expect(result.errorCsv).toContain('meena@avantifellows.org, STU001 ,second duplicate,"Duplicate student_id STU001 in rows 3, 4"');
+    }
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("trims lookup values and inserts every valid row in one transaction", async () => {
+    const txQuery = vi.fn().mockResolvedValueOnce({ rows: [{ id: 31 }, { id: 32 }] });
+    mockQuery
+      .mockResolvedValueOnce([
+        { email: "anita@avantifellows.org", user_id: 101 },
+        { email: "meena@avantifellows.org", user_id: 102 },
+      ])
+      .mockResolvedValueOnce([
+        { student_id: "STU001", student_pk_id: 201, program_id: 64 },
+        { student_id: "STU002", student_pk_id: 202, program_id: null },
+      ]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: [
+        "mentor_email,student_id,notes",
+        " ANITA@AVANTIFELLOWS.ORG , STU001 ,kept",
+        ",,",
+        "meena@avantifellows.org,STU002,also kept",
+      ].join("\n"),
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({ ok: true, insertedCount: 2 });
+    expect(mockQuery.mock.calls[0][1]).toEqual([
+      "SCH001",
+      "North",
+      20,
+      ["anita@avantifellows.org", "meena@avantifellows.org"],
+    ]);
+    expect(mockQuery.mock.calls[1][1]).toEqual([
+      20,
+      "2026-2027",
+      ["STU001", "STU002"],
+    ]);
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+    expect(String(txQuery.mock.calls[0][0])).toContain(
+      "INSERT INTO academic_mentorship_mentor_mentee_mappings"
+    );
+    expect(txQuery.mock.calls[0][1]).toEqual([
+      20,
+      "2026-2027",
+      101,
+      201,
+      64,
+      501,
+      20,
+      "2026-2027",
+      102,
+      202,
+      null,
+      501,
+    ]);
+  });
+
+  it("caps uploads at 2,000 data rows before database access", async () => {
+    const csvText = [
+      "mentor_email,student_id",
+      ...Array.from(
+        { length: 2001 },
+        (_, index) => `mentor${index}@avantifellows.org,STU${index}`
+      ),
+    ].join("\n");
+
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText,
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      type: "file",
+      error: "CSV upload is capped at 2,000 data rows",
+    });
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns row-level eligibility and active Mapping errors without writing", async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ email: "anita@avantifellows.org", user_id: 101 }])
+      .mockResolvedValueOnce([
+        {
+          student_id: "STU001",
+          student_pk_id: 201,
+          program_id: 64,
+          active_mapping_id: 77,
+        },
+      ]);
+
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: [
+        "mentor_email,student_id",
+        "unknown@avantifellows.org,STU001",
+        "anita@avantifellows.org,STU999",
+      ].join("\n"),
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2026-2027",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      type: "rows",
+      errors: [
+        {
+          rowNumber: 2,
+          error: "mentor_email is not an eligible Academic Mentor for this School",
+        },
+        { rowNumber: 2, error: "Student already has a mentor mapped" },
+        {
+          rowNumber: 3,
+          error: "student_id is not an eligible Mentee for this School and academic year",
+        },
+      ],
+    });
+    expect(mockWithTransaction).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -134,6 +134,7 @@ describe("listAcademicMentorshipMappings", () => {
         mentee_name: "Meena Student",
         mentee_student_id: "STU001",
         mentee_grade: 11,
+        program_id: PROGRAM_IDS.NVS,
         assigned_date: "2026-07-01",
         ended_date: null,
       },
@@ -146,6 +147,7 @@ describe("listAcademicMentorshipMappings", () => {
         mentee_name: "Ravi Student",
         mentee_student_id: "STU002",
         mentee_grade: 12,
+        program_id: PROGRAM_IDS.NVS,
         assigned_date: "2026-07-02",
         ended_date: null,
       },
@@ -174,6 +176,7 @@ describe("listAcademicMentorshipMappings", () => {
               name: "Meena Student",
               studentId: "STU001",
               grade: 11,
+              programId: PROGRAM_IDS.NVS,
             },
             assignedDate: "2026-07-01",
             endedDate: null,
@@ -186,6 +189,7 @@ describe("listAcademicMentorshipMappings", () => {
               name: "Ravi Student",
               studentId: "STU002",
               grade: 12,
+              programId: PROGRAM_IDS.NVS,
             },
             assignedDate: "2026-07-02",
             endedDate: null,
@@ -311,7 +315,7 @@ describe("listAcademicMentorshipMenteeOptions", () => {
     expect(sql).toContain("status IS DISTINCT FROM 'dropout'");
     expect(sql).toContain("active_mapping.id IS NULL");
     expect(sql).toContain("st.student_id ILIKE $3");
-    expect(mockQuery.mock.calls[0][1]).toEqual([20, "2026-2027", "%mee%"]);
+    expect(mockQuery.mock.calls[0][1]).toEqual([20, "2026-2027", "%mee%", null]);
     expect(mentees).toEqual([
       {
         studentPkId: 201,

--- a/src/lib/academic-mentorship.test.ts
+++ b/src/lib/academic-mentorship.test.ts
@@ -704,6 +704,8 @@ describe("importAcademicMentorshipMappingsFromCsv", () => {
     expect(String(txQuery.mock.calls[0][0])).toContain(
       "INSERT INTO academic_mentorship_mentor_mentee_mappings"
     );
+    expect(String(txQuery.mock.calls[0][0])).toContain("ended_at, ended_by_user_id");
+    expect(String(txQuery.mock.calls[0][0])).toContain("NULL, NULL");
     expect(txQuery.mock.calls[0][1]).toEqual([
       20,
       "2026-2027",
@@ -716,6 +718,40 @@ describe("importAcademicMentorshipMappingsFromCsv", () => {
       102,
       202,
       null,
+      501,
+    ]);
+  });
+
+  it("marks past-year CSV imports historical so they are not active mappings", async () => {
+    const txQuery = vi.fn().mockResolvedValueOnce({ rows: [{ id: 31 }] });
+    mockQuery
+      .mockResolvedValueOnce([{ email: "anita@avantifellows.org", user_id: 101 }])
+      .mockResolvedValueOnce([
+        { student_id: "STU001", student_pk_id: 201, program_id: 64, active_mapping_id: null },
+      ]);
+    mockWithTransaction.mockImplementationOnce(async (callback) =>
+      callback({ query: txQuery } as never)
+    );
+
+    const result = await importAcademicMentorshipMappingsFromCsv({
+      csvText: "mentor_email,student_id\nanita@avantifellows.org,STU001\n",
+      schoolId: 20,
+      schoolCode: "SCH001",
+      schoolRegion: "North",
+      academicYear: "2025-2026",
+      assignedByUserId: 501,
+    });
+
+    expect(result).toEqual({ ok: true, insertedCount: 1 });
+    const sql = String(txQuery.mock.calls[0][0]);
+    expect(sql).toContain("ended_at, ended_by_user_id");
+    expect(sql).toContain("$6, now(), now(), $6, now(), now()");
+    expect(txQuery.mock.calls[0][1]).toEqual([
+      20,
+      "2025-2026",
+      101,
+      201,
+      64,
       501,
     ]);
   });

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -1203,36 +1203,3 @@ export async function listAcademicMentorshipProgramSchoolLinks(
     schoolId: Number(row.school_id),
   }));
 }
-
-export async function filterAcademicMentorshipSchoolsByProgram(
-  schools: AcademicMentorshipSchool[],
-  academicYear: string,
-  programId: number | null
-): Promise<AcademicMentorshipSchool[]> {
-  if (programId === null || schools.length === 0) return schools;
-  const rows = await query<{ id: number | string }>(
-    `SELECT DISTINCT s.id
-     FROM school s
-     JOIN "group" school_group
-       ON school_group.child_id = s.id
-      AND school_group.type = 'school'
-     JOIN group_user school_member
-       ON school_member.group_id = school_group.id
-     JOIN enrollment_record er
-       ON er.user_id = school_member.user_id
-      AND er.group_type = 'grade'
-      AND er.academic_year = $2
-     JOIN group_user batch_member
-       ON batch_member.user_id = school_member.user_id
-     JOIN "group" batch_group
-       ON batch_group.id = batch_member.group_id
-      AND batch_group.type = 'batch'
-     JOIN batch b
-       ON b.id = batch_group.child_id
-     WHERE s.id = ANY($1::bigint[])
-       AND b.program_id = $3`,
-    [schools.map((school) => school.id), academicYear, programId]
-  );
-  const matchingIds = new Set(rows.map((row) => Number(row.id)));
-  return schools.filter((school) => matchingIds.has(school.id));
-}

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -2,6 +2,7 @@ import {
   ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST,
   CURRENT_ACADEMIC_YEAR,
 } from "./constants";
+import { parse } from "csv-parse/sync";
 import { query, withTransaction } from "./db";
 import {
   canAccessSchoolSync,
@@ -115,6 +116,36 @@ interface AcademicMentorshipMenteeOptionRow {
 export type AcademicMentorshipMutationResult =
   | { ok: true; mappingId: number }
   | { ok: false; status: 404 | 409 | 422; error: string };
+
+export type AcademicMentorshipCsvImportResult =
+  | { ok: true; insertedCount: number }
+  | { ok: false; type: "file"; error: string }
+  | {
+      ok: false;
+      type: "rows";
+      errors: Array<{ rowNumber: number; error: string }>;
+      errorCsv: string;
+    };
+
+interface AcademicMentorshipCsvRow {
+  rowNumber: number;
+  values: Record<string, string>;
+  mentorEmail: string;
+  studentId: string;
+  errors: string[];
+}
+
+interface AcademicMentorshipImportMentorRow {
+  email: string;
+  user_id: number | string;
+}
+
+interface AcademicMentorshipImportMenteeRow {
+  student_id: string;
+  student_pk_id: number | string;
+  program_id: number | string | null;
+  active_mapping_id: number | string | null;
+}
 
 function hasAcademicMentorshipProgramAccess(permission: UserPermission): boolean {
   if (ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST.includes("*")) return true;
@@ -497,6 +528,249 @@ export async function createAcademicMentorshipMapping(params: {
     }
     throw error;
   }
+}
+
+export async function importAcademicMentorshipMappingsFromCsv(params: {
+  csvText: string;
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  academicYear: string;
+  assignedByUserId: number;
+}): Promise<AcademicMentorshipCsvImportResult> {
+  let records: string[][];
+  try {
+    records = parse(params.csvText, {
+      bom: true,
+      relax_column_count: true,
+      skip_empty_lines: false,
+    }) as string[][];
+  } catch {
+    return { ok: false, type: "file", error: "CSV could not be parsed" };
+  }
+  const header = records[0]?.map((value) => value.trim()) ?? [];
+  if (header.length === 0 || header.every((value) => value === "")) {
+    return { ok: false, type: "file", error: "CSV file is empty" };
+  }
+  if (!header.includes("mentor_email") || !header.includes("student_id")) {
+    return {
+      ok: false,
+      type: "file",
+      error: "CSV must include mentor_email and student_id headers",
+    };
+  }
+
+  const rows = records
+    .slice(1)
+    .map((record, index): AcademicMentorshipCsvRow | null => {
+      if (record.every((value) => value.trim() === "")) return null;
+      const values = Object.fromEntries(
+        header.map((column, columnIndex) => [column, record[columnIndex] ?? ""])
+      );
+      const mentorEmail = (values.mentor_email ?? "").trim();
+      const studentId = (values.student_id ?? "").trim();
+      const errors: string[] = [];
+      if (!mentorEmail) errors.push("mentor_email is required");
+      if (!studentId) errors.push("student_id is required");
+      return {
+        rowNumber: index + 2,
+        values,
+        mentorEmail,
+        studentId,
+        errors,
+      };
+    })
+    .filter((row): row is AcademicMentorshipCsvRow => row !== null);
+
+  if (rows.length === 0) {
+    return { ok: false, type: "file", error: "CSV file has no data rows" };
+  }
+  if (rows.length > 2000) {
+    return { ok: false, type: "file", error: "CSV upload is capped at 2,000 data rows" };
+  }
+
+  const rowsByStudentId = new Map<string, AcademicMentorshipCsvRow[]>();
+  for (const row of rows) {
+    if (!row.studentId) continue;
+    rowsByStudentId.set(row.studentId, [
+      ...(rowsByStudentId.get(row.studentId) ?? []),
+      row,
+    ]);
+  }
+  for (const [studentId, duplicateRows] of rowsByStudentId) {
+    if (duplicateRows.length < 2) continue;
+    const rowNumbers = duplicateRows.map((row) => row.rowNumber).join(", ");
+    for (const row of duplicateRows) {
+      row.errors.push(`Duplicate student_id ${studentId} in rows ${rowNumbers}`);
+    }
+  }
+
+  const invalidRows = rows.filter((row) => row.errors.length > 0);
+  if (invalidRows.length > 0) {
+    return {
+      ok: false,
+      type: "rows",
+      errors: invalidRows.flatMap((row) =>
+        row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
+      ),
+      errorCsv: buildAcademicMentorshipImportErrorCsv(header, invalidRows),
+    };
+  }
+
+  const mentorEmails = [
+    ...new Set(rows.map((row) => row.mentorEmail.toLowerCase())),
+  ];
+  const studentIds = [...new Set(rows.map((row) => row.studentId))];
+
+  const mentorRows = await query<AcademicMentorshipImportMentorRow>(
+    `SELECT LOWER(u.email) AS email, u.id AS user_id
+     FROM teacher t
+     JOIN "user" u ON u.id = t.user_id
+     JOIN user_permission up
+       ON (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+      AND up.role = 'teacher'
+      AND up.revoked_at IS NULL
+     LEFT JOIN centre_positions cp
+       ON cp.user_id = u.id
+      AND cp.deleted_at IS NULL
+     LEFT JOIN centres c
+       ON c.id = cp.centre_id
+     WHERE t.is_af_teacher = true
+       AND t.exit_date IS NULL
+       AND LOWER(u.email) = ANY($4::text[])
+       AND (
+         up.level = 3
+         OR up.school_codes @> ARRAY[$1]::text[]
+         OR ($2::text IS NOT NULL AND up.regions @> ARRAY[$2]::text[])
+         OR c.school_id = $3
+       )
+     GROUP BY u.id, u.email`,
+    [params.schoolCode, params.schoolRegion, params.schoolId, mentorEmails]
+  );
+  const mentorByEmail = new Map(
+    mentorRows.map((row) => [row.email.toLowerCase(), Number(row.user_id)])
+  );
+
+  const menteeRows = await query<AcademicMentorshipImportMenteeRow>(
+    `SELECT DISTINCT ON (TRIM(st.student_id))
+       TRIM(st.student_id) AS student_id,
+       st.id AS student_pk_id,
+       roster_program.program_id,
+       active_mapping.id AS active_mapping_id
+     FROM group_user gu
+     JOIN "group" g ON g.id = gu.group_id
+     JOIN "user" u ON u.id = gu.user_id
+     JOIN student st ON st.user_id = u.id
+     JOIN enrollment_record er_grade
+       ON er_grade.user_id = u.id
+      AND er_grade.group_type = 'grade'
+      AND er_grade.is_current = true
+      AND er_grade.academic_year = $2
+     LEFT JOIN LATERAL (
+       SELECT b.program_id
+       FROM group_user gu_batch
+       JOIN "group" g_batch ON g_batch.id = gu_batch.group_id AND g_batch.type = 'batch'
+       JOIN batch b ON b.id = g_batch.child_id
+       WHERE gu_batch.user_id = u.id
+       ORDER BY array_position(ARRAY[1, 2, 64]::int[], b.program_id)
+       LIMIT 1
+     ) roster_program ON true
+     LEFT JOIN academic_mentorship_mentor_mentee_mappings active_mapping
+       ON active_mapping.school_id = $1
+      AND active_mapping.academic_year = $2
+      AND active_mapping.student_id = st.id
+      AND active_mapping.ended_at IS NULL
+     WHERE g.type = 'school'
+       AND g.child_id = $1
+       AND st.status IS DISTINCT FROM 'dropout'
+       AND TRIM(st.student_id) = ANY($3::text[])
+     ORDER BY TRIM(st.student_id), active_mapping.id NULLS FIRST`,
+    [params.schoolId, params.academicYear, studentIds]
+  );
+  const menteeByStudentId = new Map(
+    menteeRows.map((row) => [row.student_id, row])
+  );
+
+  for (const row of rows) {
+    if (!mentorByEmail.has(row.mentorEmail.toLowerCase())) {
+      row.errors.push("mentor_email is not an eligible Academic Mentor for this School");
+    }
+    const mentee = menteeByStudentId.get(row.studentId);
+    if (!mentee) {
+      row.errors.push("student_id is not an eligible Mentee for this School and academic year");
+    } else if (mentee.active_mapping_id != null) {
+      row.errors.push("Student already has a mentor mapped");
+    }
+  }
+  const dbInvalidRows = rows.filter((row) => row.errors.length > 0);
+  if (dbInvalidRows.length > 0) {
+    return {
+      ok: false,
+      type: "rows",
+      errors: dbInvalidRows.flatMap((row) =>
+        row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
+      ),
+      errorCsv: buildAcademicMentorshipImportErrorCsv(header, dbInvalidRows),
+    };
+  }
+
+  try {
+    return await withTransaction(async (client) => {
+      const values = rows
+        .map((_, index) => {
+          const start = index * 6;
+          return `($${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, now(), now(), now())`;
+        })
+        .join(", ");
+      const insertParams = rows.flatMap((row) => {
+        const mentee = menteeByStudentId.get(row.studentId)!;
+        return [
+          params.schoolId,
+          params.academicYear,
+          mentorByEmail.get(row.mentorEmail.toLowerCase())!,
+          Number(mentee.student_pk_id),
+          mentee.program_id === null ? null : Number(mentee.program_id),
+          params.assignedByUserId,
+        ];
+      });
+      const inserted = await client.query<{ id: number | string }>(
+        `INSERT INTO academic_mentorship_mentor_mentee_mappings
+           (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, inserted_at, updated_at)
+         VALUES ${values}
+         RETURNING id`,
+        insertParams
+      );
+      return { ok: true, insertedCount: inserted.rows.length };
+    });
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { ok: false, type: "file", error: "Student already has a mentor mapped" };
+    }
+    throw error;
+  }
+}
+
+function csvCell(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value;
+}
+
+function buildAcademicMentorshipImportErrorCsv(
+  header: string[],
+  rows: AcademicMentorshipCsvRow[]
+): string {
+  const outputHeader = [...header, "error_reason"];
+  const lines = [
+    outputHeader.map(csvCell).join(","),
+    ...rows.map((row) =>
+      [
+        ...header.map((column) => row.values[column] ?? ""),
+        row.errors.join("; "),
+      ]
+        .map(csvCell)
+        .join(",")
+    ),
+  ];
+  return `${lines.join("\n")}\n`;
 }
 
 export async function getAcademicMentorshipActorUserId(

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -163,6 +163,19 @@ interface AcademicMentorshipImportMenteeRow {
   active_mapping_id: number | string | null;
 }
 
+interface AcademicMentorshipCsvImportParams {
+  csvText: string;
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  academicYear: string;
+  assignedByUserId: number;
+}
+
+type AcademicMentorshipParsedCsv =
+  | { ok: true; header: string[]; rows: AcademicMentorshipCsvRow[] }
+  | { ok: false; result: AcademicMentorshipCsvImportResult };
+
 function hasAcademicMentorshipProgramAccess(permission: UserPermission): boolean {
   if (ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST.includes("*")) return true;
   const allowed = new Set<number>(
@@ -606,65 +619,66 @@ export async function createAcademicMentorshipMapping(params: {
   }
 }
 
-export async function importAcademicMentorshipMappingsFromCsv(params: {
-  csvText: string;
-  schoolId: number;
-  schoolCode: string;
-  schoolRegion: string | null;
-  academicYear: string;
-  assignedByUserId: number;
-}): Promise<AcademicMentorshipCsvImportResult> {
-  let records: string[][];
+function csvFileParseFailure(error: string): AcademicMentorshipParsedCsv {
+  return { ok: false, result: { ok: false, type: "file", error } };
+}
+
+function parseAcademicMentorshipCsvRecords(csvText: string): string[][] | null {
   try {
-    records = parse(params.csvText, {
+    return parse(csvText, {
       bom: true,
       relax_column_count: true,
       skip_empty_lines: false,
     }) as string[][];
   } catch {
-    return { ok: false, type: "file", error: "CSV could not be parsed" };
+    return null;
   }
-  const header = records[0]?.map((value) => value.trim()) ?? [];
+}
+
+function academicMentorshipCsvHeaderError(header: string[]): string | null {
   if (header.length === 0 || header.every((value) => value === "")) {
-    return { ok: false, type: "file", error: "CSV file is empty" };
+    return "CSV file is empty";
   }
   if (!header.includes("mentor_email") || !header.includes("student_id")) {
-    return {
-      ok: false,
-      type: "file",
-      error: "CSV must include mentor_email and student_id headers",
-    };
+    return "CSV must include mentor_email and student_id headers";
   }
+  return null;
+}
 
-  const rows = records
-    .slice(1)
-    .map((record, index): AcademicMentorshipCsvRow | null => {
-      if (record.every((value) => value.trim() === "")) return null;
-      const values = Object.fromEntries(
-        header.map((column, columnIndex) => [column, record[columnIndex] ?? ""])
-      );
-      const mentorEmail = (values.mentor_email ?? "").trim();
-      const studentId = (values.student_id ?? "").trim();
-      const errors: string[] = [];
-      if (!mentorEmail) errors.push("mentor_email is required");
-      if (!studentId) errors.push("student_id is required");
-      return {
-        rowNumber: index + 2,
-        values,
-        mentorEmail,
-        studentId,
-        errors,
-      };
-    })
-    .filter((row): row is AcademicMentorshipCsvRow => row !== null);
+function academicMentorshipCsvRowLimitError(rowCount: number): string | null {
+  if (rowCount === 0) return "CSV file has no data rows";
+  if (rowCount > 2000) return "CSV upload is capped at 2,000 data rows";
+  return null;
+}
 
-  if (rows.length === 0) {
-    return { ok: false, type: "file", error: "CSV file has no data rows" };
-  }
-  if (rows.length > 2000) {
-    return { ok: false, type: "file", error: "CSV upload is capped at 2,000 data rows" };
-  }
+function buildAcademicMentorshipCsvRow(
+  header: string[],
+  record: string[],
+  rowNumber: number
+): AcademicMentorshipCsvRow | null {
+  if (record.every((value) => value.trim() === "")) return null;
+  const values = Object.fromEntries(
+    header.map((column, columnIndex) => [column, record[columnIndex] ?? ""])
+  );
+  const mentorEmail = (values.mentor_email ?? "").trim();
+  const studentId = (values.student_id ?? "").trim();
+  const errors: string[] = [];
+  if (!mentorEmail) errors.push("mentor_email is required");
+  if (!studentId) errors.push("student_id is required");
+  return { rowNumber, values, mentorEmail, studentId, errors };
+}
 
+function buildAcademicMentorshipCsvRows(
+  header: string[],
+  records: string[][]
+): AcademicMentorshipCsvRow[] {
+  return records.slice(1).flatMap((record, index) => {
+    const row = buildAcademicMentorshipCsvRow(header, record, index + 2);
+    return row ? [row] : [];
+  });
+}
+
+function addDuplicateStudentIdErrors(rows: AcademicMentorshipCsvRow[]) {
   const rowsByStudentId = new Map<string, AcademicMentorshipCsvRow[]>();
   for (const row of rows) {
     if (!row.studentId) continue;
@@ -673,6 +687,7 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
       row,
     ]);
   }
+
   for (const [studentId, duplicateRows] of rowsByStudentId) {
     if (duplicateRows.length < 2) continue;
     const rowNumbers = duplicateRows.map((row) => row.rowNumber).join(", ");
@@ -680,24 +695,55 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
       row.errors.push(`Duplicate student_id ${studentId} in rows ${rowNumbers}`);
     }
   }
+}
 
+function academicMentorshipCsvRowsFailure(
+  header: string[],
+  invalidRows: AcademicMentorshipCsvRow[]
+): AcademicMentorshipCsvImportResult {
+  return {
+    ok: false,
+    type: "rows",
+    errors: invalidRows.flatMap((row) =>
+      row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
+    ),
+    errorCsv: buildAcademicMentorshipImportErrorCsv(header, invalidRows),
+  };
+}
+
+function parseAcademicMentorshipCsv(csvText: string): AcademicMentorshipParsedCsv {
+  const records = parseAcademicMentorshipCsvRecords(csvText);
+  if (!records) return csvFileParseFailure("CSV could not be parsed");
+
+  const header = records[0]?.map((value) => value.trim()) ?? [];
+  const headerError = academicMentorshipCsvHeaderError(header);
+  if (headerError) return csvFileParseFailure(headerError);
+
+  const rows = buildAcademicMentorshipCsvRows(header, records);
+  const rowLimitError = academicMentorshipCsvRowLimitError(rows.length);
+  if (rowLimitError) return csvFileParseFailure(rowLimitError);
+
+  addDuplicateStudentIdErrors(rows);
   const invalidRows = rows.filter((row) => row.errors.length > 0);
   if (invalidRows.length > 0) {
-    return {
-      ok: false,
-      type: "rows",
-      errors: invalidRows.flatMap((row) =>
-        row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
-      ),
-      errorCsv: buildAcademicMentorshipImportErrorCsv(header, invalidRows),
-    };
+    return { ok: false, result: academicMentorshipCsvRowsFailure(header, invalidRows) };
   }
 
-  const mentorEmails = [
-    ...new Set(rows.map((row) => row.mentorEmail.toLowerCase())),
-  ];
-  const studentIds = [...new Set(rows.map((row) => row.studentId))];
+  return { ok: true, header, rows };
+}
 
+function uniqueMentorEmails(rows: AcademicMentorshipCsvRow[]): string[] {
+  return [...new Set(rows.map((row) => row.mentorEmail.toLowerCase()))];
+}
+
+function uniqueStudentIds(rows: AcademicMentorshipCsvRow[]): string[] {
+  return [...new Set(rows.map((row) => row.studentId))];
+}
+
+async function loadAcademicMentorshipImportMentors(
+  params: AcademicMentorshipCsvImportParams,
+  mentorEmails: string[]
+): Promise<Map<string, number>> {
   const mentorRows = await query<AcademicMentorshipImportMentorRow>(
     `SELECT LOWER(u.email) AS email, u.id AS user_id
      FROM teacher t
@@ -723,10 +769,15 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
      GROUP BY u.id, u.email`,
     [params.schoolCode, params.schoolRegion, params.schoolId, mentorEmails]
   );
-  const mentorByEmail = new Map(
+  return new Map(
     mentorRows.map((row) => [row.email.toLowerCase(), Number(row.user_id)])
   );
+}
 
+async function loadAcademicMentorshipImportMentees(
+  params: AcademicMentorshipCsvImportParams,
+  studentIds: string[]
+): Promise<Map<string, AcademicMentorshipImportMenteeRow>> {
   const menteeRows = await query<AcademicMentorshipImportMenteeRow>(
     `SELECT DISTINCT ON (TRIM(st.student_id))
        TRIM(st.student_id) AS student_id,
@@ -767,10 +818,14 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
      ORDER BY TRIM(st.student_id), active_mapping.id NULLS FIRST`,
     [params.schoolId, params.academicYear, studentIds]
   );
-  const menteeByStudentId = new Map(
-    menteeRows.map((row) => [row.student_id, row])
-  );
+  return new Map(menteeRows.map((row) => [row.student_id, row]));
+}
 
+function addAcademicMentorshipImportLookupErrors(
+  rows: AcademicMentorshipCsvRow[],
+  mentorByEmail: Map<string, number>,
+  menteeByStudentId: Map<string, AcademicMentorshipImportMenteeRow>
+) {
   for (const row of rows) {
     if (!mentorByEmail.has(row.mentorEmail.toLowerCase())) {
       row.errors.push("mentor_email is not an eligible Academic Mentor for this School");
@@ -782,37 +837,49 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
       row.errors.push("Student already has a mentor mapped");
     }
   }
-  const dbInvalidRows = rows.filter((row) => row.errors.length > 0);
-  if (dbInvalidRows.length > 0) {
-    return {
-      ok: false,
-      type: "rows",
-      errors: dbInvalidRows.flatMap((row) =>
-        row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
-      ),
-      errorCsv: buildAcademicMentorshipImportErrorCsv(header, dbInvalidRows),
-    };
-  }
+}
 
+function academicMentorshipImportValues(rowCount: number): string {
+  return Array.from({ length: rowCount }, (_, index) => {
+    const start = index * 6;
+    return `($${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, now(), now(), now())`;
+  }).join(", ");
+}
+
+function academicMentorshipImportParams(
+  params: AcademicMentorshipCsvImportParams,
+  rows: AcademicMentorshipCsvRow[],
+  mentorByEmail: Map<string, number>,
+  menteeByStudentId: Map<string, AcademicMentorshipImportMenteeRow>
+): unknown[] {
+  return rows.flatMap((row) => {
+    const mentee = menteeByStudentId.get(row.studentId)!;
+    return [
+      params.schoolId,
+      params.academicYear,
+      mentorByEmail.get(row.mentorEmail.toLowerCase())!,
+      Number(mentee.student_pk_id),
+      mentee.program_id === null ? null : Number(mentee.program_id),
+      params.assignedByUserId,
+    ];
+  });
+}
+
+async function insertAcademicMentorshipImportRows(
+  params: AcademicMentorshipCsvImportParams,
+  rows: AcademicMentorshipCsvRow[],
+  mentorByEmail: Map<string, number>,
+  menteeByStudentId: Map<string, AcademicMentorshipImportMenteeRow>
+): Promise<AcademicMentorshipCsvImportResult> {
   try {
     return await withTransaction(async (client) => {
-      const values = rows
-        .map((_, index) => {
-          const start = index * 6;
-          return `($${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, now(), now(), now())`;
-        })
-        .join(", ");
-      const insertParams = rows.flatMap((row) => {
-        const mentee = menteeByStudentId.get(row.studentId)!;
-        return [
-          params.schoolId,
-          params.academicYear,
-          mentorByEmail.get(row.mentorEmail.toLowerCase())!,
-          Number(mentee.student_pk_id),
-          mentee.program_id === null ? null : Number(mentee.program_id),
-          params.assignedByUserId,
-        ];
-      });
+      const values = academicMentorshipImportValues(rows.length);
+      const insertParams = academicMentorshipImportParams(
+        params,
+        rows,
+        mentorByEmail,
+        menteeByStudentId
+      );
       const inserted = await client.query<{ id: number | string }>(
         `INSERT INTO academic_mentorship_mentor_mentee_mappings
            (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, inserted_at, updated_at)
@@ -828,6 +895,31 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
     }
     throw error;
   }
+}
+
+export async function importAcademicMentorshipMappingsFromCsv(
+  params: AcademicMentorshipCsvImportParams
+): Promise<AcademicMentorshipCsvImportResult> {
+  const parsed = parseAcademicMentorshipCsv(params.csvText);
+  if (!parsed.ok) return parsed.result;
+
+  const { header, rows } = parsed;
+  const mentorByEmail = await loadAcademicMentorshipImportMentors(
+    params,
+    uniqueMentorEmails(rows)
+  );
+  const menteeByStudentId = await loadAcademicMentorshipImportMentees(
+    params,
+    uniqueStudentIds(rows)
+  );
+
+  addAcademicMentorshipImportLookupErrors(rows, mentorByEmail, menteeByStudentId);
+  const invalidRows = rows.filter((row) => row.errors.length > 0);
+  if (invalidRows.length > 0) {
+    return academicMentorshipCsvRowsFailure(header, invalidRows);
+  }
+
+  return insertAcademicMentorshipImportRows(params, rows, mentorByEmail, menteeByStudentId);
 }
 
 function csvCell(value: string): string {

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -33,6 +33,11 @@ export interface AcademicMentorshipProgram {
   name: string;
 }
 
+export interface AcademicMentorshipProgramSchoolLink {
+  programId: number;
+  schoolId: number;
+}
+
 export type AcademicMentorshipAccessResult =
   | { ok: true; email: string; permission: UserPermission; canEdit: boolean; school?: AcademicMentorshipSchool }
   | { ok: false; status: 401 | 403 | 404; error: "Unauthorized" | "Forbidden" | "School not found" };
@@ -1164,6 +1169,39 @@ export async function listAcademicMentorshipProgramsForSchools(
      ORDER BY p.name ASC`,
     [schoolIds, academicYear]
   );
+}
+
+export async function listAcademicMentorshipProgramSchoolLinks(
+  schoolIds: number[],
+  academicYear: string
+): Promise<AcademicMentorshipProgramSchoolLink[]> {
+  if (schoolIds.length === 0) return [];
+  const rows = await query<{ program_id: number | string; school_id: number | string }>(
+    `SELECT DISTINCT b.program_id, s.id AS school_id
+     FROM school s
+     JOIN "group" school_group
+       ON school_group.child_id = s.id
+      AND school_group.type = 'school'
+     JOIN group_user school_member
+       ON school_member.group_id = school_group.id
+     JOIN enrollment_record er
+       ON er.user_id = school_member.user_id
+      AND er.group_type = 'grade'
+      AND er.academic_year = $2
+     JOIN group_user batch_member
+       ON batch_member.user_id = school_member.user_id
+     JOIN "group" batch_group
+       ON batch_group.id = batch_member.group_id
+      AND batch_group.type = 'batch'
+     JOIN batch b
+       ON b.id = batch_group.child_id
+     WHERE s.id = ANY($1::bigint[])`,
+    [schoolIds, academicYear]
+  );
+  return rows.map((row) => ({
+    programId: Number(row.program_id),
+    schoolId: Number(row.school_id),
+  }));
 }
 
 export async function filterAcademicMentorshipSchoolsByProgram(

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -2,7 +2,7 @@ import {
   ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST,
   CURRENT_ACADEMIC_YEAR,
 } from "./constants";
-import { query } from "./db";
+import { query, withTransaction } from "./db";
 import {
   canAccessSchoolSync,
   getFeatureAccess,
@@ -13,6 +13,7 @@ import {
 } from "./permissions";
 
 export type AcademicMentorshipAction = "view" | "edit";
+type QueryRows = <T>(text: string, params?: unknown[]) => Promise<T[]>;
 
 export type AcademicMentorshipSession = {
   user?: { email?: string | null } | null;
@@ -383,12 +384,18 @@ async function hasEligibleAcademicMentor(params: {
   return rows.length > 0;
 }
 
-async function getEligibleMenteeProgram(params: {
-  schoolId: number;
-  academicYear: string;
-  studentPkId: number;
-}): Promise<number | null | undefined> {
-  const rows = await query<{ student_pk_id: number | string; program_id: number | string | null }>(
+async function getEligibleMenteeProgramWithQuery(
+  runQuery: QueryRows,
+  params: {
+    schoolId: number;
+    academicYear: string;
+    studentPkId: number;
+  }
+): Promise<number | null | undefined> {
+  const rows = await runQuery<{
+    student_pk_id: number | string;
+    program_id: number | string | null;
+  }>(
     `SELECT st.id AS student_pk_id, roster_program.program_id
      FROM group_user gu
      JOIN "group" g ON g.id = gu.group_id
@@ -417,6 +424,14 @@ async function getEligibleMenteeProgram(params: {
   );
   if (rows.length === 0) return undefined;
   return rows[0].program_id === null ? null : Number(rows[0].program_id);
+}
+
+async function getEligibleMenteeProgram(params: {
+  schoolId: number;
+  academicYear: string;
+  studentPkId: number;
+}): Promise<number | null | undefined> {
+  return getEligibleMenteeProgramWithQuery(query, params);
 }
 
 export async function createAcademicMentorshipMapping(params: {
@@ -521,6 +536,114 @@ export async function endAcademicMentorshipMapping(params: {
   }
 
   return { ok: true, mappingId: Number(updated[0].id) };
+}
+
+export async function reassignAcademicMentorshipMapping(params: {
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  academicYear: string;
+  mappingId: number;
+  replacementMentorUserId: number;
+  assignedByUserId: number;
+}): Promise<AcademicMentorshipMutationResult> {
+  const mentorOk = await hasEligibleAcademicMentor({
+    schoolId: params.schoolId,
+    schoolCode: params.schoolCode,
+    schoolRegion: params.schoolRegion,
+    mentorUserId: params.replacementMentorUserId,
+  });
+  if (!mentorOk) {
+    return {
+      ok: false,
+      status: 422,
+      error: "Academic Mentor is not eligible for this School",
+    };
+  }
+
+  try {
+    return await withTransaction(async (client) => {
+      const runQuery: QueryRows = async (text, values) => {
+        const result = await client.query(text, values);
+        return result.rows;
+      };
+      const activeRows = await runQuery<{
+        student_id: number | string;
+        mentor_user_id: number | string;
+      }>(
+        `SELECT student_id, mentor_user_id
+         FROM academic_mentorship_mentor_mentee_mappings
+         WHERE id = $1
+           AND school_id = $2
+           AND academic_year = $3
+           AND ended_at IS NULL
+         FOR UPDATE`,
+        [params.mappingId, params.schoolId, params.academicYear]
+      );
+      if (activeRows.length === 0) {
+        return { ok: false, status: 404, error: "Active Mapping not found" };
+      }
+      if (Number(activeRows[0].mentor_user_id) === params.replacementMentorUserId) {
+        return {
+          ok: false,
+          status: 422,
+          error: "Replacement Academic Mentor must be different",
+        };
+      }
+
+      const studentPkId = Number(activeRows[0].student_id);
+      const programId = await getEligibleMenteeProgramWithQuery(runQuery, {
+        schoolId: params.schoolId,
+        academicYear: params.academicYear,
+        studentPkId,
+      });
+      if (programId === undefined) {
+        return {
+          ok: false,
+          status: 422,
+          error: "Mentee is not eligible for this School and academic year",
+        };
+      }
+
+      const ended = await runQuery<{ id: number | string }>(
+        `UPDATE academic_mentorship_mentor_mentee_mappings
+         SET ended_at = now(),
+             ended_by_user_id = $4,
+             updated_at = now()
+         WHERE id = $1
+           AND school_id = $2
+           AND academic_year = $3
+           AND ended_at IS NULL
+         RETURNING id`,
+        [params.mappingId, params.schoolId, params.academicYear, params.assignedByUserId]
+      );
+      if (ended.length === 0) {
+        return { ok: false, status: 404, error: "Active Mapping not found" };
+      }
+
+      const inserted = await runQuery<{ id: number | string }>(
+        `INSERT INTO academic_mentorship_mentor_mentee_mappings
+           (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, inserted_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, now(), now(), now())
+         RETURNING id`,
+        [
+          params.schoolId,
+          params.academicYear,
+          params.replacementMentorUserId,
+          studentPkId,
+          programId,
+          params.assignedByUserId,
+        ]
+      );
+
+      return { ok: true, mappingId: Number(inserted[0].id) };
+    });
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { ok: false, status: 409, error: "Student already has a mentor mapped" };
+    }
+    throw error;
+  }
 }
 
 export async function listAccessibleAcademicMentorshipSchools(

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -280,8 +280,8 @@ export async function listAcademicMentorshipMappings(params: {
        st.student_id AS mentee_student_id,
        gr.number AS mentee_grade,
        m.program_id,
-       m.assigned_at::date::text AS assigned_date,
-       m.ended_at::date::text AS ended_date
+       (m.assigned_at AT TIME ZONE 'Asia/Kolkata')::date::text AS assigned_date,
+       (m.ended_at AT TIME ZONE 'Asia/Kolkata')::date::text AS ended_date
      FROM academic_mentorship_mentor_mentee_mappings m
      JOIN "user" mentor ON mentor.id = m.mentor_user_id
      JOIN student st ON st.id = m.student_id
@@ -350,7 +350,7 @@ export async function listAcademicMentorshipTeacherMentees(params: {
        NULLIF(TRIM(COALESCE(mentee.first_name, '') || ' ' || COALESCE(mentee.last_name, '')), '') AS mentee_name,
        st.student_id AS mentee_student_id,
        gr.number AS mentee_grade,
-       m.assigned_at::date::text AS assigned_date
+       (m.assigned_at AT TIME ZONE 'Asia/Kolkata')::date::text AS assigned_date
      FROM academic_mentorship_mentor_mentee_mappings m
      JOIN student st ON st.id = m.student_id
      JOIN "user" mentee ON mentee.id = st.user_id

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -83,6 +83,38 @@ export interface AcademicMentorshipMappingGroup {
   }>;
 }
 
+export interface AcademicMentorshipMentorOption {
+  userId: number;
+  name: string;
+  email: string;
+}
+
+interface AcademicMentorshipMentorOptionRow {
+  user_id: number | string;
+  name: string | null;
+  email: string;
+}
+
+export interface AcademicMentorshipMenteeOption {
+  studentPkId: number;
+  name: string;
+  studentId: string | null;
+  grade: number | null;
+  programId: number | null;
+}
+
+interface AcademicMentorshipMenteeOptionRow {
+  student_pk_id: number | string;
+  name: string | null;
+  student_id: string | null;
+  grade: number | string | null;
+  program_id: number | string | null;
+}
+
+export type AcademicMentorshipMutationResult =
+  | { ok: true; mappingId: number }
+  | { ok: false; status: 404 | 409 | 422; error: string };
+
 function hasAcademicMentorshipProgramAccess(permission: UserPermission): boolean {
   if (ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST.includes("*")) return true;
   const allowed = new Set<number>(
@@ -202,6 +234,293 @@ export async function listAcademicMentorshipMappings(params: {
   }
 
   return [...groups.values()];
+}
+
+export async function listAcademicMentorshipMentorOptions(params: {
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  search?: string;
+}): Promise<AcademicMentorshipMentorOption[]> {
+  const search = `%${(params.search ?? "").trim()}%`;
+  const rows = await query<AcademicMentorshipMentorOptionRow>(
+    `SELECT
+       u.id AS user_id,
+       NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), '') AS name,
+       u.email
+     FROM teacher t
+     JOIN "user" u ON u.id = t.user_id
+     JOIN user_permission up
+       ON (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+      AND up.role = 'teacher'
+      AND up.revoked_at IS NULL
+     LEFT JOIN centre_positions cp
+       ON cp.user_id = u.id
+      AND cp.deleted_at IS NULL
+     LEFT JOIN centres c
+       ON c.id = cp.centre_id
+     WHERE t.is_af_teacher = true
+       AND t.exit_date IS NULL
+       AND (
+         up.level = 3
+         OR up.school_codes @> ARRAY[$1]::text[]
+         OR ($2::text IS NOT NULL AND up.regions @> ARRAY[$2]::text[])
+         OR c.school_id = $3
+       )
+       AND (
+         $4 = '%%'
+         OR u.email ILIKE $4
+         OR TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')) ILIKE $4
+       )
+     GROUP BY u.id, u.first_name, u.last_name, u.email
+     ORDER BY name ASC NULLS LAST, u.email ASC
+     LIMIT 50`,
+    [params.schoolCode, params.schoolRegion, params.schoolId, search]
+  );
+
+  return rows.map((row) => ({
+    userId: Number(row.user_id),
+    name: row.name || row.email,
+    email: row.email,
+  }));
+}
+
+export async function listAcademicMentorshipMenteeOptions(params: {
+  schoolId: number;
+  academicYear: string;
+  search?: string;
+}): Promise<AcademicMentorshipMenteeOption[]> {
+  const search = `%${(params.search ?? "").trim()}%`;
+  const rows = await query<AcademicMentorshipMenteeOptionRow>(
+    `SELECT
+       st.id AS student_pk_id,
+       NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), '') AS name,
+       st.student_id,
+       gr.number AS grade,
+       roster_program.program_id
+     FROM group_user gu
+     JOIN "group" g ON g.id = gu.group_id
+     JOIN "user" u ON u.id = gu.user_id
+     JOIN student st ON st.user_id = u.id
+     JOIN enrollment_record er_grade
+       ON er_grade.user_id = u.id
+      AND er_grade.group_type = 'grade'
+      AND er_grade.is_current = true
+      AND er_grade.academic_year = $2
+     LEFT JOIN grade gr ON gr.id = er_grade.group_id
+     LEFT JOIN LATERAL (
+       SELECT b.program_id
+       FROM group_user gu_batch
+       JOIN "group" g_batch ON g_batch.id = gu_batch.group_id AND g_batch.type = 'batch'
+       JOIN batch b ON b.id = g_batch.child_id
+       WHERE gu_batch.user_id = u.id
+       ORDER BY array_position(ARRAY[1, 2, 64]::int[], b.program_id)
+       LIMIT 1
+     ) roster_program ON true
+     LEFT JOIN academic_mentorship_mentor_mentee_mappings active_mapping
+       ON active_mapping.school_id = $1
+      AND active_mapping.academic_year = $2
+      AND active_mapping.student_id = st.id
+      AND active_mapping.ended_at IS NULL
+     WHERE g.type = 'school'
+       AND g.child_id = $1
+       AND st.status IS DISTINCT FROM 'dropout'
+       AND active_mapping.id IS NULL
+       AND (
+         $3 = '%%'
+         OR st.student_id ILIKE $3
+         OR TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')) ILIKE $3
+       )
+     ORDER BY gr.number ASC NULLS LAST, name ASC NULLS LAST, st.student_id ASC
+     LIMIT 50`,
+    [params.schoolId, params.academicYear, search]
+  );
+
+  return rows.map((row) => ({
+    studentPkId: Number(row.student_pk_id),
+    name: row.name || row.student_id || "Unknown student",
+    studentId: row.student_id,
+    grade: row.grade === null ? null : Number(row.grade),
+    programId: row.program_id === null ? null : Number(row.program_id),
+  }));
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === "23505";
+}
+
+async function hasEligibleAcademicMentor(params: {
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  mentorUserId: number;
+}): Promise<boolean> {
+  const rows = await query<{ user_id: number | string }>(
+    `SELECT u.id AS user_id
+     FROM teacher t
+     JOIN "user" u ON u.id = t.user_id
+     JOIN user_permission up
+       ON (up.user_id = u.id OR LOWER(up.email) = LOWER(u.email))
+      AND up.role = 'teacher'
+      AND up.revoked_at IS NULL
+     LEFT JOIN centre_positions cp
+       ON cp.user_id = u.id
+      AND cp.deleted_at IS NULL
+     LEFT JOIN centres c
+       ON c.id = cp.centre_id
+     WHERE t.is_af_teacher = true
+       AND t.exit_date IS NULL
+       AND u.id = $4
+       AND (
+         up.level = 3
+         OR up.school_codes @> ARRAY[$1]::text[]
+         OR ($2::text IS NOT NULL AND up.regions @> ARRAY[$2]::text[])
+         OR c.school_id = $3
+       )
+     LIMIT 1`,
+    [params.schoolCode, params.schoolRegion, params.schoolId, params.mentorUserId]
+  );
+  return rows.length > 0;
+}
+
+async function getEligibleMenteeProgram(params: {
+  schoolId: number;
+  academicYear: string;
+  studentPkId: number;
+}): Promise<number | null | undefined> {
+  const rows = await query<{ student_pk_id: number | string; program_id: number | string | null }>(
+    `SELECT st.id AS student_pk_id, roster_program.program_id
+     FROM group_user gu
+     JOIN "group" g ON g.id = gu.group_id
+     JOIN "user" u ON u.id = gu.user_id
+     JOIN student st ON st.user_id = u.id
+     JOIN enrollment_record er_grade
+       ON er_grade.user_id = u.id
+      AND er_grade.group_type = 'grade'
+      AND er_grade.is_current = true
+      AND er_grade.academic_year = $2
+     LEFT JOIN LATERAL (
+       SELECT b.program_id
+       FROM group_user gu_batch
+       JOIN "group" g_batch ON g_batch.id = gu_batch.group_id AND g_batch.type = 'batch'
+       JOIN batch b ON b.id = g_batch.child_id
+       WHERE gu_batch.user_id = u.id
+       ORDER BY array_position(ARRAY[1, 2, 64]::int[], b.program_id)
+       LIMIT 1
+     ) roster_program ON true
+     WHERE g.type = 'school'
+       AND g.child_id = $1
+       AND st.id = $3
+       AND st.status IS DISTINCT FROM 'dropout'
+     LIMIT 1`,
+    [params.schoolId, params.academicYear, params.studentPkId]
+  );
+  if (rows.length === 0) return undefined;
+  return rows[0].program_id === null ? null : Number(rows[0].program_id);
+}
+
+export async function createAcademicMentorshipMapping(params: {
+  schoolId: number;
+  schoolCode: string;
+  schoolRegion: string | null;
+  academicYear: string;
+  mentorUserId: number;
+  studentPkId: number;
+  assignedByUserId: number;
+}): Promise<AcademicMentorshipMutationResult> {
+  const mentorOk = await hasEligibleAcademicMentor(params);
+  if (!mentorOk) {
+    return {
+      ok: false,
+      status: 422,
+      error: "Academic Mentor is not eligible for this School",
+    };
+  }
+
+  const activeRows = await query<{ id: number | string }>(
+    `SELECT id
+     FROM academic_mentorship_mentor_mentee_mappings
+     WHERE school_id = $1
+       AND academic_year = $2
+       AND student_id = $3
+       AND ended_at IS NULL
+     LIMIT 1`,
+    [params.schoolId, params.academicYear, params.studentPkId]
+  );
+  if (activeRows.length > 0) {
+    return { ok: false, status: 409, error: "Student already has a mentor mapped" };
+  }
+
+  const programId = await getEligibleMenteeProgram(params);
+  if (programId === undefined) {
+    return {
+      ok: false,
+      status: 422,
+      error: "Mentee is not eligible for this School and academic year",
+    };
+  }
+
+  try {
+    const inserted = await query<{ id: number | string }>(
+      `INSERT INTO academic_mentorship_mentor_mentee_mappings
+         (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, inserted_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, now(), now(), now())
+       RETURNING id`,
+      [
+        params.schoolId,
+        params.academicYear,
+        params.mentorUserId,
+        params.studentPkId,
+        programId,
+        params.assignedByUserId,
+      ]
+    );
+    return { ok: true, mappingId: Number(inserted[0].id) };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { ok: false, status: 409, error: "Student already has a mentor mapped" };
+    }
+    throw error;
+  }
+}
+
+export async function getAcademicMentorshipActorUserId(
+  email: string,
+  permission: UserPermission
+): Promise<number | null> {
+  if (permission.user_id != null) return Number(permission.user_id);
+
+  const rows = await query<{ id: number | string }>(
+    `SELECT id FROM "user" WHERE LOWER(email) = LOWER($1) ORDER BY id LIMIT 1`,
+    [email]
+  );
+  return rows.length > 0 ? Number(rows[0].id) : null;
+}
+
+export async function endAcademicMentorshipMapping(params: {
+  schoolId: number;
+  academicYear: string;
+  mappingId: number;
+  endedByUserId: number;
+}): Promise<AcademicMentorshipMutationResult> {
+  const updated = await query<{ id: number | string }>(
+    `UPDATE academic_mentorship_mentor_mentee_mappings
+     SET ended_at = now(),
+         ended_by_user_id = $4,
+         updated_at = now()
+     WHERE id = $1
+       AND school_id = $2
+       AND academic_year = $3
+       AND ended_at IS NULL
+     RETURNING id`,
+    [params.mappingId, params.schoolId, params.academicYear, params.endedByUserId]
+  );
+
+  if (updated.length === 0) {
+    return { ok: false, status: 404, error: "Active Mapping not found" };
+  }
+
+  return { ok: true, mappingId: Number(updated[0].id) };
 }
 
 export async function listAccessibleAcademicMentorshipSchools(

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -28,6 +28,11 @@ export interface AcademicMentorshipSchool {
   region: string | null;
 }
 
+export interface AcademicMentorshipProgram {
+  id: number;
+  name: string;
+}
+
 export type AcademicMentorshipAccessResult =
   | { ok: true; email: string; permission: UserPermission; canEdit: boolean; school?: AcademicMentorshipSchool }
   | { ok: false; status: 401 | 403 | 404; error: "Unauthorized" | "Forbidden" | "School not found" };
@@ -48,7 +53,7 @@ export function getAcademicMentorshipAcademicYears(
 }
 
 export function isAcademicMentorshipEditableYear(year: string): boolean {
-  return getAcademicMentorshipAcademicYears().includes(year);
+  return year === CURRENT_ACADEMIC_YEAR;
 }
 
 interface AcademicMentorshipMappingRow {
@@ -60,6 +65,7 @@ interface AcademicMentorshipMappingRow {
   mentee_name: string | null;
   mentee_student_id: string | null;
   mentee_grade: number | null;
+  program_id: number | string | null;
   assigned_date: string;
   ended_date: string | null;
 }
@@ -86,6 +92,7 @@ export interface AcademicMentorshipMappingGroup {
       name: string;
       studentId: string | null;
       grade: number | null;
+      programId: number | null;
     };
     assignedDate: string;
     endedDate: string | null;
@@ -245,6 +252,7 @@ export async function listAcademicMentorshipMappings(params: {
   schoolId: number;
   academicYear: string;
   includeHistory: boolean;
+  programId?: number | null;
 }): Promise<AcademicMentorshipMappingGroup[]> {
   const rows = await query<AcademicMentorshipMappingRow>(
     `SELECT
@@ -256,6 +264,7 @@ export async function listAcademicMentorshipMappings(params: {
        NULLIF(TRIM(COALESCE(mentee.first_name, '') || ' ' || COALESCE(mentee.last_name, '')), '') AS mentee_name,
        st.student_id AS mentee_student_id,
        gr.number AS mentee_grade,
+       m.program_id,
        m.assigned_at::date::text AS assigned_date,
        m.ended_at::date::text AS ended_date
      FROM academic_mentorship_mentor_mentee_mappings m
@@ -275,8 +284,9 @@ export async function listAcademicMentorshipMappings(params: {
      WHERE m.school_id = $1
        AND m.academic_year = $2
        AND ($3::boolean OR m.ended_at IS NULL)
+       AND ($4::int IS NULL OR m.program_id = $4)
      ORDER BY mentor_name ASC NULLS LAST, mentor.email ASC, gr.number ASC NULLS LAST, mentee_name ASC NULLS LAST, st.student_id ASC`,
-    [params.schoolId, params.academicYear, params.includeHistory]
+    [params.schoolId, params.academicYear, params.includeHistory, params.programId ?? null]
   );
 
   const groups = new Map<number, AcademicMentorshipMappingGroup>();
@@ -301,6 +311,7 @@ export async function listAcademicMentorshipMappings(params: {
         name: row.mentee_name || row.mentee_student_id || "Unknown student",
         studentId: row.mentee_student_id,
         grade: row.mentee_grade === null ? null : Number(row.mentee_grade),
+        programId: row.program_id === null ? null : Number(row.program_id),
       },
       assignedDate: row.assigned_date,
       endedDate: row.ended_date,
@@ -407,6 +418,7 @@ export async function listAcademicMentorshipMentorOptions(params: {
 export async function listAcademicMentorshipMenteeOptions(params: {
   schoolId: number;
   academicYear: string;
+  programId?: number | null;
   search?: string;
 }): Promise<AcademicMentorshipMenteeOption[]> {
   const search = `%${(params.search ?? "").trim()}%`;
@@ -449,6 +461,7 @@ export async function listAcademicMentorshipMenteeOptions(params: {
        AND g.child_id = $1
        AND st.status IS DISTINCT FROM 'dropout'
        AND active_mapping.id IS NULL
+       AND ($4::int IS NULL OR roster_program.program_id = $4)
        AND (
          $3 = '%%'
          OR st.student_id ILIKE $3
@@ -456,7 +469,7 @@ export async function listAcademicMentorshipMenteeOptions(params: {
        )
      ORDER BY gr.number ASC NULLS LAST, name ASC NULLS LAST, st.student_id ASC
      LIMIT 50`,
-    [params.schoolId, params.academicYear, search]
+    [params.schoolId, params.academicYear, search, params.programId ?? null]
   );
 
   return rows.map((row) => ({
@@ -1119,4 +1132,69 @@ export async function listAccessibleAcademicMentorshipSchools(
      ORDER BY name ASC, code ASC`,
     [schoolCodes]
   );
+}
+
+export async function listAcademicMentorshipProgramsForSchools(
+  schoolIds: number[],
+  academicYear: string
+): Promise<AcademicMentorshipProgram[]> {
+  if (schoolIds.length === 0) return [];
+  return query<AcademicMentorshipProgram>(
+    `SELECT DISTINCT p.id::int AS id, p.name
+     FROM school s
+     JOIN "group" school_group
+       ON school_group.child_id = s.id
+      AND school_group.type = 'school'
+     JOIN group_user school_member
+       ON school_member.group_id = school_group.id
+     JOIN enrollment_record er
+       ON er.user_id = school_member.user_id
+      AND er.group_type = 'grade'
+      AND er.academic_year = $2
+     JOIN group_user batch_member
+       ON batch_member.user_id = school_member.user_id
+     JOIN "group" batch_group
+       ON batch_group.id = batch_member.group_id
+      AND batch_group.type = 'batch'
+     JOIN batch b
+       ON b.id = batch_group.child_id
+     JOIN program p
+       ON p.id = b.program_id
+     WHERE s.id = ANY($1::bigint[])
+     ORDER BY p.name ASC`,
+    [schoolIds, academicYear]
+  );
+}
+
+export async function filterAcademicMentorshipSchoolsByProgram(
+  schools: AcademicMentorshipSchool[],
+  academicYear: string,
+  programId: number | null
+): Promise<AcademicMentorshipSchool[]> {
+  if (programId === null || schools.length === 0) return schools;
+  const rows = await query<{ id: number | string }>(
+    `SELECT DISTINCT s.id
+     FROM school s
+     JOIN "group" school_group
+       ON school_group.child_id = s.id
+      AND school_group.type = 'school'
+     JOIN group_user school_member
+       ON school_member.group_id = school_group.id
+     JOIN enrollment_record er
+       ON er.user_id = school_member.user_id
+      AND er.group_type = 'grade'
+      AND er.academic_year = $2
+     JOIN group_user batch_member
+       ON batch_member.user_id = school_member.user_id
+     JOIN "group" batch_group
+       ON batch_group.id = batch_member.group_id
+      AND batch_group.type = 'batch'
+     JOIN batch b
+       ON b.id = batch_group.child_id
+     WHERE s.id = ANY($1::bigint[])
+       AND b.program_id = $3`,
+    [schools.map((school) => school.id), academicYear, programId]
+  );
+  const matchingIds = new Set(rows.map((row) => Number(row.id)));
+  return schools.filter((school) => matchingIds.has(school.id));
 }

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -1,0 +1,228 @@
+import {
+  ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST,
+  CURRENT_ACADEMIC_YEAR,
+} from "./constants";
+import { query } from "./db";
+import {
+  canAccessSchoolSync,
+  getFeatureAccess,
+  getAccessibleSchoolCodes,
+  getProgramContextSync,
+  getResolvedPermission,
+  type UserPermission,
+} from "./permissions";
+
+export type AcademicMentorshipAction = "view" | "edit";
+
+export type AcademicMentorshipSession = {
+  user?: { email?: string | null } | null;
+  isPasscodeUser?: boolean;
+} | null;
+
+export interface AcademicMentorshipSchool {
+  id: number;
+  code: string;
+  name: string;
+  region: string | null;
+}
+
+export type AcademicMentorshipAccessResult =
+  | { ok: true; email: string; permission: UserPermission; canEdit: boolean; school?: AcademicMentorshipSchool }
+  | { ok: false; status: 401 | 403 | 404; error: "Unauthorized" | "Forbidden" | "School not found" };
+
+export function isValidAcademicYear(value: string): boolean {
+  const match = /^(\d{4})-(\d{4})$/.exec(value);
+  return !!match && Number(match[2]) === Number(match[1]) + 1;
+}
+
+export function getAcademicMentorshipAcademicYears(
+  currentAcademicYear = CURRENT_ACADEMIC_YEAR
+): string[] {
+  const start = Number(currentAcademicYear.slice(0, 4));
+  return [0, 1, 2].map((offset) => {
+    const year = start - offset;
+    return `${year}-${year + 1}`;
+  });
+}
+
+export function isAcademicMentorshipEditableYear(year: string): boolean {
+  return getAcademicMentorshipAcademicYears().includes(year);
+}
+
+interface AcademicMentorshipMappingRow {
+  id: number | string;
+  mentor_user_id: number | string;
+  mentor_name: string | null;
+  mentor_email: string | null;
+  student_pk_id: number | string;
+  mentee_name: string | null;
+  mentee_student_id: string | null;
+  mentee_grade: number | null;
+  assigned_date: string;
+  ended_date: string | null;
+}
+
+export interface AcademicMentorshipMappingGroup {
+  mentor: {
+    userId: number;
+    name: string;
+    email: string | null;
+  };
+  menteeCount: number;
+  mappings: Array<{
+    id: number | string;
+    mentee: {
+      studentPkId: number;
+      name: string;
+      studentId: string | null;
+      grade: number | null;
+    };
+    assignedDate: string;
+    endedDate: string | null;
+    status: "active" | "historical";
+  }>;
+}
+
+function hasAcademicMentorshipProgramAccess(permission: UserPermission): boolean {
+  if (ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST.includes("*")) return true;
+  const allowed = new Set<number>(
+    ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST.map((id) => Number(id))
+  );
+  const context = getProgramContextSync(permission);
+  return context.programIds.some((id) => allowed.has(id));
+}
+
+export async function requireAcademicMentorshipAccess(
+  session: AcademicMentorshipSession,
+  _action: AcademicMentorshipAction,
+  options: { schoolCode?: string } = {}
+): Promise<AcademicMentorshipAccessResult> {
+  const email = session?.user?.email;
+  if (!email) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+  if (session.isPasscodeUser) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  const permission = await getResolvedPermission(email);
+  if (!permission || !hasAcademicMentorshipProgramAccess(permission)) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  const access = getFeatureAccess(permission, "academic_mentorship");
+  if (!access.canView || (_action === "edit" && !access.canEdit)) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  if (options.schoolCode) {
+    const schools = await query<AcademicMentorshipSchool>(
+      `SELECT id, code, name, region
+       FROM school
+       WHERE code = $1
+       LIMIT 1`,
+      [options.schoolCode]
+    );
+    const school = schools[0];
+    if (!school) {
+      return { ok: false, status: 404, error: "School not found" };
+    }
+    if (!canAccessSchoolSync(permission, school.code, school.region ?? undefined)) {
+      return { ok: false, status: 403, error: "Forbidden" };
+    }
+    return { ok: true, email, permission, canEdit: access.canEdit, school };
+  }
+
+  return { ok: true, email, permission, canEdit: access.canEdit };
+}
+
+export async function listAcademicMentorshipMappings(params: {
+  schoolId: number;
+  academicYear: string;
+  includeHistory: boolean;
+}): Promise<AcademicMentorshipMappingGroup[]> {
+  const rows = await query<AcademicMentorshipMappingRow>(
+    `SELECT
+       m.id,
+       m.mentor_user_id,
+       NULLIF(TRIM(COALESCE(mentor.first_name, '') || ' ' || COALESCE(mentor.last_name, '')), '') AS mentor_name,
+       mentor.email AS mentor_email,
+       st.id AS student_pk_id,
+       NULLIF(TRIM(COALESCE(mentee.first_name, '') || ' ' || COALESCE(mentee.last_name, '')), '') AS mentee_name,
+       st.student_id AS mentee_student_id,
+       gr.number AS mentee_grade,
+       m.assigned_at::date::text AS assigned_date,
+       m.ended_at::date::text AS ended_date
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN "user" mentor ON mentor.id = m.mentor_user_id
+     JOIN student st ON st.id = m.student_id
+     JOIN "user" mentee ON mentee.id = st.user_id
+     LEFT JOIN enrollment_record er_grade
+       ON er_grade.user_id = mentee.id
+      AND er_grade.group_type = 'grade'
+      AND er_grade.is_current = true
+      AND er_grade.academic_year = m.academic_year
+     LEFT JOIN grade gr ON gr.id = er_grade.group_id
+     WHERE m.school_id = $1
+       AND m.academic_year = $2
+       AND ($3::boolean OR m.ended_at IS NULL)
+     ORDER BY mentor_name ASC NULLS LAST, mentor.email ASC, gr.number ASC NULLS LAST, mentee_name ASC NULLS LAST, st.student_id ASC`,
+    [params.schoolId, params.academicYear, params.includeHistory]
+  );
+
+  const groups = new Map<number, AcademicMentorshipMappingGroup>();
+  for (const row of rows) {
+    const mentorUserId = Number(row.mentor_user_id);
+    const mentorName = row.mentor_name || row.mentor_email || "Unknown mentor";
+    const group =
+      groups.get(mentorUserId) ??
+      {
+        mentor: {
+          userId: mentorUserId,
+          name: mentorName,
+          email: row.mentor_email,
+        },
+        menteeCount: 0,
+        mappings: [],
+      };
+    group.mappings.push({
+      id: row.id,
+      mentee: {
+        studentPkId: Number(row.student_pk_id),
+        name: row.mentee_name || row.mentee_student_id || "Unknown student",
+        studentId: row.mentee_student_id,
+        grade: row.mentee_grade === null ? null : Number(row.mentee_grade),
+      },
+      assignedDate: row.assigned_date,
+      endedDate: row.ended_date,
+      status: row.ended_date ? "historical" : "active",
+    });
+    group.menteeCount = group.mappings.length;
+    groups.set(mentorUserId, group);
+  }
+
+  return [...groups.values()];
+}
+
+export async function listAccessibleAcademicMentorshipSchools(
+  permission: UserPermission
+): Promise<AcademicMentorshipSchool[]> {
+  const schoolCodes = await getAccessibleSchoolCodes(permission.email, permission);
+  if (schoolCodes !== "all" && schoolCodes.length === 0) return [];
+
+  if (schoolCodes === "all") {
+    return query<AcademicMentorshipSchool>(
+      `SELECT id, code, name, region
+       FROM school
+       ORDER BY name ASC, code ASC`
+    );
+  }
+
+  return query<AcademicMentorshipSchool>(
+    `SELECT id, code, name, region
+     FROM school
+     WHERE code = ANY($1)
+     ORDER BY name ASC, code ASC`,
+    [schoolCodes]
+  );
+}

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -64,6 +64,14 @@ interface AcademicMentorshipMappingRow {
   ended_date: string | null;
 }
 
+interface AcademicMentorshipTeacherMenteeRow {
+  student_pk_id: number | string;
+  mentee_name: string | null;
+  mentee_student_id: string | null;
+  mentee_grade: number | null;
+  assigned_date: string;
+}
+
 export interface AcademicMentorshipMappingGroup {
   mentor: {
     userId: number;
@@ -83,6 +91,14 @@ export interface AcademicMentorshipMappingGroup {
     endedDate: string | null;
     status: "active" | "historical";
   }>;
+}
+
+export interface AcademicMentorshipTeacherMentee {
+  studentPkId: number;
+  name: string;
+  studentId: string | null;
+  grade: number | null;
+  assignedDate: string;
 }
 
 export interface AcademicMentorshipMentorOption {
@@ -266,6 +282,45 @@ export async function listAcademicMentorshipMappings(params: {
   }
 
   return [...groups.values()];
+}
+
+export async function listAcademicMentorshipTeacherMentees(params: {
+  schoolId: number;
+  academicYear: string;
+  mentorEmail: string;
+}): Promise<AcademicMentorshipTeacherMentee[]> {
+  const rows = await query<AcademicMentorshipTeacherMenteeRow>(
+    `SELECT
+       st.id AS student_pk_id,
+       NULLIF(TRIM(COALESCE(mentee.first_name, '') || ' ' || COALESCE(mentee.last_name, '')), '') AS mentee_name,
+       st.student_id AS mentee_student_id,
+       gr.number AS mentee_grade,
+       m.assigned_at::date::text AS assigned_date
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN "user" mentor ON mentor.id = m.mentor_user_id
+     JOIN student st ON st.id = m.student_id
+     JOIN "user" mentee ON mentee.id = st.user_id
+     LEFT JOIN enrollment_record er_grade
+       ON er_grade.user_id = mentee.id
+      AND er_grade.group_type = 'grade'
+      AND er_grade.is_current = true
+      AND er_grade.academic_year = m.academic_year
+     LEFT JOIN grade gr ON gr.id = er_grade.group_id
+     WHERE m.school_id = $1
+       AND m.academic_year = $2
+       AND LOWER(mentor.email) = LOWER($3)
+       AND m.ended_at IS NULL
+     ORDER BY gr.number ASC NULLS LAST, mentee_name ASC NULLS LAST, st.student_id ASC`,
+    [params.schoolId, params.academicYear, params.mentorEmail]
+  );
+
+  return rows.map((row) => ({
+    studentPkId: Number(row.student_pk_id),
+    name: row.mentee_name || row.mentee_student_id || "Unknown student",
+    studentId: row.mentee_student_id,
+    grade: row.mentee_grade === null ? null : Number(row.mentee_grade),
+    assignedDate: row.assigned_date,
+  }));
 }
 
 export async function listAcademicMentorshipMentorOptions(params: {

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -191,6 +191,19 @@ export function isAcademicMentorshipManagementRole(
   return permission.role === "admin" || permission.role === "program_admin";
 }
 
+async function findAcademicMentorshipSchool(
+  schoolCode: string
+): Promise<AcademicMentorshipSchool | null> {
+  const rows = await query<AcademicMentorshipSchool>(
+    `SELECT id, code, name, region
+     FROM school
+     WHERE code = $1
+     LIMIT 1`,
+    [schoolCode]
+  );
+  return rows[0] ?? null;
+}
+
 export async function requireAcademicMentorshipAccess(
   session: AcademicMentorshipSession,
   _action: AcademicMentorshipAction,
@@ -215,14 +228,7 @@ export async function requireAcademicMentorshipAccess(
   }
 
   if (options.schoolCode) {
-    const schools = await query<AcademicMentorshipSchool>(
-      `SELECT id, code, name, region
-       FROM school
-       WHERE code = $1
-       LIMIT 1`,
-      [options.schoolCode]
-    );
-    const school = schools[0];
+    const school = await findAcademicMentorshipSchool(options.schoolCode);
     if (!school) {
       return { ok: false, status: 404, error: "School not found" };
     }

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -61,6 +61,10 @@ export function getAcademicMentorshipAcademicYears(
   });
 }
 
+export function isAcademicMentorshipSupportedYear(year: string): boolean {
+  return getAcademicMentorshipAcademicYears().includes(year);
+}
+
 export function isAcademicMentorshipEditableYear(year: string): boolean {
   return year === CURRENT_ACADEMIC_YEAR;
 }
@@ -877,10 +881,12 @@ function addAcademicMentorshipImportLookupErrors(
   }
 }
 
-function academicMentorshipImportValues(rowCount: number): string {
+function academicMentorshipImportValues(rowCount: number, historical: boolean): string {
   return Array.from({ length: rowCount }, (_, index) => {
     const start = index * 6;
-    return `($${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, now(), now(), now())`;
+    const endedAt = historical ? "now()" : "NULL";
+    const endedBy = historical ? `$${start + 6}` : "NULL";
+    return `($${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, now(), ${endedAt}, ${endedBy}, now(), now())`;
   }).join(", ");
 }
 
@@ -911,7 +917,10 @@ async function insertAcademicMentorshipImportRows(
 ): Promise<AcademicMentorshipCsvImportResult> {
   try {
     return await withTransaction(async (client) => {
-      const values = academicMentorshipImportValues(rows.length);
+      const values = academicMentorshipImportValues(
+        rows.length,
+        !isAcademicMentorshipEditableYear(params.academicYear)
+      );
       const insertParams = academicMentorshipImportParams(
         params,
         rows,
@@ -920,7 +929,7 @@ async function insertAcademicMentorshipImportRows(
       );
       const inserted = await client.query<{ id: number | string }>(
         `INSERT INTO academic_mentorship_mentor_mentee_mappings
-           (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, inserted_at, updated_at)
+           (school_id, academic_year, mentor_user_id, student_id, program_id, assigned_by_user_id, assigned_at, ended_at, ended_by_user_id, inserted_at, updated_at)
          VALUES ${values}
          RETURNING id`,
         insertParams

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -761,20 +761,15 @@ function parseAcademicMentorshipCsv(csvText: string): AcademicMentorshipParsedCs
   if (rowLimitError) return csvFileParseFailure(rowLimitError);
 
   addDuplicateStudentIdErrors(rows);
-  const invalidRows = rows.filter((row) => row.errors.length > 0);
-  if (invalidRows.length > 0) {
-    return { ok: false, result: academicMentorshipCsvRowsFailure(header, invalidRows) };
-  }
-
   return { ok: true, header, rows };
 }
 
 function uniqueMentorEmails(rows: AcademicMentorshipCsvRow[]): string[] {
-  return [...new Set(rows.map((row) => row.mentorEmail.toLowerCase()))];
+  return [...new Set(rows.map((row) => row.mentorEmail.toLowerCase()).filter(Boolean))];
 }
 
 function uniqueStudentIds(rows: AcademicMentorshipCsvRow[]): string[] {
-  return [...new Set(rows.map((row) => row.studentId))];
+  return [...new Set(rows.map((row) => row.studentId).filter(Boolean))];
 }
 
 async function loadAcademicMentorshipImportMentors(
@@ -864,19 +859,19 @@ function addAcademicMentorshipImportLookupErrors(
   menteeByStudentId: Map<string, AcademicMentorshipImportMenteeRow>
 ) {
   for (const row of rows) {
-    if (!mentorByEmail.has(row.mentorEmail.toLowerCase())) {
+    if (row.mentorEmail && !mentorByEmail.has(row.mentorEmail.toLowerCase())) {
       row.errors.push({
         field: "mentor_email",
         error: "mentor_email is not an eligible Academic Mentor for this School",
       });
     }
     const mentee = menteeByStudentId.get(row.studentId);
-    if (!mentee) {
+    if (row.studentId && !mentee) {
       row.errors.push({
         field: "student_id",
         error: "student_id is not an eligible Mentee for this School and academic year",
       });
-    } else if (mentee.active_mapping_id != null) {
+    } else if (mentee?.active_mapping_id != null) {
       row.errors.push({ field: "student_id", error: "Student already has a mentor mapped" });
     }
   }

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -28,6 +28,10 @@ export interface AcademicMentorshipSchool {
   region: string | null;
 }
 
+interface AcademicMentorshipSchoolRow extends Omit<AcademicMentorshipSchool, "id"> {
+  id: number | string;
+}
+
 export interface AcademicMentorshipProgram {
   id: number;
   name: string;
@@ -206,14 +210,14 @@ export function isAcademicMentorshipManagementRole(
 async function findAcademicMentorshipSchool(
   schoolCode: string
 ): Promise<AcademicMentorshipSchool | null> {
-  const rows = await query<AcademicMentorshipSchool>(
+  const rows = await query<AcademicMentorshipSchoolRow>(
     `SELECT id, code, name, region
      FROM school
      WHERE code = $1
      LIMIT 1`,
     [schoolCode]
   );
-  return rows[0] ?? null;
+  return rows[0] ? { ...rows[0], id: Number(rows[0].id) } : null;
 }
 
 export async function requireAcademicMentorshipAccess(
@@ -1123,20 +1127,22 @@ export async function listAccessibleAcademicMentorshipSchools(
   if (schoolCodes !== "all" && schoolCodes.length === 0) return [];
 
   if (schoolCodes === "all") {
-    return query<AcademicMentorshipSchool>(
+    const rows = await query<AcademicMentorshipSchoolRow>(
       `SELECT id, code, name, region
        FROM school
        ORDER BY name ASC, code ASC`
     );
+    return rows.map((school) => ({ ...school, id: Number(school.id) }));
   }
 
-  return query<AcademicMentorshipSchool>(
+  const rows = await query<AcademicMentorshipSchoolRow>(
     `SELECT id, code, name, region
      FROM school
      WHERE code = ANY($1)
      ORDER BY name ASC, code ASC`,
     [schoolCodes]
   );
+  return rows.map((school) => ({ ...school, id: Number(school.id) }));
 }
 
 export async function listAcademicMentorshipProgramsForSchools(

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -155,16 +155,22 @@ export type AcademicMentorshipCsvImportResult =
   | {
       ok: false;
       type: "rows";
-      errors: Array<{ rowNumber: number; error: string }>;
+      errors: Array<{ rowNumber: number; field: AcademicMentorshipCsvField; error: string }>;
       errorCsv: string;
     };
+
+type AcademicMentorshipCsvField = "mentor_email" | "student_id";
+interface AcademicMentorshipCsvRowError {
+  field: AcademicMentorshipCsvField;
+  error: string;
+}
 
 interface AcademicMentorshipCsvRow {
   rowNumber: number;
   values: Record<string, string>;
   mentorEmail: string;
   studentId: string;
-  errors: string[];
+  errors: AcademicMentorshipCsvRowError[];
 }
 
 interface AcademicMentorshipImportMentorRow {
@@ -690,9 +696,9 @@ function buildAcademicMentorshipCsvRow(
   );
   const mentorEmail = (values.mentor_email ?? "").trim();
   const studentId = (values.student_id ?? "").trim();
-  const errors: string[] = [];
-  if (!mentorEmail) errors.push("mentor_email is required");
-  if (!studentId) errors.push("student_id is required");
+  const errors: AcademicMentorshipCsvRowError[] = [];
+  if (!mentorEmail) errors.push({ field: "mentor_email", error: "mentor_email is required" });
+  if (!studentId) errors.push({ field: "student_id", error: "student_id is required" });
   return { rowNumber, values, mentorEmail, studentId, errors };
 }
 
@@ -720,7 +726,10 @@ function addDuplicateStudentIdErrors(rows: AcademicMentorshipCsvRow[]) {
     if (duplicateRows.length < 2) continue;
     const rowNumbers = duplicateRows.map((row) => row.rowNumber).join(", ");
     for (const row of duplicateRows) {
-      row.errors.push(`Duplicate student_id ${studentId} in rows ${rowNumbers}`);
+      row.errors.push({
+        field: "student_id",
+        error: `Duplicate student_id ${studentId} in rows ${rowNumbers}`,
+      });
     }
   }
 }
@@ -733,7 +742,7 @@ function academicMentorshipCsvRowsFailure(
     ok: false,
     type: "rows",
     errors: invalidRows.flatMap((row) =>
-      row.errors.map((error) => ({ rowNumber: row.rowNumber, error }))
+      row.errors.map((error) => ({ rowNumber: row.rowNumber, ...error }))
     ),
     errorCsv: buildAcademicMentorshipImportErrorCsv(header, invalidRows),
   };
@@ -856,13 +865,19 @@ function addAcademicMentorshipImportLookupErrors(
 ) {
   for (const row of rows) {
     if (!mentorByEmail.has(row.mentorEmail.toLowerCase())) {
-      row.errors.push("mentor_email is not an eligible Academic Mentor for this School");
+      row.errors.push({
+        field: "mentor_email",
+        error: "mentor_email is not an eligible Academic Mentor for this School",
+      });
     }
     const mentee = menteeByStudentId.get(row.studentId);
     if (!mentee) {
-      row.errors.push("student_id is not an eligible Mentee for this School and academic year");
+      row.errors.push({
+        field: "student_id",
+        error: "student_id is not an eligible Mentee for this School and academic year",
+      });
     } else if (mentee.active_mapping_id != null) {
-      row.errors.push("Student already has a mentor mapped");
+      row.errors.push({ field: "student_id", error: "Student already has a mentor mapped" });
     }
   }
 }
@@ -964,7 +979,7 @@ function buildAcademicMentorshipImportErrorCsv(
     ...rows.map((row) =>
       [
         ...header.map((column) => row.values[column] ?? ""),
-        row.errors.join("; "),
+        row.errors.map(({ error }) => error).join("; "),
       ]
         .map(csvCell)
         .join(",")

--- a/src/lib/academic-mentorship.ts
+++ b/src/lib/academic-mentorship.ts
@@ -172,6 +172,12 @@ function hasAcademicMentorshipProgramAccess(permission: UserPermission): boolean
   return context.programIds.some((id) => allowed.has(id));
 }
 
+export function isAcademicMentorshipManagementRole(
+  permission: UserPermission
+): boolean {
+  return permission.role === "admin" || permission.role === "program_admin";
+}
+
 export async function requireAcademicMentorshipAccess(
   session: AcademicMentorshipSession,
   _action: AcademicMentorshipAction,
@@ -237,11 +243,15 @@ export async function listAcademicMentorshipMappings(params: {
      JOIN "user" mentor ON mentor.id = m.mentor_user_id
      JOIN student st ON st.id = m.student_id
      JOIN "user" mentee ON mentee.id = st.user_id
-     LEFT JOIN enrollment_record er_grade
-       ON er_grade.user_id = mentee.id
-      AND er_grade.group_type = 'grade'
-      AND er_grade.is_current = true
-      AND er_grade.academic_year = m.academic_year
+     LEFT JOIN LATERAL (
+       SELECT er.group_id
+       FROM enrollment_record er
+       WHERE er.user_id = mentee.id
+         AND er.group_type = 'grade'
+         AND er.academic_year = m.academic_year
+       ORDER BY er.is_current DESC, er.updated_at DESC NULLS LAST, er.id DESC
+       LIMIT 1
+     ) er_grade ON true
      LEFT JOIN grade gr ON gr.id = er_grade.group_id
      WHERE m.school_id = $1
        AND m.academic_year = $2
@@ -287,7 +297,7 @@ export async function listAcademicMentorshipMappings(params: {
 export async function listAcademicMentorshipTeacherMentees(params: {
   schoolId: number;
   academicYear: string;
-  mentorEmail: string;
+  mentorUserId: number;
 }): Promise<AcademicMentorshipTeacherMentee[]> {
   const rows = await query<AcademicMentorshipTeacherMenteeRow>(
     `SELECT
@@ -297,21 +307,24 @@ export async function listAcademicMentorshipTeacherMentees(params: {
        gr.number AS mentee_grade,
        m.assigned_at::date::text AS assigned_date
      FROM academic_mentorship_mentor_mentee_mappings m
-     JOIN "user" mentor ON mentor.id = m.mentor_user_id
      JOIN student st ON st.id = m.student_id
      JOIN "user" mentee ON mentee.id = st.user_id
-     LEFT JOIN enrollment_record er_grade
-       ON er_grade.user_id = mentee.id
-      AND er_grade.group_type = 'grade'
-      AND er_grade.is_current = true
-      AND er_grade.academic_year = m.academic_year
+     LEFT JOIN LATERAL (
+       SELECT er.group_id
+       FROM enrollment_record er
+       WHERE er.user_id = mentee.id
+         AND er.group_type = 'grade'
+         AND er.academic_year = m.academic_year
+       ORDER BY er.is_current DESC, er.updated_at DESC NULLS LAST, er.id DESC
+       LIMIT 1
+     ) er_grade ON true
      LEFT JOIN grade gr ON gr.id = er_grade.group_id
      WHERE m.school_id = $1
        AND m.academic_year = $2
-       AND LOWER(mentor.email) = LOWER($3)
+       AND m.mentor_user_id = $3
        AND m.ended_at IS NULL
      ORDER BY gr.number ASC NULLS LAST, mentee_name ASC NULLS LAST, st.student_id ASC`,
-    [params.schoolId, params.academicYear, params.mentorEmail]
+    [params.schoolId, params.academicYear, params.mentorUserId]
   );
 
   return rows.map((row) => ({
@@ -389,11 +402,15 @@ export async function listAcademicMentorshipMenteeOptions(params: {
      JOIN "group" g ON g.id = gu.group_id
      JOIN "user" u ON u.id = gu.user_id
      JOIN student st ON st.user_id = u.id
-     JOIN enrollment_record er_grade
-       ON er_grade.user_id = u.id
-      AND er_grade.group_type = 'grade'
-      AND er_grade.is_current = true
-      AND er_grade.academic_year = $2
+     JOIN LATERAL (
+       SELECT er.group_id
+       FROM enrollment_record er
+       WHERE er.user_id = u.id
+         AND er.group_type = 'grade'
+         AND er.academic_year = $2
+       ORDER BY er.is_current DESC, er.updated_at DESC NULLS LAST, er.id DESC
+       LIMIT 1
+     ) er_grade ON true
      LEFT JOIN grade gr ON gr.id = er_grade.group_id
      LEFT JOIN LATERAL (
        SELECT b.program_id
@@ -487,11 +504,15 @@ async function getEligibleMenteeProgramWithQuery(
      JOIN "group" g ON g.id = gu.group_id
      JOIN "user" u ON u.id = gu.user_id
      JOIN student st ON st.user_id = u.id
-     JOIN enrollment_record er_grade
-       ON er_grade.user_id = u.id
-      AND er_grade.group_type = 'grade'
-      AND er_grade.is_current = true
-      AND er_grade.academic_year = $2
+     JOIN LATERAL (
+       SELECT er.group_id
+       FROM enrollment_record er
+       WHERE er.user_id = u.id
+         AND er.group_type = 'grade'
+         AND er.academic_year = $2
+       ORDER BY er.is_current DESC, er.updated_at DESC NULLS LAST, er.id DESC
+       LIMIT 1
+     ) er_grade ON true
      LEFT JOIN LATERAL (
        SELECT b.program_id
        FROM group_user gu_batch
@@ -716,11 +737,15 @@ export async function importAcademicMentorshipMappingsFromCsv(params: {
      JOIN "group" g ON g.id = gu.group_id
      JOIN "user" u ON u.id = gu.user_id
      JOIN student st ON st.user_id = u.id
-     JOIN enrollment_record er_grade
-       ON er_grade.user_id = u.id
-      AND er_grade.group_type = 'grade'
-      AND er_grade.is_current = true
-      AND er_grade.academic_year = $2
+     JOIN LATERAL (
+       SELECT er.group_id
+       FROM enrollment_record er
+       WHERE er.user_id = u.id
+         AND er.group_type = 'grade'
+         AND er.academic_year = $2
+       ORDER BY er.is_current DESC, er.updated_at DESC NULLS LAST, er.id DESC
+       LIMIT 1
+     ) er_grade ON true
      LEFT JOIN LATERAL (
        SELECT b.program_id
        FROM group_user gu_batch

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,3 +30,5 @@ export const PROGRAM_ID_TO_LABEL: Record<number, string> = {
   [PROGRAM_IDS.PUNJAB_NODAL]: "Punjab Nodal",
   [PROGRAM_IDS.EMRS_COE]: "EMRS CoE",
 };
+
+export const ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST = ["*"] as const;

--- a/src/lib/csv-parser.test.ts
+++ b/src/lib/csv-parser.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCsvText } from "./csv-parser";
+
+describe("parseCsvText", () => {
+  it("parses CSV previews with quoted commas and missing values", () => {
+    expect(
+      parseCsvText(
+        '\uFEFFmentor_email,student_id,notes\r\n" Mentor@AvantiFellows.Org ","","needs, support"'
+      )
+    ).toEqual({
+      headers: ["mentor_email", "student_id", "notes"],
+      rows: [
+        {
+          mentor_email: "Mentor@AvantiFellows.Org",
+          student_id: "",
+          notes: "needs, support",
+        },
+      ],
+    });
+  });
+});

--- a/src/lib/csv-parser.ts
+++ b/src/lib/csv-parser.ts
@@ -1,0 +1,31 @@
+import { parse } from "csv-parse/browser/esm/sync";
+
+export interface ParsedCsv {
+  headers: string[];
+  rows: Record<string, string>[];
+}
+
+export function parseCsvText(text: string): ParsedCsv {
+  const records = (
+    parse(text, {
+      bom: true,
+      relax_column_count: true,
+      skip_empty_lines: true,
+      trim: true,
+    }) as string[][]
+  )
+    .map((row) => row.map((value) => value.trim()))
+    .filter((row) => row.some((value) => value.length > 0));
+
+  if (records.length === 0) return { headers: [], rows: [] };
+
+  const headers = records[0];
+  const rows = records.slice(1).map((record) =>
+    headers.reduce<Record<string, string>>((row, header, index) => {
+      row[header] = record[index] ?? "";
+      return row;
+    }, {})
+  );
+
+  return { headers, rows };
+}

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -236,6 +236,14 @@ describe("getFeatureAccess", () => {
       expect(result.canEdit).toBe(false);
     });
 
+    it("gives NVS-only program_admin edit on academic mentorship", () => {
+      const perm = makePermission({ role: "program_admin", program_ids: [PROGRAM_IDS.NVS] });
+      const result = getFeatureAccess(perm, "academic_mentorship");
+      expect(result.access).toBe("edit");
+      expect(result.canView).toBe(true);
+      expect(result.canEdit).toBe(true);
+    });
+
     it("gives admin edit on visits", () => {
       const perm = makePermission({ role: "admin" });
       const result = getFeatureAccess(perm, "visits");

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -3,11 +3,12 @@ import {
   PROGRAM_IDS,
   PROGRAM_IDS_ORDERED,
   PROGRAM_ID_TO_LABEL,
+  ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST,
 } from "./constants";
 
 // Re-exported from constants so existing `@/lib/permissions` imports keep
 // working while the definitions live in a client-safe module.
-export { PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL };
+export { PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL, ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST };
 
 // Permission levels (school scope only)
 export type AccessLevel = 1 | 2 | 3;
@@ -23,7 +24,7 @@ export type Feature =
   | "students"
   | "visits"
   | "curriculum"
-  | "mentorship"
+  | "academic_mentorship"
   | "performance"
   | "summary_stats"
   | "pm_dashboard"
@@ -37,7 +38,7 @@ const FEATURE_PERMISSIONS: Record<Feature, Record<UserRole, FeatureAccess>> = {
   students:      { teacher: "edit",  program_manager: "edit",  program_admin: "edit",  admin: "edit" },
   visits:        { teacher: "none",  program_manager: "edit",  program_admin: "view",  admin: "edit" },
   curriculum:    { teacher: "edit",  program_manager: "view",  program_admin: "edit",  admin: "edit" },
-  mentorship:    { teacher: "edit",  program_manager: "view",  program_admin: "edit",  admin: "edit" },
+  academic_mentorship: { teacher: "view",  program_manager: "view",  program_admin: "edit",  admin: "edit" },
   performance:   { teacher: "view",  program_manager: "view",  program_admin: "view",  admin: "view" },
   summary_stats: { teacher: "none",  program_manager: "view",  program_admin: "view",  admin: "view" },
   pm_dashboard:  { teacher: "none",  program_manager: "view",  program_admin: "view",  admin: "view" },
@@ -46,7 +47,7 @@ const FEATURE_PERMISSIONS: Record<Feature, Record<UserRole, FeatureAccess>> = {
 
 // Features gated to CoE/Nodal programs only (NVS-only users get "none")
 const NVS_GATED_FEATURES: Set<Feature> = new Set([
-  "visits", "curriculum", "mentorship", "pm_dashboard", "summary_stats", "quiz_sessions",
+  "visits", "curriculum", "pm_dashboard", "summary_stats", "quiz_sessions",
 ]);
 
 export interface FeatureAccessResult {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -3,12 +3,11 @@ import {
   PROGRAM_IDS,
   PROGRAM_IDS_ORDERED,
   PROGRAM_ID_TO_LABEL,
-  ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST,
 } from "./constants";
 
 // Re-exported from constants so existing `@/lib/permissions` imports keep
 // working while the definitions live in a client-safe module.
-export { PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL, ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST };
+export { PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL };
 
 // Permission levels (school scope only)
 export type AccessLevel = 1 | 2 | 3;

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -298,14 +298,16 @@ describe("updateTeacherRecord", () => {
     ).toMatchObject({ ok: false, status: 409 });
   });
 
-  it("PATCHes db-service and vacates seats on exit", async () => {
+  it("PATCHes db-service and vacates seats on exit when there are no active Academic Mentees", async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", mockFetch);
     vi.stubEnv("DB_SERVICE_URL", "https://db.example/api");
     vi.stubEnv("DB_SERVICE_TOKEN", "token");
 
     mockSchemaReady();
-    mockQuery.mockResolvedValueOnce([{ id: 1, user_id: 70 }]);
+    mockQuery
+      .mockResolvedValueOnce([{ id: 1, user_id: 70 }])
+      .mockResolvedValueOnce([]);
 
     const result = await updateTeacherRecord({
       id: 1,
@@ -316,9 +318,45 @@ describe("updateTeacherRecord", () => {
       "https://db.example/api/teacher/1",
       expect.objectContaining({ method: "PATCH" })
     );
+    const blockerCall = mockQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("academic_mentorship_mentor_mentee_mappings")
+    );
+    expect(String(blockerCall?.[0])).toContain("m.mentor_user_id = $1");
+    expect(String(blockerCall?.[0])).toContain("m.ended_at IS NULL");
+    expect(blockerCall?.[1]).toEqual([70]);
     const clientSql = mockClientQuery.mock.calls.map((call) => call[0]).join("\n");
     expect(clientSql).toContain("UPDATE centre_positions SET user_id = NULL");
     expect(clientSql).toContain("UPDATE user_permission SET revoked_at = now()");
+  });
+
+  it("blocks teacher exit when the teacher has active Academic Mentees", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubEnv("DB_SERVICE_URL", "https://db.example/api");
+    vi.stubEnv("DB_SERVICE_TOKEN", "token");
+
+    mockSchemaReady();
+    mockQuery
+      .mockResolvedValueOnce([{ id: 1, user_id: 70 }])
+      .mockResolvedValueOnce([
+        {
+          school_code: "54019",
+          academic_year: "2026-2027",
+          mentee_count: "2",
+        },
+      ]);
+
+    const result = await updateTeacherRecord({
+      id: 1,
+      body: { exit_date: "2026-06-12" },
+    });
+
+    expect(result).toMatchObject({ ok: false, status: 409 });
+    expect(result.error).toContain("2 active Mentees");
+    expect(result.error).toContain(
+      "/admin/academic-mentorship?school_code=54019&academic_year=2026-2027"
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("maps db-service failures to 422/502", async () => {

--- a/src/lib/staff-admin.test.ts
+++ b/src/lib/staff-admin.test.ts
@@ -329,6 +329,32 @@ describe("updateTeacherRecord", () => {
     expect(clientSql).toContain("UPDATE user_permission SET revoked_at = now()");
   });
 
+  it("does not break teacher exits before the Academic Mentorship table is deployed", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubEnv("DB_SERVICE_URL", "https://db.example/api");
+    vi.stubEnv("DB_SERVICE_TOKEN", "token");
+    const missingTable = Object.assign(new Error("relation does not exist"), {
+      code: "42P01",
+    });
+
+    mockSchemaReady();
+    mockQuery
+      .mockResolvedValueOnce([{ id: 1, user_id: 70 }])
+      .mockRejectedValueOnce(missingTable);
+
+    const result = await updateTeacherRecord({
+      id: 1,
+      body: { exit_date: "2026-06-12" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://db.example/api/teacher/1",
+      expect.objectContaining({ method: "PATCH" })
+    );
+  });
+
   it("blocks teacher exit when the teacher has active Academic Mentees", async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", mockFetch);

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -169,21 +169,32 @@ function academicMentorshipManagementLink(
   )}&academic_year=${encodeURIComponent(row.academic_year)}`;
 }
 
+function isMissingAcademicMentorshipMappingSchema(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "42P01" || code === "42703";
+}
+
 async function blockIfActiveAcademicMentees(
   mentorUserId: number
 ): Promise<StaffValidationFailure | null> {
-  const rows = await query<AcademicMentorshipBlockerRow>(
-    `SELECT s.code AS school_code,
-            m.academic_year,
-            COUNT(*) AS mentee_count
-     FROM academic_mentorship_mentor_mentee_mappings m
-     JOIN school s ON s.id = m.school_id
-     WHERE m.mentor_user_id = $1
-       AND m.ended_at IS NULL
-     GROUP BY s.code, m.academic_year
-     ORDER BY m.academic_year DESC, s.code ASC`,
-    [mentorUserId]
-  );
+  let rows: AcademicMentorshipBlockerRow[];
+  try {
+    rows = await query<AcademicMentorshipBlockerRow>(
+      `SELECT s.code AS school_code,
+              m.academic_year,
+              COUNT(*) AS mentee_count
+       FROM academic_mentorship_mentor_mentee_mappings m
+       JOIN school s ON s.id = m.school_id
+       WHERE m.mentor_user_id = $1
+         AND m.ended_at IS NULL
+       GROUP BY s.code, m.academic_year
+       ORDER BY m.academic_year DESC, s.code ASC`,
+      [mentorUserId]
+    );
+  } catch (error) {
+    if (isMissingAcademicMentorshipMappingSchema(error)) return null;
+    throw error;
+  }
   if (rows.length === 0) return null;
 
   const count = rows.reduce((total, row) => total + Number(row.mentee_count), 0);
@@ -198,16 +209,22 @@ async function blockIfActiveAcademicMentees(
 export async function blockIfAcademicMentorshipHistory(
   mentorUserId: number
 ): Promise<StaffValidationFailure | null> {
-  const rows = await query<AcademicMentorshipBlockerTarget>(
-    `SELECT s.code AS school_code,
-            m.academic_year
-     FROM academic_mentorship_mentor_mentee_mappings m
-     JOIN school s ON s.id = m.school_id
-     WHERE m.mentor_user_id = $1
-     GROUP BY s.code, m.academic_year
-     ORDER BY m.academic_year DESC, s.code ASC`,
-    [mentorUserId]
-  );
+  let rows: AcademicMentorshipBlockerTarget[];
+  try {
+    rows = await query<AcademicMentorshipBlockerTarget>(
+      `SELECT s.code AS school_code,
+              m.academic_year
+       FROM academic_mentorship_mentor_mentee_mappings m
+       JOIN school s ON s.id = m.school_id
+       WHERE m.mentor_user_id = $1
+       GROUP BY s.code, m.academic_year
+       ORDER BY m.academic_year DESC, s.code ASC`,
+      [mentorUserId]
+    );
+  } catch (error) {
+    if (isMissingAcademicMentorshipMappingSchema(error)) return null;
+    throw error;
+  }
   if (rows.length === 0) return null;
 
   return {

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -174,27 +174,33 @@ function isMissingAcademicMentorshipMappingSchema(error: unknown): boolean {
   return code === "42P01" || code === "42703";
 }
 
+async function queryAcademicMentorshipBlockers<T>(
+  sql: string,
+  mentorUserId: number
+): Promise<T[]> {
+  try {
+    return await query<T>(sql, [mentorUserId]);
+  } catch (error) {
+    if (isMissingAcademicMentorshipMappingSchema(error)) return [];
+    throw error;
+  }
+}
+
 async function blockIfActiveAcademicMentees(
   mentorUserId: number
 ): Promise<StaffValidationFailure | null> {
-  let rows: AcademicMentorshipBlockerRow[];
-  try {
-    rows = await query<AcademicMentorshipBlockerRow>(
-      `SELECT s.code AS school_code,
-              m.academic_year,
-              COUNT(*) AS mentee_count
-       FROM academic_mentorship_mentor_mentee_mappings m
-       JOIN school s ON s.id = m.school_id
-       WHERE m.mentor_user_id = $1
-         AND m.ended_at IS NULL
-       GROUP BY s.code, m.academic_year
-       ORDER BY m.academic_year DESC, s.code ASC`,
-      [mentorUserId]
-    );
-  } catch (error) {
-    if (isMissingAcademicMentorshipMappingSchema(error)) return null;
-    throw error;
-  }
+  const rows = await queryAcademicMentorshipBlockers<AcademicMentorshipBlockerRow>(
+    `SELECT s.code AS school_code,
+            m.academic_year,
+            COUNT(*) AS mentee_count
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN school s ON s.id = m.school_id
+     WHERE m.mentor_user_id = $1
+       AND m.ended_at IS NULL
+     GROUP BY s.code, m.academic_year
+     ORDER BY m.academic_year DESC, s.code ASC`,
+    mentorUserId
+  );
   if (rows.length === 0) return null;
 
   const count = rows.reduce((total, row) => total + Number(row.mentee_count), 0);
@@ -209,22 +215,16 @@ async function blockIfActiveAcademicMentees(
 export async function blockIfAcademicMentorshipHistory(
   mentorUserId: number
 ): Promise<StaffValidationFailure | null> {
-  let rows: AcademicMentorshipBlockerTarget[];
-  try {
-    rows = await query<AcademicMentorshipBlockerTarget>(
-      `SELECT s.code AS school_code,
-              m.academic_year
-       FROM academic_mentorship_mentor_mentee_mappings m
-       JOIN school s ON s.id = m.school_id
-       WHERE m.mentor_user_id = $1
-       GROUP BY s.code, m.academic_year
-       ORDER BY m.academic_year DESC, s.code ASC`,
-      [mentorUserId]
-    );
-  } catch (error) {
-    if (isMissingAcademicMentorshipMappingSchema(error)) return null;
-    throw error;
-  }
+  const rows = await queryAcademicMentorshipBlockers<AcademicMentorshipBlockerTarget>(
+    `SELECT s.code AS school_code,
+            m.academic_year
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN school s ON s.id = m.school_id
+     WHERE m.mentor_user_id = $1
+     GROUP BY s.code, m.academic_year
+     ORDER BY m.academic_year DESC, s.code ASC`,
+    mentorUserId
+  );
   if (rows.length === 0) return null;
 
   return {

--- a/src/lib/staff-admin.ts
+++ b/src/lib/staff-admin.ts
@@ -149,6 +149,75 @@ export function safeStaffApiError(result: {
   };
 }
 
+interface AcademicMentorshipBlockerTarget {
+  school_code: string | null;
+  academic_year: string;
+}
+
+interface AcademicMentorshipBlockerRow extends AcademicMentorshipBlockerTarget {
+  mentee_count: string | number;
+}
+
+function academicMentorshipManagementLink(
+  row: AcademicMentorshipBlockerTarget | undefined
+): string {
+  if (!row?.school_code || !row.academic_year) {
+    return "/admin/academic-mentorship";
+  }
+  return `/admin/academic-mentorship?school_code=${encodeURIComponent(
+    row.school_code
+  )}&academic_year=${encodeURIComponent(row.academic_year)}`;
+}
+
+async function blockIfActiveAcademicMentees(
+  mentorUserId: number
+): Promise<StaffValidationFailure | null> {
+  const rows = await query<AcademicMentorshipBlockerRow>(
+    `SELECT s.code AS school_code,
+            m.academic_year,
+            COUNT(*) AS mentee_count
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN school s ON s.id = m.school_id
+     WHERE m.mentor_user_id = $1
+       AND m.ended_at IS NULL
+     GROUP BY s.code, m.academic_year
+     ORDER BY m.academic_year DESC, s.code ASC`,
+    [mentorUserId]
+  );
+  if (rows.length === 0) return null;
+
+  const count = rows.reduce((total, row) => total + Number(row.mentee_count), 0);
+  return {
+    ok: false,
+    status: 409,
+    code: "active_academic_mentees",
+    error: `This Teacher has ${count} active ${count === 1 ? "Mentee" : "Mentees"}. Remove or reassign them before exiting the Teacher: ${academicMentorshipManagementLink(rows[0])}`,
+  };
+}
+
+export async function blockIfAcademicMentorshipHistory(
+  mentorUserId: number
+): Promise<StaffValidationFailure | null> {
+  const rows = await query<AcademicMentorshipBlockerTarget>(
+    `SELECT s.code AS school_code,
+            m.academic_year
+     FROM academic_mentorship_mentor_mentee_mappings m
+     JOIN school s ON s.id = m.school_id
+     WHERE m.mentor_user_id = $1
+     GROUP BY s.code, m.academic_year
+     ORDER BY m.academic_year DESC, s.code ASC`,
+    [mentorUserId]
+  );
+  if (rows.length === 0) return null;
+
+  return {
+    ok: false,
+    status: 409,
+    code: "academic_mentorship_history",
+    error: `This Teacher has Academic Mentor-Mentee Mapping history. Deleting the Teacher is blocked to preserve audit history: ${academicMentorshipManagementLink(rows[0])}`,
+  };
+}
+
 // --- Roster ---
 
 export type StaffRosterResult =
@@ -538,6 +607,11 @@ export async function updateTeacherRecord(params: {
         error: `Employee code ${payload.teacher_id} is already used by another teacher`,
       };
     }
+  }
+
+  if (payload.exit_date && existing[0].user_id !== null) {
+    const blocker = await blockIfActiveAcademicMentees(Number(existing[0].user_id));
+    if (blocker) return blocker;
   }
 
   const patched = await dbServiceTeacherPatch(params.id, payload);


### PR DESCRIPTION
## Summary

- Adds the Academic Mentorship feature key, allowlist, shared access helper, and guarded `/admin/academic-mentorship` management page.
- Adds grouped active/history Mentor-Mentee mapping views plus manual add, remove, and reassign flows with server-side eligibility checks.
- Adds CSV template/download and all-or-nothing CSV import for mappings by `mentor_email` and external `student_id`.
- Replaces the School page Mentorship placeholder with role-specific current-year Academic Mentorship views and a prefilled management link for eligible Admin/Program Admin users.
- Blocks Staff Management delete/exit paths that would orphan Academic Mentor-Mentee mapping history or active mentees.
- Adds focused route, component, permission, staff-admin, and domain tests for the new workflow.

## Linked Issues

- Closes #141
- Closes #145
- Closes #146
- Closes #147
- Closes #148
- Closes #149
- Closes #150
- Closes #151

## Final Review

- Outcome: pass.
- Quality checks from final review passed: `npm test`, `npm run lint`, and `npm run build`.
- Acceptance criteria for #145, #146, #147, #148, #149, #150, and sibling db-service schema issue #151 were verified as satisfied.
- No blocking findings were found.
- Non-blocking risk noted: duplicate current-grade `enrollment_record` rows in source data could duplicate mapping display/option rows because `src/lib/academic-mentorship.ts` joins current-grade rows directly rather than using the roster helper's dedupe behavior.

## Human QA Checklist

- [ ] Log in as Admin and confirm `/admin` shows the Academic Mentorship card alongside existing admin tools.
- [ ] Log in as Program Admin and confirm `/admin` shows only the Academic Mentorship entry, with edit controls hidden when `read_only` is set.
- [ ] On `/admin/academic-mentorship`, choose a School/year and verify active mappings are grouped by Academic Mentor with Mentee counts.
- [ ] Toggle Show history and confirm ended mappings appear without Add/Remove/Reassign actions.
- [ ] Add a mapping with eligible mentor and unassigned mentee, then confirm the table refreshes and the mentee disappears from the unassigned selector.
- [ ] Remove an active mapping and confirm it moves to history only after Show history is enabled.
- [ ] Reassign an active mentee and confirm the old mentor is excluded from replacement choices and the new active mapping is shown.
- [ ] Download the CSV template, upload a valid `mentor_email,student_id` file, and confirm the success count plus refreshed table.
- [ ] Upload an invalid CSV with duplicate or unknown students and confirm no rows are written and an error CSV is available.
- [ ] Open a School page as Teacher, PM, Admin, Program Admin, and passcode user to verify role-specific Mentorship tab visibility/content.
- [ ] Try deleting/exiting a Teacher with active and historical mappings from Staff Management and confirm the expected block/allow behavior.
