### PR TITLE
chore(ci): Fallow posts one sticky summary, not inline comment spam

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -27,10 +27,11 @@ jobs:
         uses: fallow-rs/fallow@v2
         with:
           command: audit
+          # Post ONE sticky summary comment (updates in place on re-runs) instead
+          # of dozens of inline review comments. `annotations` still surfaces
+          # findings on the Files Changed view without adding PR comments.
           annotations: true
           comment: true
-          review-comments: true
-          review-guidance: false
+          review-comments: false
           diff-filter: added
-          max-comments: 30
           artifacts-dir: .var/fallow


### PR DESCRIPTION
## Problem

The Fallow audit ran with `review-comments: true`, which posts one **inline review comment per finding** — up to `max-comments: 30` per run, and they accumulate across re-runs. On the teacher-feedback PR that came to **77 inline comments**, drowning the conversation.

## Change

- `review-comments: false` — stop the per-line inline comments.
- `comment: true` (kept) — Fallow's **sticky summary comment** already updates in place on every re-run, so the PR gets exactly **one** concise findings table.
- `annotations: true` (kept) — findings still surface on the **Files Changed** view (workflow annotations), which don't create PR comments.
- Dropped `max-comments` / `review-guidance` (only relevant to inline review comments).

Net: one self-updating summary comment instead of dozens of inline ones. The audit gate/verdict behaviour is unchanged.

_(Existing inline comments on open PRs are being cleaned up separately — the config only affects future runs.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)