### PR TITLE
Create quiz sessions from new-CMS tests (chapter + major)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ QUIZ_BACKEND_URL=
 # Auth/portal base a student opens the session on, e.g. https://auth.avantifellows.org
 # (staging: https://staging-auth.avantifellows.org). Used to build the session portal_link.
 SESSION_PORTAL_URL=
+# Quiz frontend base + AF org api key, e.g. https://quiz.avantifellows.org
+# (staging: https://staging-quiz.avantifellows.org). Used to build the admin Q&A testing
+# links (quiz player as whitelisted test_admin). Optional — links stay blank when unset.
+QUIZ_FRONTEND_URL=
+QUIZ_AF_API_KEY=
 
 # =============================================================================
 # NEXTAUTH CONFIGURATION

--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,26 @@ DB_SERVICE_URL=
 DB_SERVICE_TOKEN=
  
 # =============================================================================
-# AWS SNS (Session Creator)
+# AWS SNS (Session Creator — legacy quiz_template path only)
 # =============================================================================
 AF_ACCESS_KEY_ID=
 AF_SECRET_ACCESS_KEY=
 AF_TOPIC_ARN=
 APP_ENV=
+
+# =============================================================================
+# NEW-CMS TEST SESSIONS (nex-gen-cms + quiz-backend)
+# =============================================================================
+# Session creation from a new-CMS test builds the quiz synchronously (no SNS):
+# af_lms -> quiz-backend /quiz/from-cms -> quizId -> db-service /session.
+# CMS service API (bearer-authed, mirrors DB_SERVICE_*): test list/assembled JSON + PDFs.
+CMS_SERVICE_URL=
+CMS_SERVICE_TOKEN=
+# quiz-backend base URL (the /quiz/from-cms ingest endpoint).
+QUIZ_BACKEND_URL=
+# Auth/portal base a student opens the session on, e.g. https://auth.avantifellows.org
+# (staging: https://staging-auth.avantifellows.org). Used to build the session portal_link.
+SESSION_PORTAL_URL=
 
 # =============================================================================
 # NEXTAUTH CONFIGURATION

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,10 @@ SESSION_PORTAL_URL=
 # links (quiz player as whitelisted test_admin). Optional — links stay blank when unset.
 QUIZ_FRONTEND_URL=
 QUIZ_AF_API_KEY=
+# AF link shortener (legacy sessionCreator used http://65.0.246.88:8080). Shortens the
+# student session/OMR links and the report link. Optional — full URLs are stored when unset.
+AF_SHORTENER_URL=
+AF_SHORTENER_AUTH_TOKEN=
 
 # =============================================================================
 # NEXTAUTH CONFIGURATION

--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -92,6 +92,10 @@ jobs:
           S3_DOCS_REGION: ${{ secrets.S3_DOCS_REGION }}
           S3_DOCS_ACCESS_KEY_ID: ${{ secrets.S3_DOCS_ACCESS_KEY_ID }}
           S3_DOCS_SECRET_ACCESS_KEY: ${{ secrets.S3_DOCS_SECRET_ACCESS_KEY }}
+          CMS_SERVICE_URL: ${{ secrets.CMS_SERVICE_URL }}
+          CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
+          QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
+          SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -120,6 +124,10 @@ jobs:
             --arg w "$S3_DOCS_REGION" \
             --arg x "$S3_DOCS_ACCESS_KEY_ID" \
             --arg y "$S3_DOCS_SECRET_ACCESS_KEY" \
+            --arg cms_url "$CMS_SERVICE_URL" \
+            --arg cms_token "$CMS_SERVICE_TOKEN" \
+            --arg quiz_url "$QUIZ_BACKEND_URL" \
+            --arg portal_url "$SESSION_PORTAL_URL" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -145,7 +153,11 @@ jobs:
               S3_DOCS_PREFIX: $v,
               S3_DOCS_REGION: $w,
               S3_DOCS_ACCESS_KEY_ID: $x,
-              S3_DOCS_SECRET_ACCESS_KEY: $y
+              S3_DOCS_SECRET_ACCESS_KEY: $y,
+              CMS_SERVICE_URL: $cms_url,
+              CMS_SERVICE_TOKEN: $cms_token,
+              QUIZ_BACKEND_URL: $quiz_url,
+              SESSION_PORTAL_URL: $portal_url
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -239,6 +251,10 @@ jobs:
           S3_DOCS_REGION: ${{ secrets.S3_DOCS_REGION }}
           S3_DOCS_ACCESS_KEY_ID: ${{ secrets.S3_DOCS_ACCESS_KEY_ID }}
           S3_DOCS_SECRET_ACCESS_KEY: ${{ secrets.S3_DOCS_SECRET_ACCESS_KEY }}
+          CMS_SERVICE_URL: ${{ secrets.CMS_SERVICE_URL }}
+          CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
+          QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
+          SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -267,6 +283,10 @@ jobs:
             --arg w "$S3_DOCS_REGION" \
             --arg x "$S3_DOCS_ACCESS_KEY_ID" \
             --arg y "$S3_DOCS_SECRET_ACCESS_KEY" \
+            --arg cms_url "$CMS_SERVICE_URL" \
+            --arg cms_token "$CMS_SERVICE_TOKEN" \
+            --arg quiz_url "$QUIZ_BACKEND_URL" \
+            --arg portal_url "$SESSION_PORTAL_URL" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -292,7 +312,11 @@ jobs:
               S3_DOCS_PREFIX: $v,
               S3_DOCS_REGION: $w,
               S3_DOCS_ACCESS_KEY_ID: $x,
-              S3_DOCS_SECRET_ACCESS_KEY: $y
+              S3_DOCS_SECRET_ACCESS_KEY: $y,
+              CMS_SERVICE_URL: $cms_url,
+              CMS_SERVICE_TOKEN: $cms_token,
+              QUIZ_BACKEND_URL: $quiz_url,
+              SESSION_PORTAL_URL: $portal_url
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -397,6 +421,10 @@ jobs:
           S3_DOCS_REGION: ${{ secrets.S3_DOCS_REGION }}
           S3_DOCS_ACCESS_KEY_ID: ${{ secrets.S3_DOCS_ACCESS_KEY_ID }}
           S3_DOCS_SECRET_ACCESS_KEY: ${{ secrets.S3_DOCS_SECRET_ACCESS_KEY }}
+          CMS_SERVICE_URL: ${{ secrets.CMS_SERVICE_URL }}
+          CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
+          QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
+          SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
         run: |
           ENV_VARS=$(jq -n \
             --arg a "$DATABASE_HOST" \
@@ -424,6 +452,10 @@ jobs:
             --arg w "$S3_DOCS_REGION" \
             --arg x "$S3_DOCS_ACCESS_KEY_ID" \
             --arg y "$S3_DOCS_SECRET_ACCESS_KEY" \
+            --arg cms_url "$CMS_SERVICE_URL" \
+            --arg cms_token "$CMS_SERVICE_TOKEN" \
+            --arg quiz_url "$QUIZ_BACKEND_URL" \
+            --arg portal_url "$SESSION_PORTAL_URL" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -449,7 +481,11 @@ jobs:
               S3_DOCS_PREFIX: $v,
               S3_DOCS_REGION: $w,
               S3_DOCS_ACCESS_KEY_ID: $x,
-              S3_DOCS_SECRET_ACCESS_KEY: $y
+              S3_DOCS_SECRET_ACCESS_KEY: $y,
+              CMS_SERVICE_URL: $cms_url,
+              CMS_SERVICE_TOKEN: $cms_token,
+              QUIZ_BACKEND_URL: $quiz_url,
+              SESSION_PORTAL_URL: $portal_url
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \

--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -96,6 +96,8 @@ jobs:
           CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
           QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
+          QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
+          QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -128,6 +130,8 @@ jobs:
             --arg cms_token "$CMS_SERVICE_TOKEN" \
             --arg quiz_url "$QUIZ_BACKEND_URL" \
             --arg portal_url "$SESSION_PORTAL_URL" \
+            --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
+            --arg quiz_af_key "$QUIZ_AF_API_KEY" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -157,7 +161,9 @@ jobs:
               CMS_SERVICE_URL: $cms_url,
               CMS_SERVICE_TOKEN: $cms_token,
               QUIZ_BACKEND_URL: $quiz_url,
-              SESSION_PORTAL_URL: $portal_url
+              SESSION_PORTAL_URL: $portal_url,
+              QUIZ_FRONTEND_URL: $quiz_fe_url,
+              QUIZ_AF_API_KEY: $quiz_af_key
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -255,6 +261,8 @@ jobs:
           CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
           QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
+          QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
+          QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -287,6 +295,8 @@ jobs:
             --arg cms_token "$CMS_SERVICE_TOKEN" \
             --arg quiz_url "$QUIZ_BACKEND_URL" \
             --arg portal_url "$SESSION_PORTAL_URL" \
+            --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
+            --arg quiz_af_key "$QUIZ_AF_API_KEY" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -316,7 +326,9 @@ jobs:
               CMS_SERVICE_URL: $cms_url,
               CMS_SERVICE_TOKEN: $cms_token,
               QUIZ_BACKEND_URL: $quiz_url,
-              SESSION_PORTAL_URL: $portal_url
+              SESSION_PORTAL_URL: $portal_url,
+              QUIZ_FRONTEND_URL: $quiz_fe_url,
+              QUIZ_AF_API_KEY: $quiz_af_key
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -425,6 +437,8 @@ jobs:
           CMS_SERVICE_TOKEN: ${{ secrets.CMS_SERVICE_TOKEN }}
           QUIZ_BACKEND_URL: ${{ secrets.QUIZ_BACKEND_URL }}
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
+          QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
+          QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
         run: |
           ENV_VARS=$(jq -n \
             --arg a "$DATABASE_HOST" \
@@ -456,6 +470,8 @@ jobs:
             --arg cms_token "$CMS_SERVICE_TOKEN" \
             --arg quiz_url "$QUIZ_BACKEND_URL" \
             --arg portal_url "$SESSION_PORTAL_URL" \
+            --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
+            --arg quiz_af_key "$QUIZ_AF_API_KEY" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -485,7 +501,9 @@ jobs:
               CMS_SERVICE_URL: $cms_url,
               CMS_SERVICE_TOKEN: $cms_token,
               QUIZ_BACKEND_URL: $quiz_url,
-              SESSION_PORTAL_URL: $portal_url
+              SESSION_PORTAL_URL: $portal_url,
+              QUIZ_FRONTEND_URL: $quiz_fe_url,
+              QUIZ_AF_API_KEY: $quiz_af_key
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \

--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -98,6 +98,8 @@ jobs:
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
           QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
           QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
+          AF_SHORTENER_URL: ${{ secrets.AF_SHORTENER_URL }}
+          AF_SHORTENER_AUTH_TOKEN: ${{ secrets.AF_SHORTENER_AUTH_TOKEN }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -132,6 +134,8 @@ jobs:
             --arg portal_url "$SESSION_PORTAL_URL" \
             --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
             --arg quiz_af_key "$QUIZ_AF_API_KEY" \
+            --arg shortener_url "$AF_SHORTENER_URL" \
+            --arg shortener_token "$AF_SHORTENER_AUTH_TOKEN" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -163,7 +167,9 @@ jobs:
               QUIZ_BACKEND_URL: $quiz_url,
               SESSION_PORTAL_URL: $portal_url,
               QUIZ_FRONTEND_URL: $quiz_fe_url,
-              QUIZ_AF_API_KEY: $quiz_af_key
+              QUIZ_AF_API_KEY: $quiz_af_key,
+              AF_SHORTENER_URL: $shortener_url,
+              AF_SHORTENER_AUTH_TOKEN: $shortener_token
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -263,6 +269,8 @@ jobs:
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
           QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
           QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
+          AF_SHORTENER_URL: ${{ secrets.AF_SHORTENER_URL }}
+          AF_SHORTENER_AUTH_TOKEN: ${{ secrets.AF_SHORTENER_AUTH_TOKEN }}
         run: |
           BRANCH="${{ steps.preview.outputs.branch }}"
           ENV_VARS=$(jq -n \
@@ -297,6 +305,8 @@ jobs:
             --arg portal_url "$SESSION_PORTAL_URL" \
             --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
             --arg quiz_af_key "$QUIZ_AF_API_KEY" \
+            --arg shortener_url "$AF_SHORTENER_URL" \
+            --arg shortener_token "$AF_SHORTENER_AUTH_TOKEN" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -328,7 +338,9 @@ jobs:
               QUIZ_BACKEND_URL: $quiz_url,
               SESSION_PORTAL_URL: $portal_url,
               QUIZ_FRONTEND_URL: $quiz_fe_url,
-              QUIZ_AF_API_KEY: $quiz_af_key
+              QUIZ_AF_API_KEY: $quiz_af_key,
+              AF_SHORTENER_URL: $shortener_url,
+              AF_SHORTENER_AUTH_TOKEN: $shortener_token
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \
@@ -439,6 +451,8 @@ jobs:
           SESSION_PORTAL_URL: ${{ secrets.SESSION_PORTAL_URL }}
           QUIZ_FRONTEND_URL: ${{ secrets.QUIZ_FRONTEND_URL }}
           QUIZ_AF_API_KEY: ${{ secrets.QUIZ_AF_API_KEY }}
+          AF_SHORTENER_URL: ${{ secrets.AF_SHORTENER_URL }}
+          AF_SHORTENER_AUTH_TOKEN: ${{ secrets.AF_SHORTENER_AUTH_TOKEN }}
         run: |
           ENV_VARS=$(jq -n \
             --arg a "$DATABASE_HOST" \
@@ -472,6 +486,8 @@ jobs:
             --arg portal_url "$SESSION_PORTAL_URL" \
             --arg quiz_fe_url "$QUIZ_FRONTEND_URL" \
             --arg quiz_af_key "$QUIZ_AF_API_KEY" \
+            --arg shortener_url "$AF_SHORTENER_URL" \
+            --arg shortener_token "$AF_SHORTENER_AUTH_TOKEN" \
             '{
               DATABASE_HOST: $a,
               DATABASE_PORT: $b,
@@ -503,7 +519,9 @@ jobs:
               QUIZ_BACKEND_URL: $quiz_url,
               SESSION_PORTAL_URL: $portal_url,
               QUIZ_FRONTEND_URL: $quiz_fe_url,
-              QUIZ_AF_API_KEY: $quiz_af_key
+              QUIZ_AF_API_KEY: $quiz_af_key,
+              AF_SHORTENER_URL: $shortener_url,
+              AF_SHORTENER_AUTH_TOKEN: $shortener_token
             }')
           aws amplify update-branch \
             --app-id ${{ env.AMPLIFY_APP_ID }} \

--- a/amplify.yml
+++ b/amplify.yml
@@ -31,6 +31,10 @@ frontend:
           echo "S3_DOCS_REGION=$S3_DOCS_REGION" >> .env.production
           echo "S3_DOCS_ACCESS_KEY_ID=$S3_DOCS_ACCESS_KEY_ID" >> .env.production
           echo "S3_DOCS_SECRET_ACCESS_KEY=$S3_DOCS_SECRET_ACCESS_KEY" >> .env.production
+          echo "CMS_SERVICE_URL=$CMS_SERVICE_URL" >> .env.production
+          echo "CMS_SERVICE_TOKEN=$CMS_SERVICE_TOKEN" >> .env.production
+          echo "QUIZ_BACKEND_URL=$QUIZ_BACKEND_URL" >> .env.production
+          echo "SESSION_PORTAL_URL=$SESSION_PORTAL_URL" >> .env.production
     build:
       commands:
         - npm run build

--- a/amplify.yml
+++ b/amplify.yml
@@ -37,6 +37,8 @@ frontend:
           echo "SESSION_PORTAL_URL=$SESSION_PORTAL_URL" >> .env.production
           echo "QUIZ_FRONTEND_URL=$QUIZ_FRONTEND_URL" >> .env.production
           echo "QUIZ_AF_API_KEY=$QUIZ_AF_API_KEY" >> .env.production
+          echo "AF_SHORTENER_URL=$AF_SHORTENER_URL" >> .env.production
+          echo "AF_SHORTENER_AUTH_TOKEN=$AF_SHORTENER_AUTH_TOKEN" >> .env.production
     build:
       commands:
         - npm run build

--- a/amplify.yml
+++ b/amplify.yml
@@ -35,6 +35,8 @@ frontend:
           echo "CMS_SERVICE_TOKEN=$CMS_SERVICE_TOKEN" >> .env.production
           echo "QUIZ_BACKEND_URL=$QUIZ_BACKEND_URL" >> .env.production
           echo "SESSION_PORTAL_URL=$SESSION_PORTAL_URL" >> .env.production
+          echo "QUIZ_FRONTEND_URL=$QUIZ_FRONTEND_URL" >> .env.production
+          echo "QUIZ_AF_API_KEY=$QUIZ_AF_API_KEY" >> .env.production
     build:
       commands:
         - npm run build

--- a/src/app/api/cms/chapters/route.ts
+++ b/src/app/api/cms/chapters/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
+import { EXAM_TRACKS } from "@/lib/curriculum-options";
+import { query } from "@/lib/db";
+import type { ExamTrack } from "@/types/curriculum";
+
+// Chapters for the new-CMS chapter-test picker: in-syllabus chapters for an
+// exam-track/grade/subject, so the session creator can drill Subject -> Chapter -> Test.
+// Global content (keyed by exam_track), not school-scoped like /api/curriculum/chapters.
+const SUBJECT_IDS: Record<string, number> = {
+  Maths: 1,
+  Chemistry: 2,
+  Biology: 3,
+  Physics: 4,
+};
+
+interface ChapterNameRow {
+  id: number;
+  code: string;
+  name: { lang_code: string; chapter?: string }[] | null;
+}
+
+export interface CmsChapterOption {
+  id: number;
+  code: string;
+  name: string;
+}
+
+function chapterName(row: ChapterNameRow): string {
+  const names = row.name ?? [];
+  return (
+    names.find((n) => n.lang_code === "en")?.chapter ?? names[0]?.chapter ?? row.code
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await requireQuizSessionAccess(session.user.email, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const examTrack = (searchParams.get("exam_track") || "").trim() as ExamTrack;
+  const grade = Number((searchParams.get("grade") || "").trim());
+  const subject = (searchParams.get("subject") || "").trim();
+
+  if (!EXAM_TRACKS.includes(examTrack)) {
+    return NextResponse.json(
+      { error: "Invalid or missing exam_track" },
+      { status: 400 }
+    );
+  }
+  if (grade !== 11 && grade !== 12) {
+    return NextResponse.json({ error: "grade must be 11 or 12" }, { status: 400 });
+  }
+  const subjectId = SUBJECT_IDS[subject];
+  if (!subjectId) {
+    return NextResponse.json({ error: "Invalid or missing subject" }, { status: 400 });
+  }
+
+  // Duplicate chapter rows share a code (e.g. 12P17 = ids 22 AND 27), and the syllabus
+  // config can expose more than one, which would surface two identical options. Collapse to
+  // one row per code (DISTINCT ON), keeping the lowest coverage_sequence. Test matching in
+  // /api/cms/tests is code-based, so whichever id survives still resolves to the right test.
+  const rows = await query<ChapterNameRow>(
+    `SELECT id, code, name
+     FROM (
+       SELECT DISTINCT ON (ch.code)
+              ch.id, ch.code, ch.name, cfg.coverage_sequence
+       FROM lms_chapter_exam_configs cfg
+       JOIN chapter ch ON ch.id = cfg.chapter_id
+       JOIN grade g ON g.id = ch.grade_id
+       WHERE cfg.exam_track = $1
+         AND cfg.is_in_syllabus = true
+         AND g.number = $2
+         AND ch.subject_id = $3
+       ORDER BY ch.code ASC, cfg.coverage_sequence ASC, ch.id ASC
+     ) deduped
+     ORDER BY coverage_sequence ASC, code ASC`,
+    [examTrack, grade, subjectId]
+  );
+
+  const chapters: CmsChapterOption[] = rows.map((row) => ({
+    id: Number(row.id),
+    code: row.code,
+    name: chapterName(row),
+  }));
+
+  return NextResponse.json({ chapters });
+}

--- a/src/app/api/cms/chapters/route.ts
+++ b/src/app/api/cms/chapters/route.ts
@@ -4,17 +4,11 @@ import { authOptions } from "@/lib/auth";
 import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
 import { EXAM_TRACKS } from "@/lib/curriculum-options";
 import { query } from "@/lib/db";
-import type { ExamTrack } from "@/types/curriculum";
+import { SUBJECT_IDS, type SubjectName, type ExamTrack } from "@/types/curriculum";
 
 // Chapters for the new-CMS chapter-test picker: in-syllabus chapters for an
 // exam-track/grade/subject, so the session creator can drill Subject -> Chapter -> Test.
 // Global content (keyed by exam_track), not school-scoped like /api/curriculum/chapters.
-const SUBJECT_IDS: Record<string, number> = {
-  Maths: 1,
-  Chemistry: 2,
-  Biology: 3,
-  Physics: 4,
-};
 
 interface ChapterNameRow {
   id: number;
@@ -60,7 +54,7 @@ export async function GET(request: NextRequest) {
   if (grade !== 11 && grade !== 12) {
     return NextResponse.json({ error: "grade must be 11 or 12" }, { status: 400 });
   }
-  const subjectId = SUBJECT_IDS[subject];
+  const subjectId = SUBJECT_IDS[subject as SubjectName];
   if (!subjectId) {
     return NextResponse.json({ error: "Invalid or missing subject" }, { status: 400 });
   }

--- a/src/app/api/cms/test-pdf/route.ts
+++ b/src/app/api/cms/test-pdf/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: NextRequest) {
   const curriculumId = (searchParams.get("curriculumId") || "").trim();
   const gradeId = (searchParams.get("gradeId") || "").trim();
   const type = (searchParams.get("type") || "questions").trim();
+  const download = (searchParams.get("download") || "").trim() === "1";
 
   if (!testId) {
     return NextResponse.json({ error: "testId is required" }, { status: 400 });
@@ -78,10 +79,17 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Stream the PDF straight through, preserving the CMS-supplied filename.
+  // Stream the PDF straight through, preserving the CMS-supplied filename. With
+  // download=1, force an attachment so the browser saves instead of rendering inline.
   const body = await response.arrayBuffer();
-  const disposition =
+  let disposition =
     response.headers.get("content-disposition") ?? `inline; filename="test.pdf"`;
+  if (download) {
+    disposition = disposition.replace(/^inline/i, "attachment");
+    if (!/^attachment/i.test(disposition)) {
+      disposition = `attachment; ${disposition.replace(/^[^;]*;\s*/, "")}`;
+    }
+  }
   return new NextResponse(body, {
     status: 200,
     headers: {

--- a/src/app/api/cms/test-pdf/route.ts
+++ b/src/app/api/cms/test-pdf/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
+
+// On-demand PDF for a new-CMS test, so session details can offer question/answer PDFs the
+// same way legacy sessions do — but generated fresh by the CMS rather than stored. Proxies
+// the CMS service-PDF route (bearer-authed) and streams the bytes back. Nothing is stored;
+// the PDF always reflects the current test. See task lms-cms-tests.
+const CMS_SERVICE_URL = process.env.CMS_SERVICE_URL?.trim();
+const CMS_SERVICE_TOKEN = process.env.CMS_SERVICE_TOKEN?.trim();
+
+// Only the two variants we surface (legacy showed Question + Solution): the question paper
+// and the answer key. The CMS also supports questions_with_answers, not exposed here.
+const PDF_TYPES = ["questions", "answers"];
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await requireQuizSessionAccess(session.user.email, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  if (!CMS_SERVICE_URL || !CMS_SERVICE_TOKEN) {
+    return NextResponse.json(
+      { error: "CMS service is not configured" },
+      { status: 500 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const testId = (searchParams.get("testId") || "").trim();
+  const curriculumId = (searchParams.get("curriculumId") || "").trim();
+  const gradeId = (searchParams.get("gradeId") || "").trim();
+  const type = (searchParams.get("type") || "questions").trim();
+
+  if (!testId) {
+    return NextResponse.json({ error: "testId is required" }, { status: 400 });
+  }
+  if (!curriculumId || !gradeId) {
+    return NextResponse.json(
+      { error: "curriculumId and gradeId are required" },
+      { status: 400 }
+    );
+  }
+  if (!PDF_TYPES.includes(type)) {
+    return NextResponse.json({ error: "Invalid type" }, { status: 400 });
+  }
+
+  const cmsUrl =
+    `${CMS_SERVICE_URL.replace(/\/$/, "")}/api/service/test-pdf` +
+    `?id=${encodeURIComponent(testId)}` +
+    `&curriculum_id=${encodeURIComponent(curriculumId)}` +
+    `&grade_id=${encodeURIComponent(gradeId)}` +
+    `&type=${encodeURIComponent(type)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(cmsUrl, {
+      headers: { Authorization: `Bearer ${CMS_SERVICE_TOKEN}` },
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("Failed to reach CMS PDF service:", err);
+    return NextResponse.json({ error: "Failed to reach CMS" }, { status: 502 });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("CMS PDF generation failed:", response.status, errorText);
+    return NextResponse.json(
+      { error: "Failed to generate PDF" },
+      { status: response.status }
+    );
+  }
+
+  // Stream the PDF straight through, preserving the CMS-supplied filename.
+  const body = await response.arrayBuffer();
+  const disposition =
+    response.headers.get("content-disposition") ?? `inline; filename="test.pdf"`;
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": disposition,
+    },
+  });
+}

--- a/src/app/api/cms/tests/route.ts
+++ b/src/app/api/cms/tests/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
-import { EXAM_TRACKS, curriculumIdForExamTrack } from "@/lib/curriculum-options";
+import {
+  EXAM_TRACKS,
+  curriculumIdForExamTrack,
+  resolveGradeId,
+} from "@/lib/curriculum-options";
+import { CMS_TEST_TYPES, type CmsTestType } from "@/lib/cms-tests";
 import { query } from "@/lib/db";
 import type { ExamTrack } from "@/types/curriculum";
 
@@ -14,12 +19,6 @@ import type { ExamTrack } from "@/types/curriculum";
 // chapter". Bearer-authed, mirrors the DB_SERVICE_URL/TOKEN pattern.
 const CMS_SERVICE_URL = process.env.CMS_SERVICE_URL;
 const CMS_SERVICE_TOKEN = process.env.CMS_SERVICE_TOKEN;
-
-// Test subtypes the picker can request today. chapter_test is chapter-scoped (filtered by
-// chapter_id); major_test is full-syllabus (no chapter). Both flow through the same CMS
-// list route + quiz-backend ingest, so adding a type here is a UI change only.
-const CMS_TEST_TYPES = ["chapter_test", "major_test"] as const;
-type CmsTestType = (typeof CMS_TEST_TYPES)[number];
 
 interface RawCmsTest {
   id: number;
@@ -104,13 +103,9 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Resolve the CMS grade id from the grade table (the same lookup the from-cms session
-  // route does), rather than trusting a client-side grade->id mapping that could drift.
-  const gradeRows = await query<{ id: number }>(
-    `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
-    [grade]
-  );
-  const gradeId = gradeRows[0]?.id;
+  // Resolve the CMS grade id from the grade table (shared with the from-cms session route),
+  // rather than trusting a client-side grade->id mapping that could drift.
+  const gradeId = await resolveGradeId(grade);
   if (!gradeId) {
     return NextResponse.json(
       { error: `No grade row for grade ${grade}` },
@@ -148,7 +143,14 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const rawTests = (await response.json()) as RawCmsTest[];
+  const rawBody = (await response.json()) as unknown;
+  // Defend against the CMS answering 200 with a non-array body (error/paginated shape after
+  // an upstream change): surface an empty list, not a 500 from calling .filter on a non-array.
+  if (!Array.isArray(rawBody)) {
+    console.error("CMS tests response was not an array:", rawBody);
+    return NextResponse.json({ tests: [] });
+  }
+  const rawTests = rawBody as RawCmsTest[];
   // chapter_id is only meaningful for chapter tests; other types ignore the filter. Match
   // against every sibling chapter id sharing the selected chapter's code (duplicate rows),
   // so a test linked to any of them shows up regardless of which duplicate was picked.

--- a/src/app/api/cms/tests/route.ts
+++ b/src/app/api/cms/tests/route.ts
@@ -84,7 +84,7 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const examTrack = (searchParams.get("exam_track") || "").trim() as ExamTrack;
-  const gradeId = (searchParams.get("grade_id") || "").trim();
+  const grade = Number((searchParams.get("grade") || "").trim());
   const testType = (searchParams.get("test_type") || "chapter_test").trim() as CmsTestType;
   const chapterIdParam = (searchParams.get("chapter_id") || "").trim();
 
@@ -94,8 +94,8 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   }
-  if (!gradeId) {
-    return NextResponse.json({ error: "grade_id is required" }, { status: 400 });
+  if (grade !== 11 && grade !== 12) {
+    return NextResponse.json({ error: "grade must be 11 or 12" }, { status: 400 });
   }
   if (!CMS_TEST_TYPES.includes(testType)) {
     return NextResponse.json(
@@ -104,11 +104,25 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // Resolve the CMS grade id from the grade table (the same lookup the from-cms session
+  // route does), rather than trusting a client-side grade->id mapping that could drift.
+  const gradeRows = await query<{ id: number }>(
+    `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
+    [grade]
+  );
+  const gradeId = gradeRows[0]?.id;
+  if (!gradeId) {
+    return NextResponse.json(
+      { error: `No grade row for grade ${grade}` },
+      { status: 400 }
+    );
+  }
+
   const curriculumId = curriculumIdForExamTrack(examTrack);
   const cmsUrl =
     `${CMS_SERVICE_URL.replace(/\/$/, "")}/api/service/tests` +
     `?curriculum-dropdown=${curriculumId}` +
-    `&grade-dropdown=${encodeURIComponent(gradeId)}` +
+    `&grade-dropdown=${encodeURIComponent(String(gradeId))}` +
     `&testtype-dropdown=${encodeURIComponent(testType)}`;
 
   let response: Response;

--- a/src/app/api/cms/tests/route.ts
+++ b/src/app/api/cms/tests/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
+import { EXAM_TRACKS, curriculumIdForExamTrack } from "@/lib/curriculum-options";
+import { query } from "@/lib/db";
+import type { ExamTrack } from "@/types/curriculum";
+
+// New CMS (nex-gen-cms) service API. af_lms consumes the list route to let the session
+// creator pick tests authored in the new CMS. The CMS list route is subtype-agnostic
+// (testtype-dropdown), so this route takes a test_type and forwards it as-is — widening the
+// set of supported test types is a picker/scope change with no backend work. For chapter
+// tests the CMS returns chapter_id per test (in type_params) so we can offer "tests for a
+// chapter". Bearer-authed, mirrors the DB_SERVICE_URL/TOKEN pattern.
+const CMS_SERVICE_URL = process.env.CMS_SERVICE_URL;
+const CMS_SERVICE_TOKEN = process.env.CMS_SERVICE_TOKEN;
+
+// Test subtypes the picker can request today. chapter_test is chapter-scoped (filtered by
+// chapter_id); major_test is full-syllabus (no chapter). Both flow through the same CMS
+// list route + quiz-backend ingest, so adding a type here is a UI change only.
+const CMS_TEST_TYPES = ["chapter_test", "major_test"] as const;
+type CmsTestType = (typeof CMS_TEST_TYPES)[number];
+
+interface RawCmsTest {
+  id: number;
+  code: string;
+  name?: { lang_code: string; resource: string }[];
+  subtype?: string;
+  type_params?: { chapter_id?: number; marks?: number; duration?: string };
+}
+
+export interface CmsTestOption {
+  id: number;
+  code: string;
+  name: string;
+  chapterId: number | null;
+  marks: number | null;
+  duration: string | null;
+}
+
+function resourceName(test: RawCmsTest): string {
+  const names = test.name ?? [];
+  return (
+    names.find((n) => n.lang_code === "en")?.resource ?? names[0]?.resource ?? ""
+  );
+}
+
+// Staging + prod have duplicate chapter rows for the same chapter code (e.g. 12P17
+// "Electric Charges and Fields" = ids 22 AND 27), and a test's type_params.chapter_id
+// points at just one of them while the picker may hand us either. Resolve the selected
+// chapter to every sibling id sharing its (code, subject, grade) so the match is robust to
+// which duplicate was picked. See task lms-cms-tests.
+async function chapterIdsSharingCode(chapterId: number): Promise<number[]> {
+  const rows = await query<{ id: number }>(
+    `SELECT sib.id
+       FROM chapter sel
+       JOIN chapter sib
+         ON sib.code = sel.code
+        AND sib.subject_id IS NOT DISTINCT FROM sel.subject_id
+        AND sib.grade_id IS NOT DISTINCT FROM sel.grade_id
+      WHERE sel.id = $1`,
+    [chapterId]
+  );
+  return rows.map((r) => Number(r.id));
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await requireQuizSessionAccess(session.user.email, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  if (!CMS_SERVICE_URL || !CMS_SERVICE_TOKEN) {
+    return NextResponse.json(
+      { error: "CMS service is not configured" },
+      { status: 500 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const examTrack = (searchParams.get("exam_track") || "").trim() as ExamTrack;
+  const gradeId = (searchParams.get("grade_id") || "").trim();
+  const testType = (searchParams.get("test_type") || "chapter_test").trim() as CmsTestType;
+  const chapterIdParam = (searchParams.get("chapter_id") || "").trim();
+
+  if (!EXAM_TRACKS.includes(examTrack)) {
+    return NextResponse.json(
+      { error: "Invalid or missing exam_track" },
+      { status: 400 }
+    );
+  }
+  if (!gradeId) {
+    return NextResponse.json({ error: "grade_id is required" }, { status: 400 });
+  }
+  if (!CMS_TEST_TYPES.includes(testType)) {
+    return NextResponse.json(
+      { error: "Invalid or missing test_type" },
+      { status: 400 }
+    );
+  }
+
+  const curriculumId = curriculumIdForExamTrack(examTrack);
+  const cmsUrl =
+    `${CMS_SERVICE_URL.replace(/\/$/, "")}/api/service/tests` +
+    `?curriculum-dropdown=${curriculumId}` +
+    `&grade-dropdown=${encodeURIComponent(gradeId)}` +
+    `&testtype-dropdown=${encodeURIComponent(testType)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(cmsUrl, {
+      headers: {
+        Authorization: `Bearer ${CMS_SERVICE_TOKEN}`,
+        accept: "application/json",
+      },
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("Failed to reach CMS service:", err);
+    return NextResponse.json({ error: "Failed to reach CMS" }, { status: 502 });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("CMS tests fetch failed:", response.status, errorText);
+    return NextResponse.json(
+      { error: "Failed to fetch tests" },
+      { status: response.status }
+    );
+  }
+
+  const rawTests = (await response.json()) as RawCmsTest[];
+  // chapter_id is only meaningful for chapter tests; other types ignore the filter. Match
+  // against every sibling chapter id sharing the selected chapter's code (duplicate rows),
+  // so a test linked to any of them shows up regardless of which duplicate was picked.
+  const selectedChapterId =
+    testType === "chapter_test" && chapterIdParam ? Number(chapterIdParam) : null;
+  let chapterIds: Set<number> | null = null;
+  if (selectedChapterId !== null) {
+    const siblings = await chapterIdsSharingCode(selectedChapterId);
+    chapterIds = new Set(siblings.length > 0 ? siblings : [selectedChapterId]);
+  }
+
+  const tests: CmsTestOption[] = rawTests
+    .filter((test) => (test.subtype ?? testType) === testType)
+    .filter(
+      (test) =>
+        chapterIds === null ||
+        (test.type_params?.chapter_id !== undefined &&
+          chapterIds.has(test.type_params.chapter_id))
+    )
+    .map((test) => ({
+      id: test.id,
+      code: test.code,
+      name: resourceName(test),
+      chapterId: test.type_params?.chapter_id ?? null,
+      marks: test.type_params?.marks ?? null,
+      duration: test.type_params?.duration ?? null,
+    }));
+
+  return NextResponse.json({ tests });
+}

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -6,9 +6,14 @@ import {
   requireQuizSessionAccess,
   resolveBatchGroups,
 } from "@/lib/quiz-session-access";
-import { query } from "@/lib/db";
 import { utcToISTDate } from "@/lib/quiz-session-time";
-import { EXAM_TRACKS, curriculumIdForExamTrack } from "@/lib/curriculum-options";
+import {
+  EXAM_TRACKS,
+  curriculumIdForExamTrack,
+  resolveGradeId,
+  streamForExamTrack,
+} from "@/lib/curriculum-options";
+import { CMS_SOURCE, isCmsTestType } from "@/lib/cms-tests";
 import type { ExamTrack } from "@/types/curriculum";
 
 // Create a quiz session from a new-CMS test. This is the SYNCHRONOUS replacement for the
@@ -32,9 +37,6 @@ const QUIZ_AF_API_KEY = process.env.QUIZ_AF_API_KEY?.trim();
 // stored instead — link population must never fail a create.
 const AF_SHORTENER_URL = process.env.AF_SHORTENER_URL?.trim();
 const AF_SHORTENER_AUTH_TOKEN = process.env.AF_SHORTENER_AUTH_TOKEN?.trim();
-
-const CMS_TEST_TYPES = ["chapter_test", "major_test"];
-const CMS_SOURCE = "nex-gen-cms";
 
 interface CreateFromCmsBody {
   name?: string;
@@ -148,7 +150,7 @@ export async function POST(request: NextRequest) {
   if (body.grade !== 11 && body.grade !== 12) {
     return NextResponse.json({ error: "grade must be 11 or 12" }, { status: 400 });
   }
-  if (!body.testType || !CMS_TEST_TYPES.includes(body.testType)) {
+  if (!isCmsTestType(body.testType)) {
     return NextResponse.json({ error: "Valid testType is required" }, { status: 400 });
   }
   if (!body.parentBatchId) {
@@ -165,6 +167,19 @@ export async function POST(request: NextRequest) {
   }
   if (!body.stream) {
     return NextResponse.json({ error: "stream is required" }, { status: 400 });
+  }
+  // Guard against a wrong-subject test going live: the exam track (chosen independently in
+  // the picker) must match the stream derived from the selected batch — e.g. a NEET test
+  // cannot be attached to an engineering batch. Mirrors the legacy route's template.stream
+  // vs body.stream check.
+  const expectedStream = streamForExamTrack(body.examTrack);
+  if (expectedStream && body.stream !== expectedStream) {
+    return NextResponse.json(
+      {
+        error: `Selected test's exam track (${body.examTrack}) does not match the batch stream (${body.stream})`,
+      },
+      { status: 400 }
+    );
   }
   if (!body.startTime || !body.endTime) {
     return NextResponse.json(
@@ -203,11 +218,7 @@ export async function POST(request: NextRequest) {
   const { group, authType } = resolved;
 
   const curriculumId = curriculumIdForExamTrack(body.examTrack);
-  const gradeRows = await query<{ id: number }>(
-    `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
-    [body.grade]
-  );
-  const gradeId = gradeRows[0]?.id;
+  const gradeId = await resolveGradeId(body.grade);
   if (!gradeId) {
     return NextResponse.json(
       { error: `No grade row for grade ${body.grade}` },
@@ -237,7 +248,14 @@ export async function POST(request: NextRequest) {
         { status: 502 }
       );
     }
-    const quizData = (await quizRes.json()) as { id: string; warnings?: string[] };
+    const quizData = (await quizRes.json()) as { id?: string; warnings?: string[] };
+    if (!quizData.id) {
+      console.error("quiz-backend /quiz/from-cms returned no quiz id:", quizData);
+      return NextResponse.json(
+        { error: "Quiz build returned no id" },
+        { status: 502 }
+      );
+    }
     quizId = quizData.id;
     warnings = quizData.warnings ?? [];
   } catch (err) {
@@ -274,15 +292,19 @@ export async function POST(request: NextRequest) {
   // Student-facing shortened session/OMR links + the attendance report link (legacy
   // sessionCreator parity; each falls back to its full URL if the shortener is unavailable).
   const createdBy = session.user.email;
-  const shortenedLink = await shortenUrl(portalLink, createdBy);
-  const shortenedOmrLink = await shortenUrl(`${portalLink}&omrMode=true`, createdBy);
-  const reportLink = await shortenUrl(
-    `${SESSION_PORTAL_URL.replace(/\/$/, "")}?type=attendance&platform=report` +
-      `&platform_id=${encodeURIComponent(sessionIdStr)}` +
-      `&authGroup=${encodeURIComponent(group)}` +
-      `&auth_type=${encodeURIComponent(authType)}`,
-    createdBy
-  );
+  // The three shortener calls are independent — run them concurrently so a create pays one
+  // shortener round-trip's latency, not three.
+  const [shortenedLink, shortenedOmrLink, reportLink] = await Promise.all([
+    shortenUrl(portalLink, createdBy),
+    shortenUrl(`${portalLink}&omrMode=true`, createdBy),
+    shortenUrl(
+      `${SESSION_PORTAL_URL.replace(/\/$/, "")}?type=attendance&platform=report` +
+        `&platform_id=${encodeURIComponent(sessionIdStr)}` +
+        `&authGroup=${encodeURIComponent(group)}` +
+        `&auth_type=${encodeURIComponent(authType)}`,
+      createdBy
+    ),
+  ]);
 
   const sessionPayload = {
     name: sessionName,
@@ -317,6 +339,10 @@ export async function POST(request: NextRequest) {
       test_type: "assessment",
       gurukul_format_type: gurukulFormatType,
       marking_scheme: "4,-1",
+      // Intentionally null for CMS sessions: optional-attempt limits are encoded
+      // structurally in the quiz doc itself (the quiz-backend CMS mapper sets per-
+      // question-set attempt limits from section.optional.mandatory_count), so the
+      // legacy session-level optional_limits string is superseded here.
       optional_limits: null,
       cms_source: CMS_SOURCE,
       cms_test_id: String(body.cmsTestId),

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -1,0 +1,317 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  canAccessQuizSessionBatches,
+  requireQuizSessionAccess,
+} from "@/lib/quiz-session-access";
+import { query } from "@/lib/db";
+import { utcToISTDate } from "@/lib/quiz-session-time";
+import { EXAM_TRACKS, curriculumIdForExamTrack } from "@/lib/curriculum-options";
+import type { ExamTrack } from "@/types/curriculum";
+
+// Create a quiz session from a new-CMS test. This is the SYNCHRONOUS replacement for the
+// legacy SNS -> etl-data-flow sessionCreator Lambda: af_lms builds the quiz in quiz-backend,
+// then materializes the session in db-service itself (session row + one continuous
+// occurrence + a group-session link per batch). No SNS is fired — the quiz already exists,
+// so nothing runs after this returns. See task lms-cms-tests for the locked design.
+// Trim env values — stray trailing whitespace/newlines in .env would corrupt `${URL}/path`.
+const DB_SERVICE_URL = process.env.DB_SERVICE_URL?.trim();
+const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN?.trim();
+const QUIZ_BACKEND_URL = process.env.QUIZ_BACKEND_URL?.trim();
+// Auth/portal base a student opens the session on, e.g. https://staging-auth.avantifellows.org
+const SESSION_PORTAL_URL = process.env.SESSION_PORTAL_URL?.trim();
+
+// Matches the group the session is filed under; also the session_id prefix (EnableStudents_<quizId>).
+const SESSION_GROUP = "EnableStudents";
+const CMS_TEST_TYPES = ["chapter_test", "major_test"];
+const CMS_SOURCE = "nex-gen-cms";
+
+interface CreateFromCmsBody {
+  name?: string;
+  cmsTestId?: number;
+  testType?: string;
+  examTrack?: ExamTrack;
+  grade?: number;
+  testName?: string;
+  testCode?: string;
+  parentBatchId?: string;
+  classBatchIds?: string[];
+  stream?: string;
+  showAnswers?: boolean;
+  showScores?: boolean;
+  shuffle?: boolean;
+  gurukulFormatType?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+function dbHeaders() {
+  return {
+    Authorization: `Bearer ${DB_SERVICE_TOKEN}`,
+    "Content-Type": "application/json",
+    accept: "application/json",
+  };
+}
+
+// batch_id (string code) -> db group id, via db-service: batch code -> batch pk -> group.
+async function resolveGroupId(batchId: string): Promise<number | null> {
+  const batchRes = await fetch(
+    `${DB_SERVICE_URL}/batch?batch_id=${encodeURIComponent(batchId)}`,
+    { headers: dbHeaders(), cache: "no-store" }
+  );
+  if (!batchRes.ok) return null;
+  const batches = (await batchRes.json()) as { id: number }[];
+  const batchPk = batches?.[0]?.id;
+  if (!batchPk) return null;
+
+  const groupRes = await fetch(
+    `${DB_SERVICE_URL}/group/?child_id=${batchPk}&type=batch`,
+    { headers: dbHeaders(), cache: "no-store" }
+  );
+  if (!groupRes.ok) return null;
+  const groups = (await groupRes.json()) as { id: number }[];
+  return groups?.[0]?.id ?? null;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await requireQuizSessionAccess(session.user.email, "edit");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  if (!DB_SERVICE_URL || !DB_SERVICE_TOKEN) {
+    return NextResponse.json({ error: "DB service is not configured" }, { status: 500 });
+  }
+  if (!QUIZ_BACKEND_URL) {
+    return NextResponse.json({ error: "Quiz backend is not configured" }, { status: 500 });
+  }
+  if (!SESSION_PORTAL_URL) {
+    return NextResponse.json(
+      { error: "SESSION_PORTAL_URL is not configured" },
+      { status: 500 }
+    );
+  }
+
+  const body = (await request.json()) as CreateFromCmsBody;
+
+  if (!body.cmsTestId || Number.isNaN(Number(body.cmsTestId))) {
+    return NextResponse.json({ error: "cmsTestId is required" }, { status: 400 });
+  }
+  if (!body.examTrack || !EXAM_TRACKS.includes(body.examTrack)) {
+    return NextResponse.json({ error: "Valid examTrack is required" }, { status: 400 });
+  }
+  if (body.grade !== 11 && body.grade !== 12) {
+    return NextResponse.json({ error: "grade must be 11 or 12" }, { status: 400 });
+  }
+  if (!body.testType || !CMS_TEST_TYPES.includes(body.testType)) {
+    return NextResponse.json({ error: "Valid testType is required" }, { status: 400 });
+  }
+  if (!body.parentBatchId) {
+    return NextResponse.json({ error: "parentBatchId is required" }, { status: 400 });
+  }
+  if (!Array.isArray(body.classBatchIds) || body.classBatchIds.length === 0) {
+    return NextResponse.json(
+      { error: "At least one class batch is required" },
+      { status: 400 }
+    );
+  }
+  if (!(await canAccessQuizSessionBatches(access.permission, body.classBatchIds))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!body.stream) {
+    return NextResponse.json({ error: "stream is required" }, { status: 400 });
+  }
+  if (!body.startTime || !body.endTime) {
+    return NextResponse.json(
+      { error: "startTime and endTime are required" },
+      { status: 400 }
+    );
+  }
+  const start = new Date(body.startTime);
+  const end = new Date(body.endTime);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end <= start) {
+    return NextResponse.json({ error: "Invalid start or end time" }, { status: 400 });
+  }
+
+  const curriculumId = curriculumIdForExamTrack(body.examTrack);
+  const gradeRows = await query<{ id: number }>(
+    `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
+    [body.grade]
+  );
+  const gradeId = gradeRows[0]?.id;
+  if (!gradeId) {
+    return NextResponse.json(
+      { error: `No grade row for grade ${body.grade}` },
+      { status: 400 }
+    );
+  }
+
+  // 1. Build the quiz in quiz-backend from the CMS test (this writes to quiz Mongo).
+  let quizId: string;
+  let warnings: string[] = [];
+  try {
+    const quizRes = await fetch(`${QUIZ_BACKEND_URL}/quiz/from-cms`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", accept: "application/json" },
+      body: JSON.stringify({
+        test_id: Number(body.cmsTestId),
+        curriculum_id: curriculumId,
+        grade_id: gradeId,
+        quiz_type: "assessment",
+      }),
+    });
+    if (!quizRes.ok) {
+      const errorText = await quizRes.text();
+      console.error("quiz-backend /quiz/from-cms failed:", quizRes.status, errorText);
+      return NextResponse.json(
+        { error: "Failed to build quiz from CMS test" },
+        { status: 502 }
+      );
+    }
+    const quizData = (await quizRes.json()) as { id: string; warnings?: string[] };
+    quizId = quizData.id;
+    warnings = quizData.warnings ?? [];
+  } catch (err) {
+    console.error("Failed to reach quiz backend:", err);
+    return NextResponse.json({ error: "Failed to reach quiz backend" }, { status: 502 });
+  }
+
+  // 2. Materialize the session row. platform_id/session_id are known up front (unlike the
+  // legacy flow, which left them blank for the Lambda to patch), so the session is complete
+  // on create and needs no follow-up.
+  const sessionIdStr = `${SESSION_GROUP}_${quizId}`;
+  const portalLink = `${SESSION_PORTAL_URL.replace(/\/$/, "")}?sessionId=${sessionIdStr}`;
+  const startIst = utcToISTDate(body.startTime);
+  const endIst = utcToISTDate(body.endTime);
+  const sessionName = body.name?.trim() || (body.testName ?? "").trim() || sessionIdStr;
+  const shuffle = body.shuffle ?? false;
+  const gurukulFormatType = shuffle ? "qa" : body.gurukulFormatType || "both";
+
+  const sessionPayload = {
+    name: sessionName,
+    platform: "quiz",
+    type: "sign-in",
+    auth_type: "ID,DOB",
+    redirection: true,
+    id_generation: false,
+    signup_form: false,
+    popup_form: false,
+    signup_form_id: null,
+    popup_form_id: null,
+    session_id: sessionIdStr,
+    platform_id: quizId,
+    platform_link: quizId,
+    portal_link: portalLink,
+    start_time: startIst,
+    end_time: endIst,
+    repeat_schedule: { type: "continuous", params: [1, 2, 3, 4, 5, 6, 7] },
+    is_active: true,
+    purpose: { type: "attendance", params: "quiz" },
+    meta_data: {
+      group: SESSION_GROUP,
+      parent_id: body.parentBatchId,
+      batch_id: body.classBatchIds.join(","),
+      grade: body.grade,
+      stream: body.stream,
+      test_code: body.testCode ?? "",
+      test_name: body.testName ?? sessionName,
+      test_format: body.testType,
+      test_purpose: "test",
+      test_type: "assessment",
+      gurukul_format_type: gurukulFormatType,
+      marking_scheme: "4,-1",
+      optional_limits: null,
+      cms_source: CMS_SOURCE,
+      cms_test_id: String(body.cmsTestId),
+      cms_source_id: String(body.cmsTestId),
+      // Persist what the on-demand PDF proxy needs to re-fetch the test from the CMS.
+      cms_curriculum_id: curriculumId,
+      cms_grade_id: gradeId,
+      has_synced_to_bq: false,
+      infinite_session: false,
+      report_link: "",
+      shortened_link: "",
+      shortened_omr_link: "",
+      admin_testing_link: "",
+      admin_testing_omr_link: "",
+      show_answers: body.showAnswers ?? true,
+      show_scores: body.showScores ?? true,
+      shuffle,
+      single_page_mode: false,
+      test_takers_count: 100,
+      status: "success",
+      date_created: utcToISTDate(new Date().toISOString()),
+      created_by: session.user.email,
+      created_from: "lms",
+    },
+  };
+
+  const sessionRes = await fetch(`${DB_SERVICE_URL}/session`, {
+    method: "POST",
+    headers: dbHeaders(),
+    body: JSON.stringify(sessionPayload),
+  });
+  if (!sessionRes.ok) {
+    const errorText = await sessionRes.text();
+    console.error("DB service /session error:", sessionRes.status, errorText);
+    return NextResponse.json(
+      { error: "Failed to create session", quizId },
+      { status: sessionRes.status }
+    );
+  }
+  const sessionData = (await sessionRes.json()) as { id: number };
+  const sessionPk = sessionData.id;
+
+  // 3. One occurrence spanning the whole window (continuous session), mirroring the Lambda.
+  const occRes = await fetch(`${DB_SERVICE_URL}/session-occurrence`, {
+    method: "POST",
+    headers: dbHeaders(),
+    body: JSON.stringify({
+      start_time: startIst,
+      end_time: endIst,
+      session_fk: sessionPk,
+      session_id: sessionIdStr,
+    }),
+  });
+  if (!occRes.ok) {
+    const errorText = await occRes.text();
+    console.error("DB service /session-occurrence error:", occRes.status, errorText);
+    return NextResponse.json(
+      { error: "Session created but occurrence failed", id: sessionPk, quizId },
+      { status: occRes.status }
+    );
+  }
+
+  // 4. Link each class batch's group to the session so its students can access it.
+  for (const batchId of body.classBatchIds) {
+    const groupId = await resolveGroupId(batchId);
+    if (!groupId) {
+      console.error(`Could not resolve group for batch ${batchId}`);
+      return NextResponse.json(
+        { error: `Could not resolve group for batch ${batchId}`, id: sessionPk, quizId },
+        { status: 502 }
+      );
+    }
+    const groupSessionRes = await fetch(`${DB_SERVICE_URL}/group-session`, {
+      method: "POST",
+      headers: dbHeaders(),
+      body: JSON.stringify({ session_id: sessionPk, group_id: groupId }),
+    });
+    if (!groupSessionRes.ok) {
+      const errorText = await groupSessionRes.text();
+      console.error("DB service /group-session error:", groupSessionRes.status, errorText);
+      return NextResponse.json(
+        { error: `Failed to link batch ${batchId}`, id: sessionPk, quizId },
+        { status: groupSessionRes.status }
+      );
+    }
+  }
+
+  return NextResponse.json({ id: sessionPk, quizId, sessionId: sessionIdStr, warnings });
+}

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -26,6 +26,11 @@ const SESSION_PORTAL_URL = process.env.SESSION_PORTAL_URL?.trim();
 // Optional: when unset the links stay blank, session creation itself is unaffected.
 const QUIZ_FRONTEND_URL = process.env.QUIZ_FRONTEND_URL?.trim();
 const QUIZ_AF_API_KEY = process.env.QUIZ_AF_API_KEY?.trim();
+// AF link shortener (legacy sessionCreator parity), used for the student-facing session /
+// OMR links and the report link. Optional: when unset (or on any failure) the full URL is
+// stored instead — link population must never fail a create.
+const AF_SHORTENER_URL = process.env.AF_SHORTENER_URL?.trim();
+const AF_SHORTENER_AUTH_TOKEN = process.env.AF_SHORTENER_AUTH_TOKEN?.trim();
 
 // Matches the group the session is filed under; also the session_id prefix (EnableStudents_<quizId>).
 const SESSION_GROUP = "EnableStudents";
@@ -57,6 +62,36 @@ function dbHeaders() {
     "Content-Type": "application/json",
     accept: "application/json",
   };
+}
+
+// Best-effort AF-shortened URL (legacy shorten_url_AF): returns the original URL when the
+// shortener is unconfigured, errors, or answers with anything unexpected.
+async function shortenUrl(originalUrl: string, createdBy: string): Promise<string> {
+  if (!AF_SHORTENER_URL || !AF_SHORTENER_AUTH_TOKEN) return originalUrl;
+  try {
+    const res = await fetch(`${AF_SHORTENER_URL.replace(/\/$/, "")}/shorten`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AF_SHORTENER_AUTH_TOKEN}`,
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        original_url: originalUrl,
+        custom_code: "",
+        created_by: createdBy,
+      }),
+    });
+    if (!res.ok) {
+      console.warn(`URL shortener returned ${res.status} — storing full URL`);
+      return originalUrl;
+    }
+    const data = (await res.json()) as { short_url?: string };
+    return data.short_url || originalUrl;
+  } catch (err) {
+    console.warn("URL shortener unreachable — storing full URL:", err);
+    return originalUrl;
+  }
 }
 
 // batch_id (string code) -> db group id, via db-service: batch code -> batch pk -> group.
@@ -213,6 +248,17 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Student-facing shortened session/OMR links + the attendance report link (legacy
+  // sessionCreator parity; each falls back to its full URL if the shortener is unavailable).
+  const createdBy = session.user.email;
+  const shortenedLink = await shortenUrl(portalLink, createdBy);
+  const shortenedOmrLink = await shortenUrl(`${portalLink}&omrMode=true`, createdBy);
+  const reportLink = await shortenUrl(
+    `${SESSION_PORTAL_URL.replace(/\/$/, "")}?type=attendance&platform=report` +
+      `&platform_id=${sessionIdStr}&authGroup=${SESSION_GROUP}&auth_type=ID,DOB`,
+    createdBy
+  );
+
   const sessionPayload = {
     name: sessionName,
     platform: "quiz",
@@ -255,9 +301,9 @@ export async function POST(request: NextRequest) {
       cms_grade_id: gradeId,
       has_synced_to_bq: false,
       infinite_session: false,
-      report_link: "",
-      shortened_link: "",
-      shortened_omr_link: "",
+      report_link: reportLink,
+      shortened_link: shortenedLink,
+      shortened_omr_link: shortenedOmrLink,
       admin_testing_link: adminTestingLink,
       admin_testing_omr_link: adminTestingOmrLink,
       show_answers: body.showAnswers ?? true,

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -297,8 +297,8 @@ export async function POST(request: NextRequest) {
       cms_test_id: String(body.cmsTestId),
       cms_source_id: String(body.cmsTestId),
       // Persist what the on-demand PDF proxy needs to re-fetch the test from the CMS.
-      cms_curriculum_id: curriculumId,
-      cms_grade_id: gradeId,
+      cms_curriculum_id: String(curriculumId),
+      cms_grade_id: String(gradeId),
       has_synced_to_bq: false,
       infinite_session: false,
       report_link: reportLink,

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -21,6 +21,11 @@ const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN?.trim();
 const QUIZ_BACKEND_URL = process.env.QUIZ_BACKEND_URL?.trim();
 // Auth/portal base a student opens the session on, e.g. https://staging-auth.avantifellows.org
 const SESSION_PORTAL_URL = process.env.SESSION_PORTAL_URL?.trim();
+// Quiz frontend base + AF org api key, used only to build the admin Q&A testing links
+// (quiz player as whitelisted test_admin, no portal auth) — mirrors legacy sessionCreator.
+// Optional: when unset the links stay blank, session creation itself is unaffected.
+const QUIZ_FRONTEND_URL = process.env.QUIZ_FRONTEND_URL?.trim();
+const QUIZ_AF_API_KEY = process.env.QUIZ_AF_API_KEY?.trim();
 
 // Matches the group the session is filed under; also the session_id prefix (EnableStudents_<quizId>).
 const SESSION_GROUP = "EnableStudents";
@@ -193,6 +198,21 @@ export async function POST(request: NextRequest) {
   const shuffle = body.shuffle ?? false;
   const gurukulFormatType = shuffle ? "qa" : body.gurukulFormatType || "both";
 
+  // Admin Q&A testing links: quiz player as the whitelisted test_admin user (legacy
+  // sessionCreator parity). Blank when the frontend URL / api key aren't configured.
+  let adminTestingLink = "";
+  let adminTestingOmrLink = "";
+  if (QUIZ_FRONTEND_URL && QUIZ_AF_API_KEY) {
+    adminTestingLink =
+      `${QUIZ_FRONTEND_URL.replace(/\/$/, "")}/quiz/${quizId}` +
+      `?apiKey=${encodeURIComponent(QUIZ_AF_API_KEY)}&userId=test_admin`;
+    adminTestingOmrLink = `${adminTestingLink}&omrMode=true`;
+  } else {
+    console.warn(
+      "QUIZ_FRONTEND_URL / QUIZ_AF_API_KEY not configured — admin testing links left blank"
+    );
+  }
+
   const sessionPayload = {
     name: sessionName,
     platform: "quiz",
@@ -238,8 +258,8 @@ export async function POST(request: NextRequest) {
       report_link: "",
       shortened_link: "",
       shortened_omr_link: "",
-      admin_testing_link: "",
-      admin_testing_omr_link: "",
+      admin_testing_link: adminTestingLink,
+      admin_testing_omr_link: adminTestingOmrLink,
       show_answers: body.showAnswers ?? true,
       show_scores: body.showScores ?? true,
       shuffle,
@@ -268,6 +288,30 @@ export async function POST(request: NextRequest) {
   const sessionData = (await sessionRes.json()) as { id: number };
   const sessionPk = sessionData.id;
 
+  // If a later step fails, don't leave a live-looking session behind: mark it inactive and
+  // failed (best-effort — the create already failed, so this must not mask that error).
+  async function markSessionFailed(reason: string) {
+    try {
+      const res = await fetch(`${DB_SERVICE_URL}/session/${sessionPk}`, {
+        method: "PATCH",
+        headers: dbHeaders(),
+        body: JSON.stringify({
+          is_active: false,
+          meta_data: { ...sessionPayload.meta_data, status: "failed" },
+        }),
+      });
+      if (!res.ok) {
+        console.error(
+          `Failed to mark session ${sessionPk} failed after ${reason}:`,
+          res.status,
+          await res.text()
+        );
+      }
+    } catch (err) {
+      console.error(`Failed to mark session ${sessionPk} failed after ${reason}:`, err);
+    }
+  }
+
   // 3. One occurrence spanning the whole window (continuous session), mirroring the Lambda.
   const occRes = await fetch(`${DB_SERVICE_URL}/session-occurrence`, {
     method: "POST",
@@ -282,8 +326,13 @@ export async function POST(request: NextRequest) {
   if (!occRes.ok) {
     const errorText = await occRes.text();
     console.error("DB service /session-occurrence error:", occRes.status, errorText);
+    await markSessionFailed("occurrence failure");
     return NextResponse.json(
-      { error: "Session created but occurrence failed", id: sessionPk, quizId },
+      {
+        error: "Occurrence creation failed — session was deactivated. Retry the create.",
+        id: sessionPk,
+        quizId,
+      },
       { status: occRes.status }
     );
   }
@@ -293,8 +342,13 @@ export async function POST(request: NextRequest) {
     const groupId = await resolveGroupId(batchId);
     if (!groupId) {
       console.error(`Could not resolve group for batch ${batchId}`);
+      await markSessionFailed(`unresolvable batch ${batchId}`);
       return NextResponse.json(
-        { error: `Could not resolve group for batch ${batchId}`, id: sessionPk, quizId },
+        {
+          error: `Could not resolve group for batch ${batchId} — session was deactivated. Retry the create.`,
+          id: sessionPk,
+          quizId,
+        },
         { status: 502 }
       );
     }
@@ -306,8 +360,13 @@ export async function POST(request: NextRequest) {
     if (!groupSessionRes.ok) {
       const errorText = await groupSessionRes.text();
       console.error("DB service /group-session error:", groupSessionRes.status, errorText);
+      await markSessionFailed(`group-session failure for batch ${batchId}`);
       return NextResponse.json(
-        { error: `Failed to link batch ${batchId}`, id: sessionPk, quizId },
+        {
+          error: `Failed to link batch ${batchId} — session was deactivated. Retry the create.`,
+          id: sessionPk,
+          quizId,
+        },
         { status: groupSessionRes.status }
       );
     }

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import {
   canAccessQuizSessionBatches,
   requireQuizSessionAccess,
+  resolveBatchGroups,
 } from "@/lib/quiz-session-access";
 import { query } from "@/lib/db";
 import { utcToISTDate } from "@/lib/quiz-session-time";
@@ -32,8 +33,6 @@ const QUIZ_AF_API_KEY = process.env.QUIZ_AF_API_KEY?.trim();
 const AF_SHORTENER_URL = process.env.AF_SHORTENER_URL?.trim();
 const AF_SHORTENER_AUTH_TOKEN = process.env.AF_SHORTENER_AUTH_TOKEN?.trim();
 
-// Matches the group the session is filed under; also the session_id prefix (EnableStudents_<quizId>).
-const SESSION_GROUP = "EnableStudents";
 const CMS_TEST_TYPES = ["chapter_test", "major_test"];
 const CMS_SOURCE = "nex-gen-cms";
 
@@ -179,6 +178,30 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid start or end time" }, { status: 400 });
   }
 
+  const batchGroups = await resolveBatchGroups(body.classBatchIds);
+  const resolved = batchGroups.get(body.classBatchIds[0]);
+  if (!resolved) {
+    return NextResponse.json(
+      { error: "Selected batch has no auth group configured" },
+      { status: 400 }
+    );
+  }
+  const mismatchedBatchId = body.classBatchIds.find((batchId) => {
+    const batchGroup = batchGroups.get(batchId);
+    return (
+      !batchGroup ||
+      batchGroup.group !== resolved.group ||
+      batchGroup.authType !== resolved.authType
+    );
+  });
+  if (mismatchedBatchId) {
+    return NextResponse.json(
+      { error: "Selected class batches must share the same auth group" },
+      { status: 400 }
+    );
+  }
+  const { group, authType } = resolved;
+
   const curriculumId = curriculumIdForExamTrack(body.examTrack);
   const gradeRows = await query<{ id: number }>(
     `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
@@ -225,7 +248,7 @@ export async function POST(request: NextRequest) {
   // 2. Materialize the session row. platform_id/session_id are known up front (unlike the
   // legacy flow, which left them blank for the Lambda to patch), so the session is complete
   // on create and needs no follow-up.
-  const sessionIdStr = `${SESSION_GROUP}_${quizId}`;
+  const sessionIdStr = `${group}_${quizId}`;
   const portalLink = `${SESSION_PORTAL_URL.replace(/\/$/, "")}?sessionId=${sessionIdStr}`;
   const startIst = utcToISTDate(body.startTime);
   const endIst = utcToISTDate(body.endTime);
@@ -255,7 +278,9 @@ export async function POST(request: NextRequest) {
   const shortenedOmrLink = await shortenUrl(`${portalLink}&omrMode=true`, createdBy);
   const reportLink = await shortenUrl(
     `${SESSION_PORTAL_URL.replace(/\/$/, "")}?type=attendance&platform=report` +
-      `&platform_id=${sessionIdStr}&authGroup=${SESSION_GROUP}&auth_type=ID,DOB`,
+      `&platform_id=${encodeURIComponent(sessionIdStr)}` +
+      `&authGroup=${encodeURIComponent(group)}` +
+      `&auth_type=${encodeURIComponent(authType)}`,
     createdBy
   );
 
@@ -263,7 +288,7 @@ export async function POST(request: NextRequest) {
     name: sessionName,
     platform: "quiz",
     type: "sign-in",
-    auth_type: "ID,DOB",
+    auth_type: authType,
     redirection: true,
     id_generation: false,
     signup_form: false,
@@ -280,7 +305,7 @@ export async function POST(request: NextRequest) {
     is_active: true,
     purpose: { type: "attendance", params: "quiz" },
     meta_data: {
-      group: SESSION_GROUP,
+      group,
       parent_id: body.parentBatchId,
       batch_id: body.classBatchIds.join(","),
       grade: body.grade,

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/quiz-session-options";
 import { addHours, toDateTimeLocalValue } from "@/lib/quiz-session-time";
 import { parseBatchStream } from "@/lib/batch-code";
+import type { ExamTrack } from "@/types/curriculum";
 
 interface BatchOption {
   id: number;
@@ -80,6 +81,39 @@ const DEFAULT_DURATION_HOURS = 4;
 const AUTO_SYNC_INTERVAL_MINUTES = 60;
 const QA_GURUKUL_FORMAT = "qa";
 const GradeOptions = [11, 12];
+
+// New-CMS chapter-test picker (source toggle inside session creation).
+type TestSource = "legacy" | "cms";
+// New-CMS test subtypes the picker supports. chapter_test drills Subject -> Chapter;
+// major_test is full-syllabus (picked straight off exam track + grade). The CMS list route
+// is subtype-agnostic, so widening this list is a UI-only change.
+type CmsTestType = "chapter_test" | "major_test";
+const CMS_TEST_TYPE_OPTIONS: { value: CmsTestType; label: string }[] = [
+  { value: "chapter_test", label: "Chapter Test" },
+  { value: "major_test", label: "Major Test" },
+];
+const EXAM_TRACK_OPTIONS: { value: ExamTrack; label: string }[] = [
+  { value: "jee_main", label: "JEE Main" },
+  { value: "jee_advanced", label: "JEE Advanced" },
+  { value: "neet", label: "NEET" },
+];
+const CMS_SUBJECT_OPTIONS = ["Physics", "Chemistry", "Maths", "Biology"];
+const GRADE_ID_BY_NUMBER: Record<string, string> = { "11": "3", "12": "4" };
+
+interface CmsChapterOption {
+  id: number;
+  code: string;
+  name: string;
+}
+
+interface CmsTestOption {
+  id: number;
+  code: string;
+  name: string;
+  chapterId: number | null;
+  marks: number | null;
+  duration: string | null;
+}
 
 function getDefaultSessionName(baseName: string): string {
   return baseName.trim();
@@ -911,6 +945,21 @@ function QuizSessionCreateModal({
     return () => window.removeEventListener("keydown", handleEscape);
   }, [onClose]);
 
+  // New-CMS test picker. chapter_test drills Exam track -> Grade -> Subject -> Chapter -> test;
+  // major_test skips subject/chapter and lists straight off exam track + grade.
+  const [testSource, setTestSource] = useState<TestSource>("legacy");
+  const [cmsTestType, setCmsTestType] = useState<CmsTestType>("chapter_test");
+  const [cmsExamTrack, setCmsExamTrack] = useState<ExamTrack | "">("");
+  const [cmsGrade, setCmsGrade] = useState("");
+  const [cmsSubject, setCmsSubject] = useState("");
+  const [cmsChapters, setCmsChapters] = useState<CmsChapterOption[]>([]);
+  const [cmsChapterId, setCmsChapterId] = useState<number | null>(null);
+  const [cmsTests, setCmsTests] = useState<CmsTestOption[]>([]);
+  const [loadingCmsChapters, setLoadingCmsChapters] = useState(false);
+  const [loadingCmsTests, setLoadingCmsTests] = useState(false);
+  const [cmsError, setCmsError] = useState<string | null>(null);
+  const [selectedCmsTestId, setSelectedCmsTestId] = useState<number | null>(null);
+
   const parentIdSet = useMemo(() => {
     const set = new Set<number>();
     batches.forEach((batch) => {
@@ -1056,6 +1105,100 @@ function QuizSessionCreateModal({
     [selectedTemplateId, templates]
   );
 
+  // CMS cascade: fetch in-syllabus chapters once exam-track + grade + subject are chosen.
+  // Only chapter tests drill by chapter; major tests skip this step entirely.
+  useEffect(() => {
+    if (
+      testSource !== "cms" ||
+      cmsTestType !== "chapter_test" ||
+      !cmsExamTrack ||
+      !cmsGrade ||
+      !cmsSubject
+    ) {
+      setCmsChapters([]);
+      setCmsChapterId(null);
+      return;
+    }
+    let cancelled = false;
+    async function run() {
+      setLoadingCmsChapters(true);
+      setCmsError(null);
+      try {
+        const params = new URLSearchParams({
+          exam_track: cmsExamTrack,
+          grade: cmsGrade,
+          subject: cmsSubject,
+        });
+        const res = await fetch(`/api/cms/chapters?${params.toString()}`);
+        if (!res.ok) throw new Error("Failed to fetch chapters");
+        const data = await res.json();
+        if (!cancelled) setCmsChapters(data.chapters ?? []);
+      } catch (err) {
+        if (!cancelled) {
+          setCmsError((err as Error).message);
+          setCmsChapters([]);
+        }
+      } finally {
+        if (!cancelled) setLoadingCmsChapters(false);
+      }
+    }
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [testSource, cmsTestType, cmsExamTrack, cmsGrade, cmsSubject]);
+
+  useEffect(() => {
+    if (cmsChapterId && !cmsChapters.some((chapter) => chapter.id === cmsChapterId)) {
+      setCmsChapterId(null);
+    }
+  }, [cmsChapterId, cmsChapters]);
+
+  // CMS cascade: fetch tests once the type's inputs are complete — chapter tests need a
+  // chapter selected; major tests list straight off exam track + grade.
+  const cmsTestsReady =
+    testSource === "cms" &&
+    !!cmsExamTrack &&
+    !!cmsGrade &&
+    (cmsTestType === "major_test" || cmsChapterId !== null);
+  useEffect(() => {
+    if (!cmsTestsReady) {
+      setCmsTests([]);
+      setSelectedCmsTestId(null);
+      return;
+    }
+    let cancelled = false;
+    async function run() {
+      setLoadingCmsTests(true);
+      setCmsError(null);
+      try {
+        const params = new URLSearchParams({
+          exam_track: cmsExamTrack,
+          grade_id: GRADE_ID_BY_NUMBER[cmsGrade] ?? "",
+          test_type: cmsTestType,
+        });
+        if (cmsTestType === "chapter_test" && cmsChapterId !== null) {
+          params.set("chapter_id", String(cmsChapterId));
+        }
+        const res = await fetch(`/api/cms/tests?${params.toString()}`);
+        if (!res.ok) throw new Error("Failed to fetch tests");
+        const data = await res.json();
+        if (!cancelled) setCmsTests(data.tests ?? []);
+      } catch (err) {
+        if (!cancelled) {
+          setCmsError((err as Error).message);
+          setCmsTests([]);
+        }
+      } finally {
+        if (!cancelled) setLoadingCmsTests(false);
+      }
+    }
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [cmsTestsReady, testSource, cmsTestType, cmsExamTrack, cmsGrade, cmsChapterId]);
+
   useEffect(() => {
     if (!selectedTemplate) {
       if (!nameEdited) {
@@ -1089,11 +1232,21 @@ function QuizSessionCreateModal({
     if (!batchDerivation.stream) {
       return "Batch details could not be derived.";
     }
-    if (!selectedGrade) return "Grade is required.";
-    if (!testFormat) return "Test format is required.";
-    if (!selectedTemplate) return "Please select a paper.";
-    if (selectedTemplate.grade === null) {
-      return "Selected paper is missing grade metadata.";
+
+    if (testSource === "cms") {
+      if (!cmsExamTrack) return "Exam track is required.";
+      if (!cmsGrade) return "Grade is required.";
+      if (cmsTestType === "chapter_test" && cmsChapterId === null) {
+        return "Chapter is required.";
+      }
+      if (selectedCmsTestId === null) return "Please select a CMS test.";
+    } else {
+      if (!selectedGrade) return "Grade is required.";
+      if (!testFormat) return "Test format is required.";
+      if (!selectedTemplate) return "Please select a paper.";
+      if (selectedTemplate.grade === null) {
+        return "Selected paper is missing grade metadata.";
+      }
     }
 
     if (timingMode === "schedule") {
@@ -1117,8 +1270,6 @@ function QuizSessionCreateModal({
       return;
     }
 
-    if (!selectedTemplate || selectedTemplate.grade === null) return;
-
     setSaving(true);
     setError(null);
 
@@ -1129,6 +1280,48 @@ function QuizSessionCreateModal({
         timingMode === "start_now"
           ? addHours(computedStart, DEFAULT_DURATION_HOURS)
           : new Date(endTime);
+
+      if (testSource === "cms") {
+        // Synchronous CMS path: af_lms builds the quiz + materializes the session itself
+        // (no SNS/Lambda), so the session is ready when this returns.
+        const selectedCmsTest = cmsTests.find(
+          (test) => test.id === selectedCmsTestId
+        );
+        const cmsPayload = {
+          name: name.trim() || selectedCmsTest?.name || "",
+          cmsTestId: selectedCmsTestId,
+          testType: cmsTestType,
+          examTrack: cmsExamTrack,
+          grade: Number(cmsGrade),
+          testName: selectedCmsTest?.name,
+          testCode: selectedCmsTest?.code,
+          parentBatchId: batchDerivation.parentBatchId,
+          classBatchIds,
+          stream: batchDerivation.stream,
+          showAnswers,
+          showScores,
+          shuffle,
+          gurukulFormatType: getGurukulFormatForShuffle(gurukulFormatType, shuffle),
+          startTime: computedStart.toISOString(),
+          endTime: computedEnd.toISOString(),
+        };
+
+        const response = await fetch("/api/quiz-sessions/from-cms", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cmsPayload),
+        });
+
+        if (!response.ok) {
+          const data = await response.json();
+          throw new Error(data.error || "Failed to create session");
+        }
+
+        onCreated("Session created.");
+        return;
+      }
+
+      if (!selectedTemplate || selectedTemplate.grade === null) return;
 
       const payload = {
         name: name.trim() || getDefaultSessionName(selectedTemplate.name),
@@ -1241,6 +1434,30 @@ function QuizSessionCreateModal({
 
               <SectionCard title="2. Select Paper">
                 <div className="space-y-4">
+                  <div className="flex flex-wrap gap-2">
+                    {(
+                      [
+                        { value: "legacy", label: "Legacy paper" },
+                        { value: "cms", label: "New CMS Test" },
+                      ] as { value: TestSource; label: string }[]
+                    ).map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => setTestSource(option.value)}
+                        className={`rounded-lg border px-3 py-1.5 text-sm font-medium ${
+                          testSource === option.value
+                            ? "border-accent bg-accent text-text-on-accent"
+                            : "border-border bg-bg-card text-text-primary hover:bg-hover-bg"
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {testSource === "legacy" && (
+                  <div className="space-y-4">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div>
                       <label
@@ -1367,6 +1584,216 @@ function QuizSessionCreateModal({
                           </div>
                         );
                       })}
+                    </div>
+                  )}
+                  </div>
+                  )}
+
+                  {testSource === "cms" && (
+                    <div className="space-y-4">
+                      <div className="grid gap-4 md:grid-cols-3">
+                        <div>
+                          <label className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                            Test type
+                          </label>
+                          <select
+                            value={cmsTestType}
+                            onChange={(event) => {
+                              setCmsTestType(event.target.value as CmsTestType);
+                              // Chapter/subject are only meaningful for chapter tests; clear
+                              // them (and any selection) when the type changes.
+                              setCmsSubject("");
+                              setCmsChapterId(null);
+                              setSelectedCmsTestId(null);
+                            }}
+                            className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                          >
+                            {CMS_TEST_TYPE_OPTIONS.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div>
+                          <label className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                            Exam Track
+                          </label>
+                          <select
+                            value={cmsExamTrack}
+                            onChange={(event) => {
+                              setCmsExamTrack(event.target.value as ExamTrack | "");
+                              setCmsChapterId(null);
+                            }}
+                            className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                          >
+                            <option value="">Select exam track</option>
+                            {EXAM_TRACK_OPTIONS.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div>
+                          <label className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                            Grade
+                          </label>
+                          <select
+                            value={cmsGrade}
+                            onChange={(event) => {
+                              setCmsGrade(event.target.value);
+                              setCmsChapterId(null);
+                            }}
+                            className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                          >
+                            <option value="">Select grade</option>
+                            {GradeOptions.map((grade) => (
+                              <option key={grade} value={grade}>
+                                {grade}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      {cmsTestType === "chapter_test" && (
+                        <div className="grid gap-4 md:grid-cols-3">
+                          <div>
+                            <label className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                              Subject
+                            </label>
+                            <select
+                              value={cmsSubject}
+                              onChange={(event) => {
+                                setCmsSubject(event.target.value);
+                                setCmsChapterId(null);
+                              }}
+                              className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                            >
+                              <option value="">Select subject</option>
+                              {CMS_SUBJECT_OPTIONS.map((subject) => (
+                                <option key={subject} value={subject}>
+                                  {subject}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+
+                          <div className="md:col-span-2">
+                            <label className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted">
+                              Chapter
+                            </label>
+                            <select
+                              value={cmsChapterId ?? ""}
+                              onChange={(event) =>
+                                setCmsChapterId(
+                                  event.target.value ? Number(event.target.value) : null
+                                )
+                              }
+                              disabled={
+                                !cmsExamTrack || !cmsGrade || !cmsSubject || loadingCmsChapters
+                              }
+                              className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-60"
+                            >
+                              <option value="">
+                                {loadingCmsChapters ? "Loading chapters..." : "Select chapter"}
+                              </option>
+                              {cmsChapters.map((chapter) => (
+                                <option key={chapter.id} value={chapter.id}>
+                                  {chapter.name}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                      )}
+
+                      {cmsError && (
+                        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                          {cmsError}
+                        </div>
+                      )}
+
+                      {!cmsTestsReady ? (
+                        <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                          {cmsTestType === "chapter_test"
+                            ? "Choose exam track, grade, subject, and chapter to see its tests."
+                            : "Choose exam track and grade to see the major tests."}
+                        </div>
+                      ) : loadingCmsTests ? (
+                        <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                          Loading tests...
+                        </div>
+                      ) : cmsTests.length === 0 ? (
+                        <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                          {cmsTestType === "chapter_test"
+                            ? "No chapter tests found for this chapter."
+                            : "No major tests found for this exam track and grade."}
+                        </div>
+                      ) : (
+                        <div className="max-h-72 overflow-y-auto rounded-lg border border-border">
+                          {cmsTests.map((test) => {
+                            const isSelected = test.id === selectedCmsTestId;
+                            return (
+                              <div
+                                key={test.id}
+                                role="button"
+                                aria-pressed={isSelected}
+                                tabIndex={0}
+                                onClick={() =>
+                                  setSelectedCmsTestId((previous) =>
+                                    previous === test.id ? null : test.id
+                                  )
+                                }
+                                onKeyDown={(event) => {
+                                  if (event.key === "Enter" || event.key === " ") {
+                                    event.preventDefault();
+                                    setSelectedCmsTestId((previous) =>
+                                      previous === test.id ? null : test.id
+                                    );
+                                  }
+                                }}
+                                className={`flex w-full items-start gap-3 border-b border-border px-3 py-3 text-left last:border-b-0 ${
+                                  isSelected
+                                    ? "bg-success-bg"
+                                    : "bg-bg-card hover:bg-hover-bg"
+                                }`}
+                              >
+                                <span
+                                  className={`mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center border text-[11px] leading-none ${
+                                    isSelected
+                                      ? "border-accent bg-accent text-text-on-accent"
+                                      : "border-border bg-bg-card text-transparent"
+                                  }`}
+                                  aria-hidden="true"
+                                >
+                                  ✓
+                                </span>
+                                <div className="min-w-0 flex-1">
+                                  <div className="text-sm font-semibold text-text-primary">
+                                    {test.name}
+                                  </div>
+                                  <div className="mt-1 font-mono text-xs text-accent">
+                                    {test.code || "-"}
+                                  </div>
+                                  <div className="mt-1 text-xs text-text-secondary">
+                                    {test.marks !== null ? `${test.marks} marks` : ""}
+                                    {test.duration ? ` · ${test.duration} min` : ""}
+                                  </div>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+
+                      <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-2 text-xs text-text-secondary">
+                        The quiz is built and the session is created in one step when you
+                        click Create Session — this may take a few seconds.
+                      </div>
                     </div>
                   )}
                 </div>
@@ -1976,10 +2403,7 @@ function QuizSessionDetailsModal({
                   label="Ranking Cutoff"
                   value={formatDate(getMetaString(session.meta_data, "ranking_cutoff_date"))}
                 />
-                <PaperResourceLinks
-                  questionHref={getMetaString(session.meta_data, "question_pdf")}
-                  solutionHref={getMetaString(session.meta_data, "solution_pdf")}
-                />
+                <CmsAwarePaperLinks meta={session.meta_data} />
               </div>
             </SectionCard>
 
@@ -2277,6 +2701,40 @@ function PaperLinkChip({
       <span>{label}</span>
       <ExternalLinkIcon />
     </a>
+  );
+}
+
+// Chooses PDF links for the session-details Paper card: for new-CMS sessions the PDFs are
+// generated on demand (proxy route), rebuilt from the CMS ids stored at create time; for
+// legacy sessions they're the stored question_pdf/solution_pdf URLs.
+function CmsAwarePaperLinks({
+  meta,
+}: {
+  meta: Record<string, unknown> | null | undefined;
+}) {
+  const cmsSource = getMetaString(meta, "cms_source");
+  const cmsTestId = getMetaString(meta, "cms_test_id");
+  const curriculumId = getMetaString(meta, "cms_curriculum_id");
+  const gradeId = getMetaString(meta, "cms_grade_id");
+
+  if (cmsSource && cmsTestId && curriculumId && gradeId) {
+    const base =
+      `/api/cms/test-pdf?testId=${encodeURIComponent(cmsTestId)}` +
+      `&curriculumId=${encodeURIComponent(curriculumId)}` +
+      `&gradeId=${encodeURIComponent(gradeId)}`;
+    return (
+      <PaperResourceLinks
+        questionHref={`${base}&type=questions`}
+        solutionHref={`${base}&type=answers`}
+      />
+    );
+  }
+
+  return (
+    <PaperResourceLinks
+      questionHref={getMetaString(meta, "question_pdf")}
+      solutionHref={getMetaString(meta, "solution_pdf")}
+    />
   );
 }
 

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -8,6 +8,11 @@ import {
 } from "@/lib/quiz-session-options";
 import { addHours, toDateTimeLocalValue } from "@/lib/quiz-session-time";
 import { parseBatchStream } from "@/lib/batch-code";
+import {
+  CMS_SOURCE,
+  CMS_TEST_TYPE_OPTIONS,
+  type CmsTestType,
+} from "@/lib/cms-tests";
 import type { ExamTrack } from "@/types/curriculum";
 
 interface BatchOption {
@@ -82,16 +87,9 @@ const AUTO_SYNC_INTERVAL_MINUTES = 60;
 const QA_GURUKUL_FORMAT = "qa";
 const GradeOptions = [11, 12];
 
-// New-CMS chapter-test picker (source toggle inside session creation).
+// New-CMS chapter-test picker (source toggle inside session creation). Test subtypes +
+// their labels are shared with the server routes via CMS_TEST_TYPE_OPTIONS (@/lib/cms-tests).
 type TestSource = "legacy" | "cms";
-// New-CMS test subtypes the picker supports. chapter_test drills Subject -> Chapter;
-// major_test is full-syllabus (picked straight off exam track + grade). The CMS list route
-// is subtype-agnostic, so widening this list is a UI-only change.
-type CmsTestType = "chapter_test" | "major_test";
-const CMS_TEST_TYPE_OPTIONS: { value: CmsTestType; label: string }[] = [
-  { value: "chapter_test", label: "Chapter Test" },
-  { value: "major_test", label: "Major Test" },
-];
 const EXAM_TRACK_OPTIONS: { value: ExamTrack; label: string }[] = [
   { value: "jee_main", label: "JEE Main" },
   { value: "jee_advanced", label: "JEE Advanced" },
@@ -845,6 +843,11 @@ export default function QuizSessionsTab({
             const busy = savingAction?.id === menuState.id;
             const enabled = currentSession?.is_active !== false;
             const endNowAvailable = canEndNow(currentSession, currentTimeMs);
+            // Regenerate fires the legacy SNS -> etl-data-flow path, which cannot rebuild a
+            // new-CMS quiz. Hide it for CMS sessions until the CMS regenerate path ships;
+            // clicking it would flip the session to a stuck "pending" and brick its actions.
+            const isCmsSession =
+              getMetaString(currentSession?.meta_data, "cms_source") === CMS_SOURCE;
 
             return (
               <>
@@ -889,17 +892,19 @@ export default function QuizSessionsTab({
                     </span>
                   </button>
                 ) : null}
-                <button
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleRegenerate(menuState.id);
-                    setMenuState(null);
-                  }}
-                  disabled={sessionProcessing || busy}
-                  className="block w-full px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
-                >
-                  Regenerate
-                </button>
+                {!isCmsSession ? (
+                  <button
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleRegenerate(menuState.id);
+                      setMenuState(null);
+                    }}
+                    disabled={sessionProcessing || busy}
+                    className="block w-full px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
+                  >
+                    Regenerate
+                  </button>
+                ) : null}
               </>
             );
           })()}

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -2639,6 +2639,16 @@ function ExternalLinkIcon() {
   );
 }
 
+function DownloadIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5">
+      <path d="M8 2v8" />
+      <path d="m4.5 7 3.5 3.5L11.5 7" />
+      <path d="M3 13h10" />
+    </svg>
+  );
+}
+
 function ChevronDownIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -2723,6 +2733,31 @@ function PaperLinkChip({
   );
 }
 
+// Icon-only companion to PaperLinkChip: saves the file instead of opening it. Only
+// rendered when a same-origin download href exists (the CMS proxy with download=1).
+function PaperDownloadChip({
+  href,
+  label,
+}: {
+  href?: string;
+  label: string;
+}) {
+  const value = href?.trim();
+  if (!value) return null;
+
+  return (
+    <a
+      href={value}
+      download
+      title={label}
+      aria-label={label}
+      className="inline-flex items-center rounded-full border border-border bg-bg-card px-2 py-1 text-xs font-medium text-text-primary hover:border-accent hover:text-accent"
+    >
+      <DownloadIcon />
+    </a>
+  );
+}
+
 // Chooses PDF links for the session-details Paper card: for new-CMS sessions the PDFs are
 // generated on demand (proxy route), rebuilt from the CMS ids stored at create time; for
 // legacy sessions they're the stored question_pdf/solution_pdf URLs.
@@ -2745,6 +2780,8 @@ function CmsAwarePaperLinks({
       <PaperResourceLinks
         questionHref={`${base}&type=questions`}
         solutionHref={`${base}&type=answers`}
+        questionDownloadHref={`${base}&type=questions&download=1`}
+        solutionDownloadHref={`${base}&type=answers&download=1`}
       />
     );
   }
@@ -2760,10 +2797,14 @@ function CmsAwarePaperLinks({
 function PaperResourceLinks({
   questionHref,
   solutionHref,
+  questionDownloadHref,
+  solutionDownloadHref,
   inline = false,
 }: {
   questionHref?: string;
   solutionHref?: string;
+  questionDownloadHref?: string;
+  solutionDownloadHref?: string;
   inline?: boolean;
 }) {
   if (!questionHref?.trim() && !solutionHref?.trim()) {
@@ -2780,7 +2821,9 @@ function PaperResourceLinks({
   const content = (
     <div className="flex flex-wrap items-center gap-2" onClick={(event) => event.stopPropagation()}>
       <PaperLinkChip href={questionHref} label="Question PDF" />
+      <PaperDownloadChip href={questionDownloadHref} label="Download Question PDF" />
       <PaperLinkChip href={solutionHref} label="Answer PDF" />
+      <PaperDownloadChip href={solutionDownloadHref} label="Download Answer PDF" />
     </div>
   );
 

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -851,18 +851,24 @@ export default function QuizSessionsTab({
 
             return (
               <>
-                <button
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    if (!currentSession) return;
-                    setEditingSession(currentSession);
-                    setMenuState(null);
-                  }}
-                  disabled={sessionProcessing || busy}
-                  className="block w-full px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
-                >
-                  Edit
-                </button>
+                {/* Edit is hidden for new-CMS sessions only: their edit path fires the
+                    legacy SNS patch, which KeyErrors on the absent meta_data.course and
+                    flips the session to "failed". Legacy sessions still edit normally.
+                    Re-enable for CMS once the CMS session-patch fix ships. */}
+                {!isCmsSession ? (
+                  <button
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      if (!currentSession) return;
+                      setEditingSession(currentSession);
+                      setMenuState(null);
+                    }}
+                    disabled={sessionProcessing || busy}
+                    className="block w-full px-4 py-2 text-left text-sm font-medium text-text-primary hover:bg-hover-bg disabled:text-text-muted"
+                  >
+                    Edit
+                  </button>
+                ) : null}
                 <button
                   onClick={(event) => {
                     event.stopPropagation();
@@ -2363,6 +2369,9 @@ function QuizSessionDetailsModal({
   const classBatchNames = classBatchIds?.map(
     (batchId) => batchNameMap.get(batchId) || batchId
   );
+  // Edit is hidden for new-CMS sessions until the CMS session-patch fix ships (the legacy
+  // edit path KeyErrors on the absent meta_data.course). Legacy sessions edit normally.
+  const isCmsSession = getMetaString(session.meta_data, "cms_source") === CMS_SOURCE;
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -2382,7 +2391,7 @@ function QuizSessionDetailsModal({
               </h2>
             </div>
             <div className="flex items-center gap-3">
-              {canEdit ? (
+              {canEdit && !isCmsSession ? (
                 <button
                   type="button"
                   onClick={onEdit}

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -218,6 +218,16 @@ function getMetaString(
   return typeof value === "string" ? value : undefined;
 }
 
+function getMetaScalar(
+  meta: Record<string, unknown> | null | undefined,
+  key: string
+): string | undefined {
+  const value = meta?.[key];
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
 function getMetaBoolean(
   meta: Record<string, unknown> | null | undefined,
   key: string
@@ -2767,9 +2777,10 @@ function CmsAwarePaperLinks({
   meta: Record<string, unknown> | null | undefined;
 }) {
   const cmsSource = getMetaString(meta, "cms_source");
-  const cmsTestId = getMetaString(meta, "cms_test_id");
-  const curriculumId = getMetaString(meta, "cms_curriculum_id");
-  const gradeId = getMetaString(meta, "cms_grade_id");
+  // Ids may be stored as numbers (older sessions) or strings — accept both.
+  const cmsTestId = getMetaScalar(meta, "cms_test_id");
+  const curriculumId = getMetaScalar(meta, "cms_curriculum_id");
+  const gradeId = getMetaScalar(meta, "cms_grade_id");
 
   if (cmsSource && cmsTestId && curriculumId && gradeId) {
     const base =

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -98,7 +98,6 @@ const EXAM_TRACK_OPTIONS: { value: ExamTrack; label: string }[] = [
   { value: "neet", label: "NEET" },
 ];
 const CMS_SUBJECT_OPTIONS = ["Physics", "Chemistry", "Maths", "Biology"];
-const GRADE_ID_BY_NUMBER: Record<string, string> = { "11": "3", "12": "4" };
 
 interface CmsChapterOption {
   id: number;
@@ -1174,7 +1173,7 @@ function QuizSessionCreateModal({
       try {
         const params = new URLSearchParams({
           exam_track: cmsExamTrack,
-          grade_id: GRADE_ID_BY_NUMBER[cmsGrade] ?? "",
+          grade: cmsGrade,
           test_type: cmsTestType,
         });
         if (cmsTestType === "chapter_test" && cmsChapterId !== null) {
@@ -1183,7 +1182,17 @@ function QuizSessionCreateModal({
         const res = await fetch(`/api/cms/tests?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch tests");
         const data = await res.json();
-        if (!cancelled) setCmsTests(data.tests ?? []);
+        if (!cancelled) {
+          const tests: CmsTestOption[] = data.tests ?? [];
+          setCmsTests(tests);
+          // The list may have been refetched under new filters (e.g. exam track changed
+          // with major_test still ready) — drop any selection the new list doesn't contain.
+          setSelectedCmsTestId((previous) =>
+            previous !== null && tests.some((test) => test.id === previous)
+              ? previous
+              : null
+          );
+        }
       } catch (err) {
         if (!cancelled) {
           setCmsError((err as Error).message);
@@ -1287,14 +1296,17 @@ function QuizSessionCreateModal({
         const selectedCmsTest = cmsTests.find(
           (test) => test.id === selectedCmsTestId
         );
+        if (!selectedCmsTest) {
+          throw new Error("Selected test is no longer in the list — pick it again.");
+        }
         const cmsPayload = {
-          name: name.trim() || selectedCmsTest?.name || "",
-          cmsTestId: selectedCmsTestId,
+          name: name.trim() || selectedCmsTest.name || "",
+          cmsTestId: selectedCmsTest.id,
           testType: cmsTestType,
           examTrack: cmsExamTrack,
           grade: Number(cmsGrade),
-          testName: selectedCmsTest?.name,
-          testCode: selectedCmsTest?.code,
+          testName: selectedCmsTest.name,
+          testCode: selectedCmsTest.code,
           parentBatchId: batchDerivation.parentBatchId,
           classBatchIds,
           stream: batchDerivation.stream,
@@ -1312,12 +1324,19 @@ function QuizSessionCreateModal({
           body: JSON.stringify(cmsPayload),
         });
 
+        const data = await response.json();
         if (!response.ok) {
-          const data = await response.json();
           throw new Error(data.error || "Failed to create session");
         }
 
-        onCreated("Session created.");
+        // Surface non-fatal quiz-build warnings (e.g. question subtypes the mapper had to
+        // approximate) — the quiz is live, but the creator should eyeball it.
+        const warnings: string[] = data.warnings ?? [];
+        onCreated(
+          warnings.length
+            ? `Session created with warnings: ${warnings.join("; ")}`
+            : "Session created."
+        );
         return;
       }
 

--- a/src/lib/cms-tests.ts
+++ b/src/lib/cms-tests.ts
@@ -1,0 +1,23 @@
+// Shared new-CMS test constants. Imported by both the server routes (list/create
+// validation) and the client picker (dropdown), so the UI can never offer a test type the
+// create/list routes would reject. No server-only imports here — safe for client bundles.
+
+// Test subtypes the picker supports. chapter_test is chapter-scoped; major_test is
+// full-syllabus. Both flow through the same CMS list route + quiz-backend ingest, so
+// widening this list is a UI-only change.
+export const CMS_TEST_TYPES = ["chapter_test", "major_test"] as const;
+export type CmsTestType = (typeof CMS_TEST_TYPES)[number];
+
+export const CMS_TEST_TYPE_OPTIONS: { value: CmsTestType; label: string }[] = [
+  { value: "chapter_test", label: "Chapter Test" },
+  { value: "major_test", label: "Major Test" },
+];
+
+// Discriminator stored on sessions created from the new CMS (meta_data.cms_source). Used to
+// tell CMS-sourced sessions apart from legacy ones (e.g. to gate legacy-only row actions).
+export const CMS_SOURCE = "nex-gen-cms";
+
+// Narrow an arbitrary string to a supported CMS test type.
+export function isCmsTestType(value: string | undefined): value is CmsTestType {
+  return !!value && (CMS_TEST_TYPES as readonly string[]).includes(value);
+}

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -122,6 +122,30 @@ export function curriculumIdForExamTrack(examTrack: ExamTrack): number {
   return EXAM_TRACK_CURRICULUM_IDS[examTrack];
 }
 
+// The batch stream (as produced by parseBatchStream: "engineering" | "medical") each exam
+// track targets. Used to reject mismatched pairings (e.g. a NEET test on an engineering
+// batch), which would otherwise put a wrong-subject test live for those students.
+const EXAM_TRACK_STREAMS: Record<ExamTrack, string> = {
+  jee_main: "engineering",
+  jee_advanced: "engineering",
+  neet: "medical",
+};
+
+export function streamForExamTrack(examTrack: ExamTrack): string {
+  return EXAM_TRACK_STREAMS[examTrack];
+}
+
+// CMS grade id from the grade table (grade number -> id). Both CMS routes resolve it via
+// the DB rather than a client-supplied map (which could drift), so the lookup lives here
+// once. Returns null when no grade row matches.
+export async function resolveGradeId(gradeNumber: number): Promise<number | null> {
+  const rows = await query<{ id: number }>(
+    `SELECT id FROM grade WHERE number = $1 LIMIT 1`,
+    [gradeNumber]
+  );
+  return rows[0]?.id ?? null;
+}
+
 function sortByCurriculumOrder<T extends { examTrack: ExamTrack; grade: number; subject: SubjectName }>(
   rows: T[]
 ): T[] {


### PR DESCRIPTION
Adds the af_lms side of the new-CMS test → session flow. Picking a test authored in the new CMS (nex-gen-cms) now builds the quiz and creates the session **synchronously in af_lms**, replacing the legacy SNS → sessionCreator Lambda hop for these tests.

Pairs with **quiz-backend #158** (CMS→quiz mapper + `/quiz/from-cms`) and **nex-gen-cms #151** (CMS service routes: list/assembled JSON + `chapter_id` + `/api/service/test-pdf`). db-service #574 (chapter_id backfill) already merged.

## What's here
- **Picker** — the create modal gains a "New CMS Test" source with a **test-type dropdown** (Chapter Test | Major Test). Chapter tests cascade Exam Track → Grade → Subject → Chapter; major tests list off exam track + grade.
- **Create wiring** — `POST /api/quiz-sessions/from-cms`: `quiz-backend /quiz/from-cms` → `quizId` → db-service `/session` + `session_occurrence` + `group_session`, tagged `cms_source`. No SNS.
- **Server routes** — `/api/cms/tests` (chapter/major, matched by chapter **code** to survive duplicate chapter rows), `/api/cms/chapters` (deduped by code), `/api/cms/test-pdf` (on-demand question/answer PDF proxy to the CMS).
- **Session details** — question/answer PDF links for CMS sessions, generated on demand (parity with legacy's stored PDFs).
- New env: `CMS_SERVICE_URL`, `CMS_SERVICE_TOKEN`, `QUIZ_BACKEND_URL`, `SESSION_PORTAL_URL` (documented in `.env.example`).

## Testing
Verified end-to-end against staging (db-service + quiz Mongo): created session `EnableStudents_6a463039d0e950a1ae6c840c` from chapter test 1229 — session row, occurrence, group-session all correct; quiz doc in Mongo (20 single-choice + 5 numerical-integer); PDFs generate and stream through the proxy. Full af_lms suite green (2438 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)