### PR TITLE
Redesign curriculum tab: clearer status + Log a class flow

### DIFF
--- a/src/components/curriculum/ChapterAccordion.test.tsx
+++ b/src/components/curriculum/ChapterAccordion.test.tsx
@@ -6,16 +6,17 @@ import type { Chapter, ChapterProgress } from "@/types/curriculum";
 
 // --- Mocks ---
 
-const mockGetProgressIndicator = vi.fn();
-const mockGetProgressColorClass = vi.fn();
 const mockFormatDuration = vi.fn();
 const mockFormatDate = vi.fn();
 
 vi.mock("@/lib/curriculum-helpers", () => ({
-  getProgressIndicator: (...args: unknown[]) =>
-    mockGetProgressIndicator(...args),
-  getProgressColorClass: (...args: unknown[]) =>
-    mockGetProgressColorClass(...args),
+  getChapterStatus: (progress: ChapterProgress | undefined) => {
+    if (progress?.isChapterComplete) return { key: "complete", label: "Complete" };
+    if (progress && progress.completedTopicIds.length > 0) {
+      return { key: "progress", label: "In progress" };
+    }
+    return { key: "none", label: "Not started" };
+  },
   formatDuration: (...args: unknown[]) => mockFormatDuration(...args),
   formatDate: (...args: unknown[]) => mockFormatDate(...args),
 }));
@@ -64,8 +65,6 @@ describe("ChapterAccordion", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetProgressIndicator.mockReturnValue("○");
-    mockGetProgressColorClass.mockReturnValue("text-gray-400");
     mockFormatDuration.mockReturnValue("1h 30m");
     mockFormatDate.mockReturnValue("-");
   });
@@ -159,32 +158,42 @@ describe("ChapterAccordion", () => {
     );
 
     expect(screen.getByText("1. Kinematics")).toHaveClass("line-through");
-    await user.click(screen.getByRole("button", { name: "Unmark complete" }));
+    await user.click(screen.getByRole("button", { name: "Undo" }));
     expect(onToggleChapterCompletion).toHaveBeenCalledWith(1, false);
   });
 
-  it("shows progress indicator and color class from helpers", () => {
+  it("shows the status pill derived from progress", () => {
     const chapters = [makeChapter({ id: 1, name: "Kinematics" })];
-    const progress = {
-      1: makeProgress(1, { completedTopicIds: [10, 11] }),
-    };
 
-    mockGetProgressIndicator.mockReturnValue("◐");
-    mockGetProgressColorClass.mockReturnValue("text-yellow-500");
-
-    render(
+    const { rerender } = render(
       <ChapterAccordion
         chapters={chapters}
-        progress={progress}
+        progress={{}}
         expandedChapterIds={[]}
         onToggleChapter={vi.fn()}
       />
     );
+    expect(screen.getByText("Not started")).toBeInTheDocument();
 
-    const indicator = screen.getByText("◐");
-    expect(indicator).toHaveClass("text-yellow-500");
-    expect(mockGetProgressIndicator).toHaveBeenCalledWith(progress[1]);
-    expect(mockGetProgressColorClass).toHaveBeenCalledWith(progress[1]);
+    rerender(
+      <ChapterAccordion
+        chapters={chapters}
+        progress={{ 1: makeProgress(1, { completedTopicIds: [10, 11] }) }}
+        expandedChapterIds={[]}
+        onToggleChapter={vi.fn()}
+      />
+    );
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+
+    rerender(
+      <ChapterAccordion
+        chapters={chapters}
+        progress={{ 1: makeProgress(1, { isChapterComplete: true }) }}
+        expandedChapterIds={[]}
+        onToggleChapter={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Complete")).toBeInTheDocument();
   });
 
   it("shows completed/total topic counts", () => {

--- a/src/components/curriculum/ChapterAccordion.tsx
+++ b/src/components/curriculum/ChapterAccordion.tsx
@@ -2,8 +2,7 @@
 
 import type { Chapter, ChapterProgress } from "@/types/curriculum";
 import {
-  getProgressIndicator,
-  getProgressColorClass,
+  getChapterStatus,
   formatDuration,
   formatDate,
 } from "@/lib/curriculum-helpers";
@@ -19,6 +18,30 @@ interface ChapterAccordionProps {
   updatingChapterId?: number | null;
 }
 
+// status key -> pill and meter-fill colors (AF brand tokens). Status shows via
+// the pill + meter; cards use the neutral enrollment-style border, and turn
+// brown only when expanded.
+const STATUS_STYLES: Record<
+  "complete" | "progress" | "none",
+  { pill: string; dot: string; bar: string }
+> = {
+  complete: {
+    pill: "bg-success-bg text-success",
+    dot: "bg-success",
+    bar: "bg-success",
+  },
+  progress: {
+    pill: "bg-warning-bg text-warning-text",
+    dot: "bg-warning-border",
+    bar: "bg-warning-border",
+  },
+  none: {
+    pill: "bg-gray-100 text-gray-500",
+    dot: "bg-gray-400",
+    bar: "bg-gray-200",
+  },
+};
+
 export default function ChapterAccordion({
   chapters,
   progress,
@@ -30,7 +53,7 @@ export default function ChapterAccordion({
 }: ChapterAccordionProps) {
   if (chapters.length === 0) {
     return (
-      <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+      <div className="bg-bg-card border border-border rounded-lg shadow-sm p-8 text-center text-gray-500">
         No chapters found for this grade and subject.
       </div>
     );
@@ -43,18 +66,23 @@ export default function ChapterAccordion({
         const isExpanded = expandedChapterIds.includes(chapter.id);
         const completedCount = chapterProgress?.completedTopicIds.length || 0;
         const totalCount = chapter.topics.length;
-        const indicator = getProgressIndicator(chapterProgress);
-        const colorClass = getProgressColorClass(chapterProgress);
         const isChapterComplete = chapterProgress?.isChapterComplete || false;
         const isUpdatingCompletion = updatingChapterId === chapter.id;
+        const status = getChapterStatus(chapterProgress);
+        const styles = STATUS_STYLES[status.key];
+        const percent = isChapterComplete
+          ? 100
+          : totalCount > 0
+            ? Math.round((completedCount / totalCount) * 100)
+            : 0;
 
         return (
           <div
             key={chapter.id}
             data-chapter-row
-            className={`bg-white rounded-lg shadow overflow-hidden ${
-              isChapterComplete ? "bg-gray-50" : ""
-            }`}
+            className={`bg-bg-card border rounded-lg shadow-sm overflow-hidden ${
+              isExpanded ? "border-warning-border" : "border-border"
+            } ${isChapterComplete ? "bg-bg-card-alt" : ""}`}
           >
             {/* Chapter Header */}
             <div className="w-full px-4 py-3 flex items-center gap-3">
@@ -92,26 +120,68 @@ export default function ChapterAccordion({
                 </div>
               </button>
 
-              {/* Progress Indicator */}
-              <div className="flex items-center gap-2">
-                <span className={`text-lg ${colorClass}`}>{indicator}</span>
-                <span className="text-sm text-gray-500">
-                  {completedCount}/{totalCount}
-                </span>
-              </div>
+              {/* Status pill (read-only) */}
+              <span
+                className={`shrink-0 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${styles.pill}`}
+              >
+                {status.key === "complete" ? (
+                  <svg
+                    className="w-3 h-3"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={3}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                ) : (
+                  <span
+                    className={`w-2 h-2 rounded-full ${styles.dot}`}
+                    aria-hidden="true"
+                  />
+                )}
+                {status.label}
+              </span>
 
               {canEdit && onToggleChapterCompletion && (
-                <button
-                  type="button"
-                  disabled={isUpdatingCompletion}
-                  onClick={() =>
-                    onToggleChapterCompletion(chapter.id, !isChapterComplete)
-                  }
-                  className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
-                >
-                  {isChapterComplete ? "Unmark complete" : "Mark complete"}
-                </button>
+                isChapterComplete ? (
+                  <button
+                    type="button"
+                    disabled={isUpdatingCompletion}
+                    onClick={() => onToggleChapterCompletion(chapter.id, false)}
+                    className="shrink-0 px-2 py-1.5 text-xs font-medium text-gray-500 hover:text-accent underline-offset-2 hover:underline disabled:text-gray-300 disabled:cursor-not-allowed"
+                  >
+                    Undo
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={isUpdatingCompletion}
+                    onClick={() => onToggleChapterCompletion(chapter.id, true)}
+                    className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
+                  >
+                    Mark complete
+                  </button>
+                )
               )}
+            </div>
+
+            {/* Topics coverage meter */}
+            <div className="px-4 pb-3 pl-10 flex items-center gap-3">
+              <div className="flex-1 h-1.5 rounded-full bg-gray-200 overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${styles.bar}`}
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <span className="text-sm text-gray-500 tabular-nums shrink-0">
+                {completedCount}/{totalCount}
+              </span>
             </div>
 
             {/* Expanded Topics */}
@@ -122,18 +192,23 @@ export default function ChapterAccordion({
                     No topics defined for this chapter
                   </div>
                 ) : (
-                  <div className="divide-y divide-gray-50">
-                    {chapter.topics.map((topic) => (
-                      <TopicRow
-                        key={topic.id}
-                        topic={topic}
-                        isCompleted={
-                          chapterProgress?.completedTopicIds.includes(topic.id) ||
-                          false
-                        }
-                      />
-                    ))}
-                  </div>
+                  <>
+                    <div className="px-4 pt-2 pl-10 text-[11px] uppercase tracking-wide text-gray-400">
+                      Topics — marked from what you log
+                    </div>
+                    <div className="divide-y divide-gray-50">
+                      {chapter.topics.map((topic) => (
+                        <TopicRow
+                          key={topic.id}
+                          topic={topic}
+                          isCompleted={
+                            chapterProgress?.completedTopicIds.includes(topic.id) ||
+                            false
+                          }
+                        />
+                      ))}
+                    </div>
+                  </>
                 )}
               </div>
             )}

--- a/src/components/curriculum/CurriculumTab.test.tsx
+++ b/src/components/curriculum/CurriculumTab.test.tsx
@@ -395,7 +395,7 @@ describe("CurriculumTab", () => {
       )
     );
 
-    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+    await user.click(screen.getByRole("button", { name: "+ Log a class" }));
 
     expect(screen.getByTestId("log-session-modal")).toHaveAttribute(
       "data-chapters",
@@ -409,7 +409,7 @@ describe("CurriculumTab", () => {
 
     await screen.findByTestId("chapter-accordion");
 
-    const addButton = screen.getByRole("button", { name: "+ Add Log" });
+    const addButton = screen.getByRole("button", { name: "+ Log a class" });
     await waitFor(() => expect(addButton).not.toBeDisabled());
     expect(screen.queryByText("History")).not.toBeInTheDocument();
 
@@ -427,7 +427,7 @@ describe("CurriculumTab", () => {
     renderTab({ canEdit: true });
 
     await screen.findByTestId("chapter-accordion");
-    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+    await user.click(screen.getByRole("button", { name: "+ Log a class" }));
     await user.click(screen.getByText("Save Mock Log"));
 
     await waitFor(() => {
@@ -482,7 +482,7 @@ describe("CurriculumTab", () => {
     renderTab({ canEdit: true });
 
     await screen.findByTestId("chapter-accordion");
-    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+    await user.click(screen.getByRole("button", { name: "+ Log a class" }));
     await user.click(screen.getByText("Save Mock Log"));
 
     await waitFor(() => {
@@ -500,7 +500,7 @@ describe("CurriculumTab", () => {
     renderTab({ canEdit: true });
 
     await screen.findByTestId("chapter-accordion");
-    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+    await user.click(screen.getByRole("button", { name: "+ Log a class" }));
     await user.click(screen.getByText("Save Completion Only"));
 
     await waitFor(() => {
@@ -806,7 +806,7 @@ describe("CurriculumTab", () => {
     renderTab({ canEdit: true });
 
     await screen.findByTestId("chapter-accordion");
-    await user.click(screen.getByRole("button", { name: "+ Add Log" }));
+    await user.click(screen.getByRole("button", { name: "+ Log a class" }));
     await user.click(screen.getByText("Save Completion Only"));
 
     expect(

--- a/src/components/curriculum/CurriculumTab.tsx
+++ b/src/components/curriculum/CurriculumTab.tsx
@@ -16,6 +16,7 @@ import ChapterAccordion from "./ChapterAccordion";
 import LogSessionModal from "./LogSessionModal";
 import ProgressSummary from "./ProgressSummary";
 import SessionHistory from "./SessionHistory";
+import { calculateStats } from "@/lib/curriculum-helpers";
 
 interface CurriculumTabProps {
   schoolCode: string;
@@ -472,8 +473,8 @@ export default function CurriculumTab({
         </div>
       </div>
 
-      <div className="bg-gray-50 rounded-lg p-4 mb-6">
-        <div className="flex flex-wrap gap-4 items-center">
+      <div className="mb-6">
+        <div className="flex flex-wrap gap-4 items-start">
           {options && options.programs.length > 1 && (
             <div>
               <label
@@ -574,17 +575,27 @@ export default function CurriculumTab({
           <div className="flex-1" />
 
           {canEdit && (
-            <button
-              disabled={!selectedProgramId || isDataLoading || chapters.length === 0}
-              onClick={() => {
-                setLogError(null);
-                setEditingLog(null);
-                setIsLogSessionModalOpen(true);
-              }}
-              className="px-4 py-2 bg-accent text-white text-sm font-medium rounded-md hover:bg-accent-hover disabled:bg-gray-200 disabled:text-gray-500 disabled:cursor-not-allowed"
-            >
-              + Add Log
-            </button>
+            <div className="flex flex-col items-end">
+              {/* invisible spacer matching the filter labels so the button lines
+                  up with the select boxes, not the labels above them */}
+              <span aria-hidden="true" className="block text-xs font-medium mb-1 invisible">
+                Log
+              </span>
+              <button
+                disabled={!selectedProgramId || isDataLoading || chapters.length === 0}
+                onClick={() => {
+                  setLogError(null);
+                  setEditingLog(null);
+                  setIsLogSessionModalOpen(true);
+                }}
+                className="px-5 py-2.5 bg-accent text-white text-base font-bold rounded-md shadow-sm hover:bg-accent-hover disabled:bg-gray-200 disabled:text-gray-500 disabled:cursor-not-allowed"
+              >
+                + Log a class
+              </button>
+              <p className="mt-1 max-w-[13rem] text-right text-xs text-gray-500">
+                Record a class after it&rsquo;s taught.
+              </p>
+            </div>
           )}
         </div>
       </div>
@@ -596,11 +607,11 @@ export default function CurriculumTab({
       ) : error ? (
         <div className="bg-red-50 text-red-700 p-4 rounded-lg">{error}</div>
       ) : hasNoPrograms ? (
-        <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+        <div className="bg-bg-card border border-border rounded-lg shadow-sm p-8 text-center text-gray-500">
           No curriculum-enabled Programs are available for this school.
         </div>
       ) : hasEmptyConfig ? (
-        <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+        <div className="bg-bg-card border border-border rounded-lg shadow-sm p-8 text-center text-gray-500">
           No Curriculum configuration is available for this school.
         </div>
       ) : (
@@ -646,6 +657,21 @@ export default function CurriculumTab({
                   {completionError}
                 </div>
               )}
+              {canEdit &&
+                chapters.length > 0 &&
+                (() => {
+                  const stats = calculateStats(chapters, progress);
+                  return stats.chaptersCompleted === 0 && stats.topicsCovered === 0;
+                })() && (
+                  <div className="mb-4 flex items-start gap-2 rounded-lg border border-border bg-hover-bg px-4 py-3 text-sm text-gray-600">
+                    <span aria-hidden="true" className="text-accent">ⓘ</span>
+                    <span>
+                      Nothing logged{selectedSubject ? ` for ${selectedSubject}` : ""} yet.
+                      After each class, use <b>+ Log a class</b> to record what you taught —
+                      the chapters below fill in automatically.
+                    </span>
+                  </div>
+                )}
               <ProgressSummary
                 chapters={chapters}
                 progress={progress}
@@ -680,6 +706,13 @@ export default function CurriculumTab({
             <LogSessionModal
               chapters={chapters}
               progress={progress}
+              scopeLabel={[
+                examTrackLabel(selectedExamTrack),
+                selectedGrade ? `Grade ${selectedGrade}` : null,
+                selectedSubject,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
               onClose={() => {
                 setIsLogSessionModalOpen(false);
                 setEditingLog(null);

--- a/src/components/curriculum/LogSessionModal.test.tsx
+++ b/src/components/curriculum/LogSessionModal.test.tsx
@@ -77,12 +77,12 @@ describe("LogSessionModal", () => {
   it("renders topic-backed log controls with today's IST date", () => {
     renderModal();
 
-    expect(screen.getByText("Log Teaching Session")).toBeInTheDocument();
+    expect(screen.getByText("Log a class")).toBeInTheDocument();
     expect((document.querySelector('input[type="date"]') as HTMLInputElement).value).toBe(
       "2026-02-15"
     );
     expect(screen.getByText("Select topics covered")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save Log" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save class log" })).toBeDisabled();
     expect(screen.queryByText("Will Complete")).not.toBeInTheDocument();
   });
 
@@ -94,7 +94,7 @@ describe("LogSessionModal", () => {
     await user.click(screen.getByText("Kinematics"));
     const topicLabel = screen.getByText("Motion in a Straight Line").closest("label")!;
     await user.click(within(topicLabel).getByRole("checkbox"));
-    await user.click(screen.getByRole("button", { name: "Save Log" }));
+    await user.click(screen.getByRole("button", { name: "Save class log" }));
 
     expect(onSave).toHaveBeenCalledWith({
       date: "2026-02-15",
@@ -119,7 +119,7 @@ describe("LogSessionModal", () => {
     await user.click(screen.getByText("Laws of Motion"));
     const topicLabel = screen.getByText("Newton's Laws").closest("label")!;
     await user.click(within(topicLabel).getByRole("checkbox"));
-    await user.click(screen.getByRole("button", { name: "Save Log" }));
+    await user.click(screen.getByRole("button", { name: "Save class log" }));
 
     expect(onSave).toHaveBeenCalledWith({
       date: "2026-02-15",
@@ -145,7 +145,7 @@ describe("LogSessionModal", () => {
     await user.click(screen.getByText("Kinematics"));
     const topicLabel = screen.getByText("Motion in a Straight Line").closest("label")!;
     await user.click(within(topicLabel).getByRole("checkbox"));
-    await user.click(screen.getByRole("button", { name: "Save Log" }));
+    await user.click(screen.getByRole("button", { name: "Save class log" }));
 
     expect(onSave).toHaveBeenCalledWith({
       date: "2026-02-15",
@@ -171,7 +171,7 @@ describe("LogSessionModal", () => {
     await user.click(within(lawsRow).getByRole("checkbox", { name: /complete/i }));
 
     expect(screen.getByText("Prescribed: 1h 30m")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Save Log" }));
+    await user.click(screen.getByRole("button", { name: "Save class log" }));
 
     expect(onSave).toHaveBeenCalledWith({
       date: "2026-02-15",
@@ -241,7 +241,7 @@ describe("LogSessionModal", () => {
     const topicLabel = screen.getByText("Projectile Motion").closest("label")!;
     expect(within(topicLabel).getByRole("checkbox")).toBeChecked();
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
     expect(onSave).toHaveBeenCalledWith({
       date: "2026-02-12",
       durationMinutes: 90,

--- a/src/components/curriculum/LogSessionModal.tsx
+++ b/src/components/curriculum/LogSessionModal.tsx
@@ -7,6 +7,7 @@ import { getTodayIST } from "@/lib/curriculum-date-helpers";
 interface LogSessionModalProps {
   chapters: Chapter[];
   progress: Record<number, ChapterProgress>;
+  scopeLabel?: string;
   onClose: () => void;
   onSave: (payload: {
     date: string;
@@ -44,6 +45,7 @@ function parseDurationInput(value: string): number {
 export default function LogSessionModal({
   chapters,
   progress,
+  scopeLabel,
   onClose,
   onSave,
   isSaving = false,
@@ -174,10 +176,15 @@ export default function LogSessionModal({
       <div className="relative min-h-screen flex items-center justify-center p-4">
         <div className="relative bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[90vh] flex flex-col">
           {/* Header */}
-          <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-gray-900">
-              Log Teaching Session
-            </h2>
+          <div className="px-4 py-3 border-b border-gray-200 flex items-start justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">
+                {isEditMode ? "Edit class log" : "Log a class"}
+              </h2>
+              {scopeLabel && (
+                <p className="mt-0.5 text-sm text-gray-500">{scopeLabel}</p>
+              )}
+            </div>
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600"
@@ -242,9 +249,12 @@ export default function LogSessionModal({
 
             {/* Topic Selection */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Select Topics Covered
+              <label className="block text-sm font-medium text-gray-700">
+                What did you teach?
               </label>
+              <p className="mb-2 mt-0.5 text-xs text-gray-500">
+                Tick the topics you covered in this class.
+              </p>
 
               <div className="border border-gray-200 rounded-lg max-h-64 overflow-y-auto">
                 {chapters.map((chapter) => {
@@ -403,7 +413,7 @@ export default function LogSessionModal({
               }
               className="px-4 py-2 text-sm font-medium text-white bg-accent rounded-md hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isSaving ? "Saving..." : isEditMode ? "Save Changes" : "Save Log"}
+              {isSaving ? "Saving..." : isEditMode ? "Save changes" : "Save class log"}
             </button>
           </div>
         </div>

--- a/src/components/curriculum/ProgressSummary.tsx
+++ b/src/components/curriculum/ProgressSummary.tsx
@@ -17,7 +17,7 @@ export default function ProgressSummary({
   const stats = calculateStats(chapters, progress);
 
   return (
-    <div className="bg-white rounded-lg shadow p-4 mb-6">
+    <div className="bg-bg-card border border-border rounded-lg shadow-sm p-4 mb-6">
       <div className="grid grid-cols-3 gap-4">
         {/* Chapters Completed */}
         <div className="text-center">

--- a/src/components/curriculum/SessionHistory.test.tsx
+++ b/src/components/curriculum/SessionHistory.test.tsx
@@ -31,8 +31,8 @@ function makeLog(overrides: Partial<LmsCurriculumLog> = {}): LmsCurriculumLog {
 describe("SessionHistory", () => {
   it("renders empty state when no LMS Curriculum Logs exist", () => {
     render(<SessionHistory logs={[]} />);
-    expect(screen.getByText("No LMS Curriculum Logs yet.")).toBeInTheDocument();
-    expect(screen.getByText(/Click .+ Add Log/)).toBeInTheDocument();
+    expect(screen.getByText("No classes logged yet.")).toBeInTheDocument();
+    expect(screen.getByText(/Click .+ Log a class/)).toBeInTheDocument();
   });
 
   it("renders a single LMS Curriculum Log with date, duration, and topics", () => {

--- a/src/components/curriculum/SessionHistory.tsx
+++ b/src/components/curriculum/SessionHistory.tsx
@@ -18,11 +18,11 @@ export default function SessionHistory({
 }: SessionHistoryProps) {
   if (logs.length === 0) {
     return (
-      <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
-        No LMS Curriculum Logs yet.
+      <div className="bg-bg-card border border-border rounded-lg shadow-sm p-8 text-center text-gray-500">
+        No classes logged yet.
         <br />
         <span className="text-sm">
-          Click &quot;+ Add Log&quot; to record your first LMS Curriculum Log.
+          Click &quot;+ Log a class&quot; to record your first class.
         </span>
       </div>
     );
@@ -74,10 +74,10 @@ export default function SessionHistory({
           <div
             key={log.id}
             data-curriculum-log-row
-            className="bg-white rounded-lg shadow overflow-hidden"
+            className="bg-bg-card border border-border rounded-lg shadow-sm overflow-hidden"
           >
             {/* Session Header */}
-            <div className="px-4 py-3 bg-gray-50 border-b border-gray-100 flex items-center justify-between gap-3">
+            <div className="px-4 py-3 bg-bg-card-alt border-b border-border flex items-center justify-between gap-3">
               <div className="font-medium text-gray-900">
                 {formatSessionDate(log.logDate)}
               </div>

--- a/src/components/curriculum/TopicRow.test.tsx
+++ b/src/components/curriculum/TopicRow.test.tsx
@@ -42,14 +42,13 @@ describe("TopicRow", () => {
       <TopicRow topic={baseTopic} isCompleted={true} />
     );
 
-    // Checkbox span has completed green style
-    const checkbox = container.querySelector("span.bg-green-500");
-    expect(checkbox).toBeInTheDocument();
-    expect(checkbox?.classList.contains("border-green-500")).toBe(true);
-    expect(checkbox?.classList.contains("text-white")).toBe(true);
+    // Read-only check mark rendered in the success color (not a checkbox control)
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.classList.contains("text-success")).toBe(true);
 
-    // Checkmark SVG is rendered
-    expect(container.querySelector("svg")).toBeInTheDocument();
+    // No pending ring when completed
+    expect(container.querySelector("span.border-gray-300")).toBeNull();
 
     // Topic name has muted text
     expect(screen.getByText("Newton's Laws of Motion").className).toContain(

--- a/src/components/curriculum/TopicRow.tsx
+++ b/src/components/curriculum/TopicRow.tsx
@@ -10,17 +10,12 @@ interface TopicRowProps {
 export default function TopicRow({ topic, isCompleted }: TopicRowProps) {
   return (
     <div className="px-4 py-2.5 pl-12 flex items-center gap-3">
-      {/* Checkbox (read-only) */}
-      <span
-        className={`w-4 h-4 flex items-center justify-center rounded border ${
-          isCompleted
-            ? "bg-green-500 border-green-500 text-white"
-            : "border-gray-300 bg-white"
-        }`}
-      >
-        {isCompleted && (
+      {/* Read-only status marker: green check when taught, quiet ring otherwise.
+          Not a control — topics are marked from what you log. */}
+      <span className="w-4 h-4 flex items-center justify-center" aria-hidden="true">
+        {isCompleted ? (
           <svg
-            className="w-3 h-3"
+            className="w-4 h-4 text-success"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -32,8 +27,11 @@ export default function TopicRow({ topic, isCompleted }: TopicRowProps) {
               d="M5 13l4 4L19 7"
             />
           </svg>
+        ) : (
+          <span className="w-2.5 h-2.5 rounded-full border-[1.5px] border-gray-300 bg-white" />
         )}
       </span>
+      <span className="sr-only">{isCompleted ? "Taught" : "Not taught yet"}</span>
 
       {/* Topic Name */}
       <span

--- a/src/lib/curriculum-helpers.ts
+++ b/src/lib/curriculum-helpers.ts
@@ -53,6 +53,21 @@ export function getProgressColorClass(progress: ChapterProgress | undefined): st
   return "text-yellow-600";
 }
 
+// Read-only completion status for a chapter, shown as a labelled pill on the
+// progress view. This replaces the old glyph indicator, which looked like a
+// clickable tickbox — the label makes clear it is a status, not a control.
+export type ChapterStatusKey = "complete" | "progress" | "none";
+
+export function getChapterStatus(
+  progress: ChapterProgress | undefined
+): { key: ChapterStatusKey; label: string } {
+  if (progress?.isChapterComplete) return { key: "complete", label: "Complete" };
+  if (progress && progress.completedTopicIds.length > 0) {
+    return { key: "progress", label: "In progress" };
+  }
+  return { key: "none", label: "Not started" };
+}
+
 // Summary stats
 export interface CurriculumStats {
   chaptersCompleted: number;

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,27 +1,32 @@
 /**
  * Ledger UI theme tokens for dynamic inline styles.
  *
+ * These MIRROR the Avanti Fellows brand tokens defined in `src/app/globals.css`
+ * (the `--color-*` custom properties). Keep them in sync with that file — it is
+ * the source of truth that Tailwind utility classes resolve against.
+ *
  * Use ONLY where CSS variables cannot work (e.g., style={{ width: `${percent}%` }}).
  * For color references in JSX, use Tailwind utility classes (bg-accent, text-text-primary, etc.).
  */
 export const theme = {
-  accent: "#059669",
-  accentHover: "#047857",
-  bg: "#F0F7F4",
-  bgCard: "#FFFFFF",
-  bgCardAlt: "#F5FAF7",
-  bgInput: "#FFFFFF",
-  hoverBg: "#E6F2EC",
-  border: "#D1E7DD",
-  borderAccent: "#059669",
-  textPrimary: "#2A2A2A",
-  textSecondary: "#6B6560",
-  textMuted: "#9A948D",
+  accent: "#ad2f2f",
+  accentHover: "#8a2525",
+  bg: "#f5efe8",
+  bgCard: "#fffaf5",
+  bgCardAlt: "#f3ece5",
+  bgInput: "#ffffff",
+  hoverBg: "rgba(173, 47, 47, 0.06)",
+  border: "rgba(38, 20, 16, 0.15)",
+  borderAccent: "#ad2f2f",
+  textPrimary: "#261410",
+  textSecondary: "#685851",
+  textMuted: "#685851",
   textOnAccent: "#FFFFFF",
-  danger: "#ef4444",
-  dangerBg: "rgba(239, 68, 68, 0.08)",
-  successBg: "rgba(5, 150, 105, 0.08)",
-  warningBg: "#fef3c7",
-  warningBorder: "#fcd34d",
-  warningText: "#92400e",
+  danger: "#ad2f2f",
+  dangerBg: "rgba(173, 47, 47, 0.08)",
+  success: "#1e6b4b",
+  successBg: "rgba(30, 107, 75, 0.12)",
+  warningBg: "rgba(140, 90, 29, 0.08)",
+  warningBorder: "#8c5a1d",
+  warningText: "#8c5a1d",
 } as const;


### PR DESCRIPTION
## What
Redesign of the school **Curriculum** tab so completion status reads as a *status*, and logging a class is the obvious action. Triggered by a real usage bug: a teacher thought she couldn't edit CoE curriculum — she was clicking the status glyphs instead of the "Add Log" button.

## Changes (af_lms only — view/copy layer)
- **Status is a read-out, not a fake control:** chapter glyph (`○ ◐ ●`) → labelled pill (Not started / In progress / Complete) + a topics meter, via a new pure `getChapterStatus()`. The expanded chapter is highlighted with the brand brown border.
- **Topic markers** → read-only green check / muted ring (was a bordered checkbox that invited clicking).
- **"Log a class" flow:** "Add Log" → **"Log a class"** (bolder, with a hint); a first-use nudge when a subject has no logs; the modal is retitled "Log a class" with scope context and a "What did you teach?" section. Tickboxes now live **only** in the dialog (data entry) vs. read-only status on the page.
- **Card surfaces** switched to the brand `bg-bg-card` (matching the enrollment/school cards); transparent filter bar; consistent borders.
- `theme.ts` synced to the real AF maroon palette (was stale emerald; dead file, 0 imports).

## Not changed
No changes to logging/marking/saving logic, API payloads, permissions, or DB. Purely presentation + copy + a conditional empty-state banner.

## Testing
Full unit suite green (2,522 pass, 3 pre-existing skips); lint clean. Component tests updated for the new markup/copy. Verified live on the dev server (status pill, meter, expanded brown border, empty-state nudge, button alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
