### PR TITLE
[codex] Fix curriculum program scope for seated users

### DIFF
--- a/.mex/context/permissions.md
+++ b/.mex/context/permissions.md
@@ -22,7 +22,7 @@ edges:
     condition: when a user is wrongly denied or wrongly granted access
   - target: patterns/add-api-route.md
     condition: when adding a route that needs gating
-last_updated: 2026-07-01
+last_updated: 2026-07-06
 ---
 
 # Permissions
@@ -63,6 +63,7 @@ Per-row ownership uses `ownsRecord(permission, programId)` — admins own all, n
 
 ## Gotchas
 - **`getUserPermission` for a school decision = bug.** Seats are absent, so a seated-but-no-explicit-codes user is wrongly denied. Use `getResolvedPermission`.
+- **Raw `program_ids` for program filtering = bug.** Use `getProgramContextSync(permission).programIds` so centre-seat-derived programs are included. Otherwise a seated manager can access a school but see empty curriculum/program data for the wrong program.
 - **`requireEdit` matters on writes.** `canAccessStudent(session, id, { requireEdit: true })` for upload/delete — without it a `read_only` user could mutate via direct API call even though the UI hides the button. It also enforces per-program ownership in mixed schools.
 - **Passcode users** must be handled explicitly (`session.isPasscodeUser`) — they're blocked from visits and all non-`students` features; the gate checks `session.schoolCode` against the target school.
 - **`revoked_at`** is the single "exited" switch — a revoked user resolves to no permission everywhere.

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -28,4 +28,5 @@ Lookup table for all pattern files in this directory. Check here before starting
 | [add-visit-action-type.md](add-visit-action-type.md) | Adding a new PM visit action type (the ~8-file registry change) |
 | [db-service-write.md](db-service-write.md) | Writing students/batches/quiz-sessions/documents (proxy to the DB Service) |
 | [debug-access-denied.md](debug-access-denied.md) | Diagnosing unexpected 401/403, empty lists, or wrongly-granted access |
+| [debug-curriculum-progress.md](debug-curriculum-progress.md) | Diagnosing teacher LMS curriculum updates not appearing in manager LMS |
 | [debug-e2e-fixtures.md](debug-e2e-fixtures.md) | Diagnosing Playwright failures caused by stale local fixtures or app flow drift |

--- a/.mex/patterns/debug-curriculum-progress.md
+++ b/.mex/patterns/debug-curriculum-progress.md
@@ -1,0 +1,62 @@
+---
+name: debug-curriculum-progress
+description: Diagnose teacher LMS curriculum updates not appearing in manager LMS curriculum views.
+triggers:
+  - "curriculum not reflecting"
+  - "teacher LMS"
+  - "manager LMS"
+  - "topics covered"
+  - "curriculum progress"
+  - "curriculum logs"
+edges:
+  - target: context/data-access.md
+    condition: before checking Postgres or adding curriculum reads/writes
+  - target: context/permissions.md
+    condition: when the mismatch depends on user role, school scope, program ids, or centre seats
+  - target: patterns/debug-access-denied.md
+    condition: when the symptom is an empty view, 403, or wrong school/program scope
+last_updated: 2026-07-06
+---
+
+# Debug Curriculum Progress
+
+## Context
+Curriculum writes are LMS-owned direct Postgres writes. Teacher logs live in
+`lms_curriculum_logs` + `lms_curriculum_log_topics`; explicit chapter completion
+lives in `lms_curriculum_chapter_completions`.
+
+Manager and teacher views use the same APIs, but selected `program_id` matters.
+A seated manager can reach a school through `centre_positions`; the program list
+must include both explicit `program_ids` and seat-derived `scope.programs`.
+
+## Steps
+1. Load `context/data-access.md` and `context/permissions.md`.
+2. Confirm the school row by `school.code` and `school.udise_code`.
+3. Check active curriculum logs for the exact scope: `school_code`, `program_id`,
+   `grade_id`, `subject_id`, `exam_track`, `deleted_at IS NULL`.
+4. Check the viewer's active `user_permission` row, then active centre seats:
+   `user_permission.user_id` -> `centre_positions` -> `centres.program_id` and
+   linked school.
+5. If the user sees the school through a seat, verify code uses
+   `getResolvedPermission` and `getProgramContextSync(permission).programIds`
+   instead of raw `permission.program_ids`.
+6. If a screenshot shows a modal date, verify an actual saved log exists for that
+   `log_date` or `inserted_at`; the modal date can just be today's default.
+
+## Gotchas
+- Empty progress can be a program-scope bug, not missing teacher logs.
+- A topic marked "covered" in the log modal comes from loaded progress; it is not
+  proof that the current modal was saved.
+- Chapter completion is separate from topic coverage. `0/11 chapters completed`
+  can be correct even when topics are covered.
+- Use `BEGIN READ ONLY` when checking prod manually. Do not run writes in prod.
+
+## Verify
+- Focused API tests for `options`, `chapters`, `progress`, `logs`, and completion
+  still pass after scope changes.
+- For the reported school/user, the program list includes the program that owns
+  the existing logs.
+
+## Update Scaffold
+- [ ] Update `context/permissions.md` if a new seat/program-scope gotcha was found.
+- [ ] Add the pattern to `.mex/patterns/INDEX.md`.

--- a/.mex/patterns/debug-curriculum-progress.md
+++ b/.mex/patterns/debug-curriculum-progress.md
@@ -40,11 +40,18 @@ must include both explicit `program_ids` and seat-derived `scope.programs`.
 5. If the user sees the school through a seat, verify code uses
    `getResolvedPermission` and `getProgramContextSync(permission).programIds`
    instead of raw `permission.program_ids`.
-6. If a screenshot shows a modal date, verify an actual saved log exists for that
+6. Check both school-tab APIs and `/curriculum-summary`; both need effective
+   programs, not raw `program_ids`.
+7. For a specific school page, default the Program picker to that school's
+   assigned centre program when available; otherwise mixed CoE/Nodal users can
+   land on the wrong empty Program.
+8. If a screenshot shows a modal date, verify an actual saved log exists for that
    `log_date` or `inserted_at`; the modal date can just be today's default.
 
 ## Gotchas
 - Empty progress can be a program-scope bug, not missing teacher logs.
+- A user can have raw CoE plus a Nodal school seat, or raw Nodal plus a CoE
+  school seat. Do not assume CoE-first default is the right school default.
 - A topic marked "covered" in the log modal comes from loaded progress; it is not
   proof that the current modal was saved.
 - Chapter completion is separate from topic coverage. `0/11 chapters completed`

--- a/src/app/api/curriculum/chapters/[chapterId]/completion/route.test.ts
+++ b/src/app/api/curriculum/chapters/[chapterId]/completion/route.test.ts
@@ -7,10 +7,11 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,

--- a/src/app/api/curriculum/chapters/route.test.ts
+++ b/src/app/api/curriculum/chapters/route.test.ts
@@ -4,10 +4,11 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,

--- a/src/app/api/curriculum/logs/[id]/route.test.ts
+++ b/src/app/api/curriculum/logs/[id]/route.test.ts
@@ -7,10 +7,11 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,

--- a/src/app/api/curriculum/logs/route.test.ts
+++ b/src/app/api/curriculum/logs/route.test.ts
@@ -7,10 +7,11 @@ vi.mock("@/lib/db", () => ({
   query: vi.fn(),
   withTransaction: vi.fn(),
 }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,

--- a/src/app/api/curriculum/options/route.test.ts
+++ b/src/app/api/curriculum/options/route.test.ts
@@ -210,6 +210,7 @@ describe("GET /api/curriculum/options", () => {
         { id: "1", name: "JNV CoE" },
         { id: "2", name: "JNV Nodal" },
       ])
+      .mockResolvedValueOnce([{ program_id: 1 }])
       .mockResolvedValueOnce([]);
 
     const res = await GET(nextReq("/api/curriculum/options?school_code=49045"));
@@ -221,6 +222,44 @@ describe("GET /api/curriculum/options", () => {
       { id: 2, name: "JNV Nodal" },
     ]);
     expect(json.defaults.programId).toBe(1);
+  });
+
+  it("defaults to the selected school's seat-derived Program over global Program order", async () => {
+    mockGetUserPermission.mockResolvedValue({
+      email: "pm@avantifellows.org",
+      level: 1,
+      role: "program_manager",
+      school_codes: null,
+      regions: null,
+      program_ids: [1],
+      read_only: false,
+      scope: {
+        schools: new Set(["49046"]),
+        centres: new Set([45]),
+        programs: new Set([2]),
+      },
+    });
+    mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { code: "49046", region: "HYDERABAD", program_ids: [] },
+      ])
+      .mockResolvedValueOnce([
+        { id: "1", name: "JNV CoE" },
+        { id: "2", name: "JNV Nodal" },
+      ])
+      .mockResolvedValueOnce([{ program_id: 2 }])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(nextReq("/api/curriculum/options?school_code=49046"));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.programs).toEqual([
+      { id: 1, name: "JNV CoE" },
+      { id: 2, name: "JNV Nodal" },
+    ]);
+    expect(json.defaults.programId).toBe(2);
   });
 
   it("returns an empty state when the user has no curriculum-backed Program", async () => {

--- a/src/app/api/curriculum/options/route.test.ts
+++ b/src/app/api/curriculum/options/route.test.ts
@@ -4,10 +4,11 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,
@@ -183,6 +184,43 @@ describe("GET /api/curriculum/options", () => {
       { id: 1, name: "JNV CoE" },
       { id: 2, name: "JNV Nodal" },
     ]);
+  });
+
+  it("includes seat-derived Programs when building Curriculum options", async () => {
+    mockGetUserPermission.mockResolvedValue({
+      email: "pm@avantifellows.org",
+      level: 1,
+      role: "program_manager",
+      school_codes: null,
+      regions: null,
+      program_ids: [2],
+      read_only: false,
+      scope: {
+        schools: new Set(["49045"]),
+        centres: new Set([21]),
+        programs: new Set([1]),
+      },
+    });
+    mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { code: "49045", region: "HYDERABAD", program_ids: [] },
+      ])
+      .mockResolvedValueOnce([
+        { id: "1", name: "JNV CoE" },
+        { id: "2", name: "JNV Nodal" },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(nextReq("/api/curriculum/options?school_code=49045"));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.programs).toEqual([
+      { id: 1, name: "JNV CoE" },
+      { id: 2, name: "JNV Nodal" },
+    ]);
+    expect(json.defaults.programId).toBe(1);
   });
 
   it("returns an empty state when the user has no curriculum-backed Program", async () => {

--- a/src/app/api/curriculum/progress/route.test.ts
+++ b/src/app/api/curriculum/progress/route.test.ts
@@ -4,10 +4,11 @@ import { NextRequest } from "next/server";
 vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/db", () => ({ query: vi.fn() }));
-vi.mock("@/lib/permissions", () => {
+vi.mock("@/lib/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/permissions")>();
   const getUserPermission = vi.fn();
   return {
-    PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
+    ...actual,
     getFeatureAccess: vi.fn(),
     getUserPermission,
     getResolvedPermission: getUserPermission,

--- a/src/lib/curriculum-chapter-completion.test.ts
+++ b/src/lib/curriculum-chapter-completion.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./db", () => ({ query: vi.fn() }));
-vi.mock("./permissions", () => ({
-  PROGRAM_IDS: { COE: 1, NODAL: 2, NVS: 64 },
-  canAccessSchoolSync: vi.fn(),
-}));
+vi.mock("./permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./permissions")>();
+  return {
+    ...actual,
+    canAccessSchoolSync: vi.fn(),
+  };
+});
 
 import { query } from "./db";
 import { canAccessSchoolSync } from "./permissions";

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -3,6 +3,7 @@ import { query } from "./db";
 import {
   PROGRAM_IDS,
   canAccessSchoolSync,
+  getProgramContextSync,
   type UserPermission,
 } from "./permissions";
 import type {
@@ -149,7 +150,9 @@ export async function resolveCurriculumProgramScope(
   }
 
   const callerProgramIds =
-    permission.role === "admin" ? CURRICULUM_PROGRAM_IDS : permission.program_ids ?? [];
+    permission.role === "admin"
+      ? CURRICULUM_PROGRAM_IDS
+      : getProgramContextSync(permission).programIds;
   const allowedProgramIds = CURRICULUM_PROGRAM_IDS.filter((id) =>
     callerProgramIds.includes(id)
   );

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -29,6 +29,10 @@ interface SchoolScopeRow {
   region: string | null;
 }
 
+interface PreferredSeatProgramRow {
+  program_id: number | string | null;
+}
+
 interface ConfigScopeRow {
   exam_track: ExamTrack;
   grade_id: number;
@@ -66,6 +70,7 @@ interface ScopeSuccess {
   school: SchoolScopeRow;
   programs: CurriculumProgramOption[];
   allowedProgramIds: number[];
+  preferredProgramId: number | null;
 }
 
 type ProgramScopeResult = ScopeSuccess | ScopeFailure;
@@ -166,12 +171,32 @@ export async function resolveCurriculumProgramScope(
         [allowedProgramIds]
       )).map((program) => ({ ...program, id: Number(program.id) }))
     : [];
+  const seatCentreIds = permission.scope?.centres;
+  const preferredProgramRows =
+    allowedProgramIds.length > 0 && seatCentreIds instanceof Set && seatCentreIds.size > 0
+      ? await query<PreferredSeatProgramRow>(
+          `SELECT c.program_id
+           FROM centres c
+           JOIN school s ON s.id = c.school_id
+           WHERE c.id = ANY($1::int[])
+             AND s.code = $2
+             AND c.program_id = ANY($3::int[])
+           ORDER BY array_position($3::int[], c.program_id), c.id
+           LIMIT 1`,
+          [[...seatCentreIds], schoolCode, allowedProgramIds]
+        )
+      : [];
+  const preferredProgramId =
+    preferredProgramRows[0]?.program_id == null
+      ? null
+      : Number(preferredProgramRows[0].program_id);
 
   return {
     ok: true,
     school,
     programs,
     allowedProgramIds: programs.map((program) => program.id),
+    preferredProgramId,
   };
 }
 
@@ -246,7 +271,7 @@ export async function getCurriculumOptions(params: {
     examTracks,
     gradeSubjects,
     defaults: {
-      programId: overrideProgramId ?? scope.programs[0]?.id ?? null,
+      programId: overrideProgramId ?? scope.preferredProgramId ?? scope.programs[0]?.id ?? null,
       examTrack: examTracks[0] ?? null,
       grade: firstGradeSubject?.grade ?? null,
       gradeId: firstGradeSubject?.gradeId ?? null,

--- a/src/lib/curriculum-summary.test.ts
+++ b/src/lib/curriculum-summary.test.ts
@@ -964,6 +964,25 @@ describe("buildCommonQueryParams (seat-aware scope)", () => {
     expect(params[2]).toBeNull(); // $3: regions
   });
 
+  it("passes explicit plus seat-derived program ids as the program scope ($6)", () => {
+    const params = buildCommonQueryParams(
+      {
+        ...pmPermission,
+        level: 1,
+        role: "program_manager",
+        school_codes: [],
+        program_ids: [2],
+        scope: {
+          schools: new Set(["49045"]),
+          centres: new Set([21]),
+          programs: new Set([1]),
+        },
+      },
+      emptyFilters
+    );
+    expect(new Set(params[5] as number[])).toEqual(new Set([1, 2]));
+  });
+
   it("falls back to raw school_codes for level 1 when scope is unresolved", () => {
     const params = buildCommonQueryParams(
       { ...pmPermission, level: 1, role: "teacher", school_codes: ["70705"], regions: null },

--- a/src/lib/curriculum-summary.ts
+++ b/src/lib/curriculum-summary.ts
@@ -1,6 +1,6 @@
 import { checkCurriculumSchema, type CurriculumSchemaUnavailable } from "./curriculum-schema";
 import { query } from "./db";
-import { PROGRAM_IDS, type UserPermission } from "./permissions";
+import { getProgramContextSync, PROGRAM_IDS, type UserPermission } from "./permissions";
 import type { ExamTrack } from "@/types/curriculum";
 
 export type CurriculumSummarySortKey =
@@ -397,7 +397,7 @@ export function buildCommonQueryParams(
     permission.level === 2 ? permission.regions ?? [] : null,
     CURRICULUM_PROGRAM_IDS,
     permission.role === "admin",
-    permission.program_ids ?? [],
+    getProgramContextSync(permission).programIds,
     filters.schools.length ? filters.schools : null,
     filters.programs.length ? filters.programs : null,
     filters.grades.length ? filters.grades : null,


### PR DESCRIPTION
## Summary

Fixes Curriculum program scoping so seated users see programs inferred from their centre assignments, not only raw `user_permission.program_ids`.

## Root Cause

Bellary is a CoE centre and teacher logs are correctly saved under `program_id=1` (`JNV CoE`). The reported manager has raw `program_ids={2}` (`JNV Nodal`) but is assigned to Bellary through a CoE centre seat. Curriculum options were using only `permission.program_ids`, so the manager saw the Nodal program path for Bellary, which has no logs.

## Changes

- Use `getProgramContextSync(permission).programIds` in curriculum program scope resolution so explicit and centre-seat-derived programs are both included.
- Add a regression test for a manager with raw Nodal access plus a CoE Bellary-style centre seat.
- Update curriculum-related API test mocks to import the real permission helper.
- Add a short `.mex` debug runbook for future teacher-vs-manager curriculum progress mismatches.

## Validation

- `npm test -- src/app/api/curriculum/options/route.test.ts src/app/api/curriculum/chapters/route.test.ts src/app/api/curriculum/progress/route.test.ts src/app/api/curriculum/logs/route.test.ts 'src/app/api/curriculum/logs/[id]/route.test.ts' 'src/app/api/curriculum/chapters/[chapterId]/completion/route.test.ts'`
- `npm run lint` passes with existing warnings only.