### PR TITLE
fix(quiz-sessions): derive program group from batch→auth_group FK (support EMRS/Punjab/Gujarat)

### DIFF
--- a/src/app/api/quiz-sessions/batches/route.ts
+++ b/src/app/api/quiz-sessions/batches/route.ts
@@ -49,9 +49,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ batches: [] });
   }
 
+  // Scope to the PM's authorized programs. (Previously also filtered
+  // batch_id LIKE 'EnableStudents_%', which wrongly hid EMRS/Punjab/Gujarat
+  // batches even when the PM had those programs — program_id is the real scope.)
   const baseFilters = `
     b.program_id = ANY($2::int[])
-    AND b.batch_id LIKE 'EnableStudents_%'
   `;
 
   let batches = await query<BatchRow>(
@@ -72,7 +74,6 @@ export async function GET(request: NextRequest) {
       SELECT b.id, b.name, b.batch_id, b.parent_id, b.program_id
       FROM batch b
       WHERE b.program_id = ANY($1::int[])
-        AND b.batch_id LIKE 'EnableStudents_%'
       ORDER BY b.name
       `,
       [programIds]

--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   mockRequireQuizSessionAccess: vi.fn(),
   mockCanAccessQuizSessionSchool: vi.fn(),
   mockCanAccessQuizSessionBatches: vi.fn(),
+  mockResolveBatchGroups: vi.fn(),
   mockQuery: vi.fn(),
   mockPublishMessage: vi.fn(),
   mockFetch: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock("@/lib/quiz-session-access", () => ({
   requireQuizSessionAccess: mocks.mockRequireQuizSessionAccess,
   canAccessQuizSessionSchool: mocks.mockCanAccessQuizSessionSchool,
   canAccessQuizSessionBatches: mocks.mockCanAccessQuizSessionBatches,
+  resolveBatchGroups: mocks.mockResolveBatchGroups,
 }));
 vi.mock("@/lib/db", () => ({
   query: mocks.mockQuery,
@@ -71,6 +73,10 @@ beforeEach(() => {
   });
   mocks.mockCanAccessQuizSessionSchool.mockResolvedValue(true);
   mocks.mockCanAccessQuizSessionBatches.mockResolvedValue(true);
+  // Default: the test class batch resolves to EnableStudents / ID,DOB.
+  mocks.mockResolveBatchGroups.mockResolvedValue(
+    new Map([["EnableStudents_11_Engg_A", { group: "EnableStudents", authType: "ID,DOB" }]])
+  );
 });
 
 afterEach(() => {
@@ -145,7 +151,8 @@ describe("GET /api/quiz-sessions", () => {
     expect(mocks.mockQuery).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("FROM session s"),
-      [["EnableStudents_11_Engg_A"], 11, 0]
+      // groups (derived from the class batch prefix), then class batch ids, limit, offset
+      [["EnableStudents"], ["EnableStudents_11_Engg_A"], 11, 0]
     );
     expect(mocks.mockRequireQuizSessionAccess).toHaveBeenCalledWith(
       ADMIN_SESSION.user.email,

--- a/src/app/api/quiz-sessions/route.ts
+++ b/src/app/api/quiz-sessions/route.ts
@@ -5,6 +5,7 @@ import {
   canAccessQuizSessionBatches,
   canAccessQuizSessionSchool,
   requireQuizSessionAccess,
+  resolveBatchGroups,
 } from "@/lib/quiz-session-access";
 import { query } from "@/lib/db";
 import {
@@ -71,7 +72,6 @@ async function getBatchesForSchool(
     JOIN batch b ON b.id = sb.batch_id
     WHERE sb.school_id = $1
       AND b.program_id = ANY($2::int[])
-      AND b.batch_id LIKE 'EnableStudents_%'
     ORDER BY b.name
     `,
     [schoolId, programIds]
@@ -83,7 +83,6 @@ async function getBatchesForSchool(
       SELECT b.id, b.name, b.batch_id, b.parent_id, b.program_id
       FROM batch b
       WHERE b.program_id = ANY($1::int[])
-        AND b.batch_id LIKE 'EnableStudents_%'
       ORDER BY b.name
       `,
       [programIds]
@@ -178,6 +177,15 @@ export async function GET(request: NextRequest) {
   const limit = perPage + 1;
   const offset = page * perPage;
 
+  // Groups present among the resolved class batches (EnableStudents, EMRSStudents,
+  // …), from the batch→auth_group FK. Replaces the old hardcoded
+  // group='EnableStudents' so EMRS/Punjab/Gujarat sessions list too; batch_id
+  // overlap already scopes to this school's batches.
+  const batchGroups = await resolveBatchGroups(filteredClassIds);
+  const groups = Array.from(
+    new Set(Array.from(batchGroups.values()).map((g) => g.group))
+  );
+
   const sessions = await query<SessionRow>(
     `
     SELECT
@@ -191,12 +199,12 @@ export async function GET(request: NextRequest) {
       s.platform
     FROM session s
     WHERE s.platform = 'quiz'
-      AND s.meta_data->>'group' = 'EnableStudents'
-      AND string_to_array(s.meta_data->>'batch_id', ',') && $1::text[]
+      AND s.meta_data->>'group' = ANY($1::text[])
+      AND string_to_array(s.meta_data->>'batch_id', ',') && $2::text[]
     ORDER BY s.id DESC
-    LIMIT $2 OFFSET $3
+    LIMIT $3 OFFSET $4
     `,
-    [filteredClassIds, limit, offset]
+    [groups, filteredClassIds, limit, offset]
   );
 
   const hasMore = sessions.length > perPage;
@@ -332,11 +340,25 @@ export async function POST(request: NextRequest) {
   const cmsLink = selectedTemplate.cmsLink;
   const cmsSourceId = selectedTemplate.cmsSourceId;
 
+  // Resolve the program group + auth type from the selected class batch via the
+  // batch→auth_group FK (was hardcoded to EnableStudents/"ID,DOB"). Gurukul
+  // matches sessions on meta_data.group and portal-frontend honours the session's
+  // auth_type, so both must match the batch's program (EMRSStudents, Punjab, …).
+  const batchGroups = await resolveBatchGroups([body.classBatchIds[0]]);
+  const resolved = batchGroups.get(body.classBatchIds[0]);
+  if (!resolved) {
+    return NextResponse.json(
+      { error: "Selected batch has no auth group configured" },
+      { status: 400 }
+    );
+  }
+  const { group, authType } = resolved;
+
   const payload = {
     name: sessionName,
     platform: "quiz",
     type: "sign-in",
-    auth_type: "ID,DOB",
+    auth_type: authType,
     redirection: true,
     id_generation: false,
     signup_form: false,
@@ -356,7 +378,7 @@ export async function POST(request: NextRequest) {
     is_active: true,
     purpose: { type: "attendance", params: "quiz" },
     meta_data: {
-      group: "EnableStudents",
+      group,
       parent_id: body.parentBatchId,
       batch_id: Array.isArray(body.classBatchIds)
         ? body.classBatchIds.join(",")

--- a/src/lib/quiz-session-access.test.ts
+++ b/src/lib/quiz-session-access.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./db", () => ({ query: vi.fn() }));
+
+import { query } from "./db";
+import { resolveBatchGroups } from "./quiz-session-access";
+
+const mockQuery = vi.mocked(query);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("resolveBatchGroups", () => {
+  it("maps each batch to its auth_group name + auth_type via the FK", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { batch_id: "EMRSStudents_11_Alpha_Eng_25_C001", group: "EMRSStudents", auth_type: "ID,DOB" },
+      { batch_id: "PunjabStudents_12_25_A001", group: "PunjabStudents", auth_type: "ID" },
+    ] as never);
+
+    const map = await resolveBatchGroups([
+      "EMRSStudents_11_Alpha_Eng_25_C001",
+      "PunjabStudents_12_25_A001",
+    ]);
+
+    expect(map.get("EMRSStudents_11_Alpha_Eng_25_C001")).toEqual({
+      group: "EMRSStudents",
+      authType: "ID,DOB",
+    });
+    expect(map.get("PunjabStudents_12_25_A001")).toEqual({
+      group: "PunjabStudents",
+      authType: "ID",
+    });
+  });
+
+  it("resolves short-code batches whose prefix does NOT match the group name", async () => {
+    // The whole point of using the FK: "EMRS-11-25-P01" would prefix-parse wrong.
+    mockQuery.mockResolvedValueOnce([
+      { batch_id: "EMRS-11-25-P01", group: "EMRSStudents", auth_type: "ID,DOB" },
+      { batch_id: "AIS-11-A25", group: "AllIndiaStudents", auth_type: "ID,DOB" },
+    ] as never);
+
+    const map = await resolveBatchGroups(["EMRS-11-25-P01", "AIS-11-A25"]);
+    expect(map.get("EMRS-11-25-P01")?.group).toBe("EMRSStudents");
+    expect(map.get("AIS-11-A25")?.group).toBe("AllIndiaStudents");
+  });
+
+  it("defaults auth_type to ID when the auth_group lacks it", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { batch_id: "SomeBatch_1", group: "SomeGroup", auth_type: null },
+    ] as never);
+    const map = await resolveBatchGroups(["SomeBatch_1"]);
+    expect(map.get("SomeBatch_1")?.authType).toBe("ID");
+  });
+
+  it("omits batches with no auth_group row, and skips the query for an empty list", async () => {
+    const empty = await resolveBatchGroups([]);
+    expect(empty.size).toBe(0);
+    expect(mockQuery).not.toHaveBeenCalled();
+
+    mockQuery.mockResolvedValueOnce([] as never); // no rows returned
+    const none = await resolveBatchGroups(["UnknownBatch"]);
+    expect(none.has("UnknownBatch")).toBe(false);
+  });
+});

--- a/src/lib/quiz-session-access.ts
+++ b/src/lib/quiz-session-access.ts
@@ -64,6 +64,40 @@ export async function canAccessQuizSessionSchool(
   return canAccessSchoolSync(permission, school.code, school.region || undefined);
 }
 
+export interface BatchGroupInfo {
+  /** auth_group.name — the program tag stamped as meta_data.group (Gurukul matches on it). */
+  group: string;
+  /** auth_group.input_schema.auth_type — "ID,DOB", "ID", etc. portal-frontend honours it. */
+  authType: string;
+}
+
+/**
+ * Resolve each class batch's program group + login auth type from the
+ * batch.auth_group_id FK (NOT by parsing the batch_id prefix — ~29% of batches
+ * use short codes like "EMRS-11-25-P01"/"AIS-11-A25" whose prefix does not match
+ * the auth_group name). Returns a map keyed by batch_id; batches with no row are
+ * absent. auth_type defaults to "ID" when the auth_group lacks the field.
+ */
+export async function resolveBatchGroups(
+  batchIds: string[]
+): Promise<Map<string, BatchGroupInfo>> {
+  const byBatch = new Map<string, BatchGroupInfo>();
+  if (batchIds.length === 0) return byBatch;
+  const rows = await query<{ batch_id: string; group: string; auth_type: string | null }>(
+    `
+    SELECT b.batch_id, ag.name AS group, ag.input_schema->>'auth_type' AS auth_type
+    FROM batch b
+    JOIN auth_group ag ON ag.id = b.auth_group_id
+    WHERE b.batch_id = ANY($1::text[])
+    `,
+    [batchIds]
+  );
+  for (const r of rows) {
+    byBatch.set(r.batch_id, { group: r.group, authType: r.auth_type || "ID" });
+  }
+  return byBatch;
+}
+
 export async function canAccessQuizSessionBatches(
   permission: UserPermission,
   batchIds: string[]


### PR DESCRIPTION
## Problem

Creating a test for **EMRS Bhopal** (and any non-JNV school) showed **"No class batches available"**, and even if created, sessions would be mis-tagged. The quiz-sessions flow was hardcoded to EnableStudents in three places:

1. **Batch picker** (`quiz-sessions/batches` + `getBatchesForSchool`) filtered `batch_id LIKE 'EnableStudents_%'` — **redundant** with the existing `program_id = ANY(programIds)` scope, but it wrongly hid EMRS/Punjab/Gujarat batches even when the PM had those programs. (EMRS Bhopal's 10 batches exist correctly, `program_id 78` "EMRS CoE".)
2. **Create** hardcoded `meta_data.group = 'EnableStudents'` and `auth_type = 'ID,DOB'`.
3. **List** filtered `meta_data->>'group' = 'EnableStudents'` — so non-JNV sessions never listed.

## Why the FK, not the prefix

The obvious fix (parse the batch_id prefix before `_`) is **wrong**: `batch` has a real FK `auth_group_id → auth_group`, and **~29% of batches** (319/1100) use short codes whose prefix ≠ the group name — e.g. `EMRS-11-25-P01` → `EMRSStudents`, `AIS-11-A25` → `AllIndiaStudents`, `BH-11-A25` → `BiharStudents`. So the group (and thus auth_type) is resolved from the **`batch.auth_group_id` FK**.

## Change

- New `resolveBatchGroups(batchIds)` in `quiz-session-access.ts` — joins `batch → auth_group`, returns `{ group, authType }` per batch (auth_type from `auth_group.input_schema.auth_type`, default `"ID"`).
- **Create**: group + auth_type from the selected class batch's FK; returns **400** if the batch has no auth_group (fail loud rather than mis-tag).
- **List**: filter by the set of groups present among the school's resolved class batches (batch_id overlap already scopes to the school).
- Drop the redundant `LIKE 'EnableStudents_%'` filters; `program_id` stays the access scope.

## Scope / safety

- Only `quiz-sessions` (batches picker, list, create). No teacher-feedback code (not on main).
- EnableStudents behaviour unchanged (its FK group *is* EnableStudents); EMRS/Punjab/Gujarat now work end-to-end.
- Full unit suite green (2519 pass); new `resolveBatchGroups` tests cover the short-code (prefix≠group) case, auth_type default, and empty/absent rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)