### PR TITLE
[codex] Remove mentorship card from admin page

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -33,5 +33,7 @@ jobs:
           annotations: true
           comment: true
           review-comments: false
-          diff-filter: added
+          # Match the audit gate's changed-file scope. `added` can hide
+          # fail-level findings that anchor to existing/context lines.
+          diff-filter: file
           artifacts-dir: .var/fallow

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -297,7 +297,7 @@ _Avoid_: Academic Mentorship tab
 - Academic Mentorship mentee selection uses the same active-student rules as the School page roster for the selected School and academic year, excluding dropouts and students who already have an active mapping
 - Academic Mentorship access in v1 is controlled by role, school scope, `read_only`, and the Academic Mentorship Program allowlist
 - Academic Mentorship data model supports all programs, including NVS and PMU schools
-- `program_admin` users can enter `/admin` only to discover Academic Mentorship management; existing admin-only cards remain restricted to `admin`
+- `/admin` does not show an Academic Mentorship card; Academic Mentorship management entry comes from the School page **Mentorship Tab** Manage mappings link
 - `read_only` downgrades Academic Mentorship management to view-only
 - A **PM** creates **Visits** to a **School**
 - A **Visit** has many **Actions** (each with an **Action Type**)

--- a/src/app/admin/academic-mentorship/loading.test.tsx
+++ b/src/app/admin/academic-mentorship/loading.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import AcademicMentorshipLoading from "./loading";
+
+describe("AcademicMentorshipLoading", () => {
+  it("shows a route-level loading state", () => {
+    render(<AcademicMentorshipLoading />);
+
+    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading mentorship mappings...");
+  });
+});

--- a/src/app/admin/academic-mentorship/loading.tsx
+++ b/src/app/admin/academic-mentorship/loading.tsx
@@ -1,0 +1,33 @@
+import { Card } from "@/components/ui";
+
+export default function AcademicMentorshipLoading() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <header className="bg-bg-card border-b border-border shadow-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+          <div>
+            <h1 className="text-xl font-bold uppercase tracking-tight text-text-primary sm:text-2xl">
+              Academic Mentorship
+            </h1>
+            <p className="text-xs text-text-muted">Loading mappings...</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <Card className="p-6" role="status" aria-live="polite">
+          <div className="flex items-center gap-3 text-sm font-semibold text-text-primary">
+            <span className="h-5 w-5 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+            Loading mentorship mappings...
+          </div>
+          <div className="mt-5 grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)_220px_auto]">
+            <div className="h-11 rounded-lg bg-hover-bg" />
+            <div className="h-11 rounded-lg bg-hover-bg" />
+            <div className="h-11 rounded-lg bg-hover-bg" />
+            <div className="h-11 rounded-lg bg-hover-bg" />
+          </div>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -155,13 +155,24 @@ describe("AcademicMentorshipPage", () => {
       includeHistory: false,
       programId: null,
     });
+    expect(mockListAccessibleAcademicMentorshipSchools).not.toHaveBeenCalled();
+    expect(mockListAcademicMentorshipProgramsForSchools).toHaveBeenCalledWith(
+      [20],
+      "2026-2027"
+    );
+    expect(mockListAcademicMentorshipProgramSchoolLinks).toHaveBeenCalledWith(
+      [20],
+      "2026-2027"
+    );
   });
 
   it("clears a School that is not available under the selected Program", async () => {
-    mockListAccessibleAcademicMentorshipSchools.mockResolvedValue([
-      { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
-      { id: 21, code: "SCH002", name: "Second School", region: "West" },
-    ]);
+    mockRequireAcademicMentorshipAccess
+      .mockResolvedValueOnce(access)
+      .mockResolvedValueOnce({
+        ...access,
+        school: { id: 20, code: "SCH001", name: "Mapped School", region: "North" },
+      });
     mockListAcademicMentorshipProgramSchoolLinks.mockResolvedValue([
       { programId: 64, schoolId: 21 },
     ]);

--- a/src/app/admin/academic-mentorship/page.test.tsx
+++ b/src/app/admin/academic-mentorship/page.test.tsx
@@ -1,3 +1,4 @@
+// fallow-ignore-file code-duplication
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -185,7 +185,7 @@ async function loadSelectedGroups(
   includeHistory: boolean,
   programId: number | null
 ): Promise<AcademicMentorshipMappingGroup[]> {
-  if (!selectedAccess?.school) return [];
+  if (!selectedAccess?.school || !isValidAcademicYear(selectedAcademicYear)) return [];
   return listAcademicMentorshipMappings({
     schoolId: selectedAccess.school.id,
     academicYear: selectedAcademicYear,
@@ -216,16 +216,78 @@ async function loadPageModel(
     programId: selectedProgramId,
     includeHistory,
   } = selectedFilters(resolvedSearchParams, academicYears);
+
+  if (selectedSchoolCode) {
+    const selectedAccess = await requireAcademicMentorshipAccess(session, "view", {
+      schoolCode: selectedSchoolCode,
+    });
+    if (!selectedAccess.ok) {
+      if (selectedAccess.status === 404) {
+        redirect(selectionUrl({
+          academicYear: selectedAcademicYear,
+          programId: selectedProgramId,
+          includeHistory,
+        }));
+      }
+      redirect("/dashboard");
+    }
+
+    const selectedSchool = selectedAccess.school;
+    if (!selectedSchool) redirect("/dashboard");
+    const selectedSchoolIds = [selectedSchool.id];
+    const [programs, programSchoolLinks, groups] = await Promise.all([
+      listAcademicMentorshipProgramsForSchools(selectedSchoolIds, selectedAcademicYear),
+      listAcademicMentorshipProgramSchoolLinks(selectedSchoolIds, selectedAcademicYear),
+      loadSelectedGroups(
+        selectedAccess,
+        selectedAcademicYear,
+        includeHistory,
+        selectedProgramId
+      ),
+    ]);
+    redirectInvalidSchoolSelection({
+      selectedSchoolCode,
+      selectedSchool: schoolsForProgram(
+        [selectedSchool],
+        programSchoolLinks,
+        selectedProgramId
+      )[0],
+      selectedAcademicYear,
+      selectedProgramId,
+      includeHistory,
+    });
+
+    const canEdit = canEditSelection(selectedAccess, selectedAcademicYear);
+    const canUpload = selectedAccess.canEdit === true;
+    return {
+      academicYears,
+      selectedAcademicYear,
+      selectedSchoolCode,
+      selectedProgramId,
+      includeHistory,
+      programs,
+      programSchoolLinks,
+      schools: [selectedSchool],
+      selectedSchool,
+      groups,
+      canEdit,
+      canUpload,
+      historyHref: historyUrl(
+        selectedSchool.code,
+        selectedAcademicYear,
+        selectedProgramId,
+        includeHistory
+      ),
+      accessLabel: canEdit ? "Edit access" : canUpload ? "CSV-only backfill" : "View-only",
+    };
+  }
+
   const accessibleSchools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);
   const accessibleSchoolIds = accessibleSchools.map((school) => school.id);
-  const programs = await listAcademicMentorshipProgramsForSchools(
-    accessibleSchoolIds,
-    selectedAcademicYear
-  );
-  const programSchoolLinks = await listAcademicMentorshipProgramSchoolLinks(
-    accessibleSchoolIds,
-    selectedAcademicYear
-  );
+  const [programs, programSchoolLinks] = await Promise.all([
+    listAcademicMentorshipProgramsForSchools(accessibleSchoolIds, selectedAcademicYear),
+    listAcademicMentorshipProgramSchoolLinks(accessibleSchoolIds, selectedAcademicYear),
+  ]);
   const schoolsForSelectedProgram = schoolsForProgram(
     accessibleSchools,
     programSchoolLinks,

--- a/src/app/admin/academic-mentorship/page.tsx
+++ b/src/app/admin/academic-mentorship/page.tsx
@@ -204,6 +204,78 @@ function canEditSelection(
   );
 }
 
+async function loadSelectedSchoolPageModel(params: {
+  session: AuthenticatedSession;
+  academicYears: string[];
+  selectedAcademicYear: string;
+  selectedSchoolCode: string;
+  selectedProgramId: number | null;
+  includeHistory: boolean;
+}): Promise<PageModel> {
+  const selectedAccess = await requireAcademicMentorshipAccess(params.session, "view", {
+    schoolCode: params.selectedSchoolCode,
+  });
+  if (!selectedAccess.ok) {
+    if (selectedAccess.status === 404) {
+      redirect(selectionUrl({
+        academicYear: params.selectedAcademicYear,
+        programId: params.selectedProgramId,
+        includeHistory: params.includeHistory,
+      }));
+    }
+    redirect("/dashboard");
+  }
+
+  const selectedSchool = selectedAccess.school;
+  if (!selectedSchool) redirect("/dashboard");
+  const selectedSchoolIds = [selectedSchool.id];
+  const [programs, programSchoolLinks, groups] = await Promise.all([
+    listAcademicMentorshipProgramsForSchools(selectedSchoolIds, params.selectedAcademicYear),
+    listAcademicMentorshipProgramSchoolLinks(selectedSchoolIds, params.selectedAcademicYear),
+    loadSelectedGroups(
+      selectedAccess,
+      params.selectedAcademicYear,
+      params.includeHistory,
+      params.selectedProgramId
+    ),
+  ]);
+  redirectInvalidSchoolSelection({
+    selectedSchoolCode: params.selectedSchoolCode,
+    selectedSchool: schoolsForProgram(
+      [selectedSchool],
+      programSchoolLinks,
+      params.selectedProgramId
+    )[0],
+    selectedAcademicYear: params.selectedAcademicYear,
+    selectedProgramId: params.selectedProgramId,
+    includeHistory: params.includeHistory,
+  });
+
+  const canEdit = canEditSelection(selectedAccess, params.selectedAcademicYear);
+  const canUpload = selectedAccess.canEdit === true;
+  return {
+    academicYears: params.academicYears,
+    selectedAcademicYear: params.selectedAcademicYear,
+    selectedSchoolCode: params.selectedSchoolCode,
+    selectedProgramId: params.selectedProgramId,
+    includeHistory: params.includeHistory,
+    programs,
+    programSchoolLinks,
+    schools: [selectedSchool],
+    selectedSchool,
+    groups,
+    canEdit,
+    canUpload,
+    historyHref: historyUrl(
+      selectedSchool.code,
+      params.selectedAcademicYear,
+      params.selectedProgramId,
+      params.includeHistory
+    ),
+    accessLabel: canEdit ? "Edit access" : canUpload ? "CSV-only backfill" : "View-only",
+  };
+}
+
 async function loadPageModel(
   session: AuthenticatedSession,
   resolvedSearchParams: SearchParams
@@ -218,68 +290,14 @@ async function loadPageModel(
   } = selectedFilters(resolvedSearchParams, academicYears);
 
   if (selectedSchoolCode) {
-    const selectedAccess = await requireAcademicMentorshipAccess(session, "view", {
-      schoolCode: selectedSchoolCode,
-    });
-    if (!selectedAccess.ok) {
-      if (selectedAccess.status === 404) {
-        redirect(selectionUrl({
-          academicYear: selectedAcademicYear,
-          programId: selectedProgramId,
-          includeHistory,
-        }));
-      }
-      redirect("/dashboard");
-    }
-
-    const selectedSchool = selectedAccess.school;
-    if (!selectedSchool) redirect("/dashboard");
-    const selectedSchoolIds = [selectedSchool.id];
-    const [programs, programSchoolLinks, groups] = await Promise.all([
-      listAcademicMentorshipProgramsForSchools(selectedSchoolIds, selectedAcademicYear),
-      listAcademicMentorshipProgramSchoolLinks(selectedSchoolIds, selectedAcademicYear),
-      loadSelectedGroups(
-        selectedAccess,
-        selectedAcademicYear,
-        includeHistory,
-        selectedProgramId
-      ),
-    ]);
-    redirectInvalidSchoolSelection({
-      selectedSchoolCode,
-      selectedSchool: schoolsForProgram(
-        [selectedSchool],
-        programSchoolLinks,
-        selectedProgramId
-      )[0],
-      selectedAcademicYear,
-      selectedProgramId,
-      includeHistory,
-    });
-
-    const canEdit = canEditSelection(selectedAccess, selectedAcademicYear);
-    const canUpload = selectedAccess.canEdit === true;
-    return {
+    return loadSelectedSchoolPageModel({
+      session,
       academicYears,
       selectedAcademicYear,
       selectedSchoolCode,
       selectedProgramId,
       includeHistory,
-      programs,
-      programSchoolLinks,
-      schools: [selectedSchool],
-      selectedSchool,
-      groups,
-      canEdit,
-      canUpload,
-      historyHref: historyUrl(
-        selectedSchool.code,
-        selectedAcademicYear,
-        selectedProgramId,
-        includeHistory
-      ),
-      accessLabel: canEdit ? "Edit access" : canUpload ? "CSV-only backfill" : "View-only",
-    };
+    });
   }
 
   const accessibleSchools = await listAccessibleAcademicMentorshipSchools(baseAccess.permission);

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -3,22 +3,18 @@ import { render, screen } from "@testing-library/react";
 
 // ---- mocks (hoisted) ----
 
-const { mockGetServerSession, mockIsAdmin, mockRedirect, mockRequireAcademicMentorshipAccess } = vi.hoisted(() => ({
+const { mockGetServerSession, mockIsAdmin, mockRedirect } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockIsAdmin: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
-  mockRequireAcademicMentorshipAccess: vi.fn(),
 }));
 
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
-vi.mock("@/lib/academic-mentorship", () => ({
-  requireAcademicMentorshipAccess: mockRequireAcademicMentorshipAccess,
-}));
 vi.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -38,27 +34,11 @@ const adminSession = {
   user: { email: "admin@avantifellows.org" },
 };
 
-const academicAccess = (role: "admin" | "program_admin") => ({
-  ok: true,
-  email: `${role}@avantifellows.org`,
-  permission: {
-    email: `${role}@avantifellows.org`,
-    level: 3,
-    role,
-    school_codes: null,
-    regions: null,
-    program_ids: [64],
-    read_only: false,
-  },
-  canEdit: true,
-});
-
 // ---- tests ----
 
 describe("AdminPage (server component)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireAcademicMentorshipAccess.mockResolvedValue({ ok: false, status: 403, error: "Forbidden" });
   });
 
   it("redirects to / when there is no session", async () => {
@@ -76,19 +56,18 @@ describe("AdminPage (server component)", () => {
     expect(mockRedirect).toHaveBeenCalledWith("/");
   });
 
-  it("redirects to /dashboard when user lacks Academic Mentorship admin access", async () => {
+  it("redirects to /dashboard when user is not admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(false);
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/dashboard");
     expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
-    expect(mockRequireAcademicMentorshipAccess).toHaveBeenCalledWith(adminSession, "view");
+    expect(mockIsAdmin).toHaveBeenCalledWith("admin@avantifellows.org");
   });
 
   it("renders admin links when user is admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
-    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("admin"));
 
     const jsx = await AdminPage();
     render(jsx);
@@ -99,7 +78,7 @@ describe("AdminPage (server component)", () => {
     expect(screen.getByText("School Programs")).toBeInTheDocument();
     expect(screen.getByText("Centre Management")).toBeInTheDocument();
     expect(screen.getByText("Centre Option Configuration")).toBeInTheDocument();
-    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
+    expect(screen.queryByText("Academic Mentorship")).not.toBeInTheDocument();
 
     // verify links
     expect(screen.getByText("User Management").closest("a")).toHaveAttribute(
@@ -122,32 +101,19 @@ describe("AdminPage (server component)", () => {
       "href",
       "/admin/centres/config"
     );
-    expect(screen.getByText("Academic Mentorship").closest("a")).toHaveAttribute(
-      "href",
-      "/admin/academic-mentorship"
-    );
   });
 
-  it("lets program_admin users enter for Academic Mentorship only", async () => {
+  it("does not let program_admin users enter through /admin", async () => {
     mockGetServerSession.mockResolvedValue({ user: { email: "program_admin@avantifellows.org" } });
     mockIsAdmin.mockResolvedValue(false);
-    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("program_admin"));
 
-    const jsx = await AdminPage();
-    render(jsx);
-
-    expect(screen.getByText("Academic Mentorship")).toBeInTheDocument();
-    expect(screen.queryByText("User Management")).not.toBeInTheDocument();
-    expect(screen.queryByText("Batch Metadata")).not.toBeInTheDocument();
-    expect(screen.queryByText("School Programs")).not.toBeInTheDocument();
-    expect(screen.queryByText("Centre Management")).not.toBeInTheDocument();
-    expect(screen.queryByText("Centre Option Configuration")).not.toBeInTheDocument();
+    await expect(AdminPage()).rejects.toThrow("REDIRECT:/dashboard");
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
   });
 
   it("displays user email and navigation links", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
     mockIsAdmin.mockResolvedValue(true);
-    mockRequireAcademicMentorshipAccess.mockResolvedValue(academicAccess("admin"));
 
     const jsx = await AdminPage();
     render(jsx);

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -1,11 +1,12 @@
+// fallow-ignore-file code-duplication
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 // ---- mocks (hoisted) ----
 
-const { mockGetServerSession, mockIsAdmin, mockRedirect } = vi.hoisted(() => ({
+const { mockGetServerSession, mockRequireAdmin, mockRedirect } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
-  mockIsAdmin: vi.fn(),
+  mockRequireAdmin: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
@@ -14,7 +15,7 @@ const { mockGetServerSession, mockIsAdmin, mockRedirect } = vi.hoisted(() => ({
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
-vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
+vi.mock("@/lib/admin-guard", () => ({ requireAdmin: mockRequireAdmin }));
 vi.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -39,18 +40,25 @@ const adminSession = {
 describe("AdminPage (server component)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({
+      ok: true,
+      email: "admin@avantifellows.org",
+      permission: { role: "admin" },
+    });
   });
 
   it("redirects to / when there is no session", async () => {
     mockGetServerSession.mockResolvedValue(null);
+    mockRequireAdmin.mockResolvedValue({ ok: false, status: 401, error: "Unauthorized" });
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/");
     expect(mockRedirect).toHaveBeenCalledWith("/");
-    expect(mockIsAdmin).not.toHaveBeenCalled();
+    expect(mockRequireAdmin).toHaveBeenCalledWith(null);
   });
 
   it("redirects to / when session has no email", async () => {
     mockGetServerSession.mockResolvedValue({ user: {} });
+    mockRequireAdmin.mockResolvedValue({ ok: false, status: 401, error: "Unauthorized" });
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/");
     expect(mockRedirect).toHaveBeenCalledWith("/");
@@ -58,16 +66,15 @@ describe("AdminPage (server component)", () => {
 
   it("redirects to /dashboard when user is not admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
-    mockIsAdmin.mockResolvedValue(false);
+    mockRequireAdmin.mockResolvedValue({ ok: false, status: 403, error: "Forbidden" });
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/dashboard");
     expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
-    expect(mockIsAdmin).toHaveBeenCalledWith("admin@avantifellows.org");
+    expect(mockRequireAdmin).toHaveBeenCalledWith(adminSession);
   });
 
   it("renders admin links when user is admin", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
-    mockIsAdmin.mockResolvedValue(true);
 
     const jsx = await AdminPage();
     render(jsx);
@@ -105,7 +112,7 @@ describe("AdminPage (server component)", () => {
 
   it("does not let program_admin users enter through /admin", async () => {
     mockGetServerSession.mockResolvedValue({ user: { email: "program_admin@avantifellows.org" } });
-    mockIsAdmin.mockResolvedValue(false);
+    mockRequireAdmin.mockResolvedValue({ ok: false, status: 403, error: "Forbidden" });
 
     await expect(AdminPage()).rejects.toThrow("REDIRECT:/dashboard");
     expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
@@ -113,7 +120,6 @@ describe("AdminPage (server component)", () => {
 
   it("displays user email and navigation links", async () => {
     mockGetServerSession.mockResolvedValue(adminSession);
-    mockIsAdmin.mockResolvedValue(true);
 
     const jsx = await AdminPage();
     render(jsx);

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { requireAcademicMentorshipAccess } from "@/lib/academic-mentorship";
+import { isAdmin } from "@/lib/permissions";
 import Link from "next/link";
 import { Card } from "@/components/ui";
 
@@ -12,11 +12,8 @@ export default async function AdminPage() {
     redirect("/");
   }
 
-  const academicMentorshipAccess = await requireAcademicMentorshipAccess(session, "view");
-  const role = academicMentorshipAccess.ok ? academicMentorshipAccess.permission.role : null;
-  const showAdminCards = role === "admin";
-  const showAcademicMentorshipCard = role === "admin" || role === "program_admin";
-  if (!showAcademicMentorshipCard) {
+  const admin = await isAdmin(session.user.email);
+  if (!admin) {
     redirect("/dashboard");
   }
 
@@ -45,69 +42,56 @@ export default async function AdminPage() {
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {showAdminCards && (
-            <>
-              <Link href="/admin/users">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">User Management</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Add, edit, and remove users. Assign permission levels.
-                  </p>
-                </Card>
-              </Link>
-
-              <Link href="/admin/batches">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Batch Metadata</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Configure stream and grade metadata for program batches.
-                  </p>
-                </Card>
-              </Link>
-
-              <Link href="/admin/schools">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">School Programs</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Assign programs (CoE, Nodal, NVS) to schools.
-                  </p>
-                </Card>
-              </Link>
-
-              <Link href="/admin/centres">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Management</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Manage Centres, School links, streams, and active status.
-                  </p>
-                </Card>
-              </Link>
-
-              <Link href="/admin/staff">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Staff Management</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Manage AF teachers, PMs, employee codes, and Centre seats.
-                  </p>
-                </Card>
-              </Link>
-
-              <Link href="/admin/centres/config">
-                <Card className="block p-6">
-                  <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Option Configuration</h3>
-                  <p className="mt-2 text-sm text-text-muted">
-                    Manage Centre type, category, sub-category, and Centre Stream options.
-                  </p>
-                </Card>
-              </Link>
-            </>
-          )}
-
-          <Link href="/admin/academic-mentorship">
+          <Link href="/admin/users">
             <Card className="block p-6">
-              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Academic Mentorship</h3>
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">User Management</h3>
               <p className="mt-2 text-sm text-text-muted">
-                View Academic Mentor-Mentee Mappings by School and academic year.
+                Add, edit, and remove users. Assign permission levels.
+              </p>
+            </Card>
+          </Link>
+
+          <Link href="/admin/batches">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Batch Metadata</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Configure stream and grade metadata for program batches.
+              </p>
+            </Card>
+          </Link>
+
+          <Link href="/admin/schools">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">School Programs</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Assign programs (CoE, Nodal, NVS) to schools.
+              </p>
+            </Card>
+          </Link>
+
+          <Link href="/admin/centres">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Management</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Manage Centres, School links, streams, and active status.
+              </p>
+            </Card>
+          </Link>
+
+          <Link href="/admin/staff">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Staff Management</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Manage AF teachers, PMs, employee codes, and Centre seats.
+              </p>
+            </Card>
+          </Link>
+
+          <Link href="/admin/centres/config">
+            <Card className="block p-6">
+              <h3 className="text-lg font-bold text-text-primary uppercase tracking-wide">Centre Option Configuration</h3>
+              <p className="mt-2 text-sm text-text-muted">
+                Manage Centre type, category, sub-category, and Centre Stream options.
               </p>
             </Card>
           </Link>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,21 +1,14 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { isAdmin } from "@/lib/permissions";
+import { requireAdmin } from "@/lib/admin-guard";
 import Link from "next/link";
 import { Card } from "@/components/ui";
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    redirect("/");
-  }
-
-  const admin = await isAdmin(session.user.email);
-  if (!admin) {
-    redirect("/dashboard");
-  }
+  const access = await requireAdmin(session);
+  if (!access.ok) redirect(access.status === 401 ? "/" : "/dashboard");
 
   return (
     <div className="min-h-screen bg-bg">
@@ -29,7 +22,7 @@ export default async function AdminPage() {
             <Link href="/dashboard" className="text-sm font-bold text-accent hover:text-accent-hover uppercase">
               Dashboard
             </Link>
-            <span className="text-sm text-text-muted font-mono hidden sm:inline">{session.user.email}</span>
+            <span className="text-sm text-text-muted font-mono hidden sm:inline">{access.email}</span>
             <Link
               href="/api/auth/signout"
               className="text-sm font-bold text-danger hover:text-danger/80"


### PR DESCRIPTION
## Summary
- Remove the Academic Mentorship card from `/admin`.
- Restore `/admin` to admin-only access so program admins do not land on an empty admin page.
- Speed up direct Manage mappings links by loading the selected school first instead of loading global school/program selector data before render.
- Add a route-level loading state for `/admin/academic-mentorship` so navigation shows the target page while mappings are still loading.
- Update the domain context to record that Academic Mentorship management starts from the School page Mentorship tab.

## Why
Academic Mentorship should be reached from a school's Mentorship tab via the Manage mappings link, not from the admin card grid. That direct path should render off the selected school instead of scanning all accessible schools first, and slow loads should show a clear page-level loading state.

## Validation
- `npm test -- src/app/admin/academic-mentorship/loading.test.tsx src/app/admin/academic-mentorship/page.test.tsx src/app/admin/page.test.tsx`
- `npm run lint -- src/app/admin/academic-mentorship/loading.tsx src/app/admin/academic-mentorship/loading.test.tsx src/app/admin/academic-mentorship/page.tsx src/app/admin/academic-mentorship/page.test.tsx src/app/admin/page.tsx src/app/admin/page.test.tsx`