### PR TITLE
Fix empty Enrollment tab for RGNV; treat all non-NVS programs alike

### DIFF
--- a/src/app/api/curriculum/configs/export/route.test.ts
+++ b/src/app/api/curriculum/configs/export/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
   PROGRAM_IDS: { COE: 1, NODAL: 2 },
-  COE_NODAL_PROGRAM_IDS: [1, 2, 74, 94, 78],
+  PHYSICAL_CENTRE_PROGRAM_IDS: [1, 2, 74, 94, 78, 88],
 }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));
 vi.mock("@/lib/curriculum-schema", () => ({

--- a/src/app/api/curriculum/configs/route.test.ts
+++ b/src/app/api/curriculum/configs/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("@/lib/permissions", () => ({
   getUserPermission: mockGetUserPermission,
   PROGRAM_IDS: { COE: 1, NODAL: 2 },
-  COE_NODAL_PROGRAM_IDS: [1, 2, 74, 94, 78],
+  PHYSICAL_CENTRE_PROGRAM_IDS: [1, 2, 74, 94, 78, 88],
 }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));
 vi.mock("@/lib/curriculum-schema", () => ({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,7 +15,7 @@ export const PROGRAM_IDS = {
   PUNJAB_COE: 74,
   PUNJAB_NODAL: 94,
   EMRS_COE: 78,
-  UTTARAKHAND_COE: 88, // RGNV (Rajkiya Gandhi Navodaya Vidyalaya) schools
+  UTTARAKHAND_COE: 88, // RGNV (Rajiv Gandhi Navodaya Vidyalaya) schools
 } as const;
 
 // Canonical display order for program IDs (JNV first, then non-JNV centres).

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,28 +11,24 @@ export const PROGRAM_IDS = {
   COE: 1,
   NODAL: 2,
   NVS: 64,
-  // Non-JNV centre programs (centre rollout — Punjab CoE meritorious schools + EMRS).
+  // Non-JNV centre programs (centre rollout — Punjab CoE meritorious schools, EMRS, RGNV).
   PUNJAB_COE: 74,
   PUNJAB_NODAL: 94,
   EMRS_COE: 78,
+  UTTARAKHAND_COE: 88, // RGNV (Rajkiya Gandhi Navodaya Vidyalaya) schools
 } as const;
 
 // Canonical display order for program IDs (JNV first, then non-JNV centres).
 export const PROGRAM_IDS_ORDERED: number[] = Object.values(PROGRAM_IDS);
 
-// The CoE/Nodal ("academic intervention") program family: JNV CoE/Nodal plus the
-// state-centre programs (Punjab CoE/Nodal, EMRS CoE). These are the programs that
-// grant the CoE/Nodal feature set (curriculum, quiz sessions, visits, PM
-// dashboard, summary stats) and form the curriculum's program universe. NVS is
-// deliberately excluded — NVS-only users are gated out of those features. Add a
-// new non-JNV centre program here (as well as to PROGRAM_IDS) when it onboards.
-export const COE_NODAL_PROGRAM_IDS: number[] = [
-  PROGRAM_IDS.COE,
-  PROGRAM_IDS.NODAL,
-  PROGRAM_IDS.PUNJAB_COE,
-  PROGRAM_IDS.PUNJAB_NODAL,
-  PROGRAM_IDS.EMRS_COE,
-];
+// Physical-centre programs — every program EXCEPT NVS. As far as LMS features
+// go (curriculum, quiz sessions, visits, PM dashboard, summary stats) these are
+// all equivalent; NVS is the sole exception (NVS-only users are gated out of
+// those features). Derived from PROGRAM_IDS so a newly onboarded program is
+// included automatically — no separate list to keep in sync.
+export const PHYSICAL_CENTRE_PROGRAM_IDS: number[] = Object.values(
+  PROGRAM_IDS,
+).filter((id) => id !== PROGRAM_IDS.NVS);
 
 // Maps program_ids to the BigQuery `student_program` label.
 // Keep in sync with AddUserModal's PROGRAMS list.
@@ -43,6 +39,7 @@ export const PROGRAM_ID_TO_LABEL: Record<number, string> = {
   [PROGRAM_IDS.PUNJAB_COE]: "Punjab CoE",
   [PROGRAM_IDS.PUNJAB_NODAL]: "Punjab Nodal",
   [PROGRAM_IDS.EMRS_COE]: "EMRS CoE",
+  [PROGRAM_IDS.UTTARAKHAND_COE]: "Uttarakhand CoE",
 };
 
 export const ACADEMIC_MENTORSHIP_PROGRAM_ALLOWLIST = ["*"] as const;

--- a/src/lib/curriculum-config.test.ts
+++ b/src/lib/curriculum-config.test.ts
@@ -13,7 +13,7 @@ const {
 vi.mock("./permissions", () => ({
   getUserPermission: mockGetUserPermission,
   PROGRAM_IDS: { COE: 1, NODAL: 2 },
-  COE_NODAL_PROGRAM_IDS: [1, 2, 74, 94, 78],
+  PHYSICAL_CENTRE_PROGRAM_IDS: [1, 2, 74, 94, 78, 88],
 }));
 vi.mock("./db", () => ({ query: mockQuery }));
 vi.mock("./curriculum-schema", () => ({

--- a/src/lib/curriculum-config.ts
+++ b/src/lib/curriculum-config.ts
@@ -3,7 +3,7 @@ import {
   type CurriculumSchemaUnavailable,
 } from "./curriculum-schema";
 import { query } from "./db";
-import { COE_NODAL_PROGRAM_IDS, getUserPermission, type UserPermission } from "./permissions";
+import { PHYSICAL_CENTRE_PROGRAM_IDS, getUserPermission, type UserPermission } from "./permissions";
 import type { ExamTrack } from "@/types/curriculum";
 
 export type CurriculumConfigSession = {
@@ -675,7 +675,7 @@ export async function getCurriculumConfigImpact(
   const rows = await query<ImpactQueryRow>(buildImpactSql(), [
     params.chapterId,
     params.examTrack,
-    COE_NODAL_PROGRAM_IDS,
+    PHYSICAL_CENTRE_PROGRAM_IDS,
     params.coverageSequence ?? null,
     params.configId ?? null,
   ]);

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -1,7 +1,7 @@
 import { compareCurriculumCodes } from "./curriculum-code-sort";
 import { query } from "./db";
 import {
-  COE_NODAL_PROGRAM_IDS,
+  PHYSICAL_CENTRE_PROGRAM_IDS,
   canAccessSchoolSync,
   getProgramContextSync,
   type UserPermission,
@@ -17,10 +17,10 @@ import type {
 } from "@/types/curriculum";
 
 export const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
-// Curriculum applies to the whole CoE/Nodal program family (JNV + Punjab + EMRS),
-// not just JNV CoE/Nodal — otherwise a Punjab/EMRS teacher's programs intersect
-// to empty and their curriculum tab loads blank.
-const CURRICULUM_PROGRAM_IDS: number[] = COE_NODAL_PROGRAM_IDS;
+// Curriculum applies to every physical-centre program (all non-NVS programs),
+// not just JNV CoE/Nodal — otherwise a Punjab/EMRS/RGNV teacher's programs
+// intersect to empty and their curriculum tab loads blank.
+const CURRICULUM_PROGRAM_IDS: number[] = PHYSICAL_CENTRE_PROGRAM_IDS;
 const SUBJECT_ORDER: SubjectName[] = ["Physics", "Chemistry", "Maths", "Biology"];
 const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
   jee_main: 1,

--- a/src/lib/curriculum-summary.ts
+++ b/src/lib/curriculum-summary.ts
@@ -1,6 +1,6 @@
 import { checkCurriculumSchema, type CurriculumSchemaUnavailable } from "./curriculum-schema";
 import { query } from "./db";
-import { COE_NODAL_PROGRAM_IDS, getProgramContextSync, type UserPermission } from "./permissions";
+import { PHYSICAL_CENTRE_PROGRAM_IDS, getProgramContextSync, type UserPermission } from "./permissions";
 import type { ExamTrack } from "@/types/curriculum";
 
 export type CurriculumSummarySortKey =
@@ -222,9 +222,9 @@ interface GuardQueryRow {
   estimated_rows: string | number | null;
 }
 
-// The summary spans the whole CoE/Nodal program family (JNV + Punjab + EMRS), so
-// Punjab/EMRS curriculum rows appear rather than being restricted to JNV 1/2.
-const CURRICULUM_PROGRAM_IDS = COE_NODAL_PROGRAM_IDS;
+// The summary spans every physical-centre program (all non-NVS programs), so
+// Punjab/EMRS/RGNV curriculum rows appear rather than being restricted to JNV 1/2.
+const CURRICULUM_PROGRAM_IDS = PHYSICAL_CENTRE_PROGRAM_IDS;
 const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
 const SORT_SQL: Record<CurriculumSummarySortKey, string> = {
   school: "school_name",

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,6 +1,6 @@
 import { query } from "./db";
 import {
-  COE_NODAL_PROGRAM_IDS,
+  PHYSICAL_CENTRE_PROGRAM_IDS,
   PROGRAM_IDS,
   PROGRAM_IDS_ORDERED,
   PROGRAM_ID_TO_LABEL,
@@ -8,7 +8,7 @@ import {
 
 // Re-exported from constants so existing `@/lib/permissions` imports keep
 // working while the definitions live in a client-safe module.
-export { COE_NODAL_PROGRAM_IDS, PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL };
+export { PHYSICAL_CENTRE_PROGRAM_IDS, PROGRAM_IDS, PROGRAM_IDS_ORDERED, PROGRAM_ID_TO_LABEL };
 
 // Permission levels (school scope only)
 export type AccessLevel = 1 | 2 | 3;
@@ -573,12 +573,13 @@ export function getProgramContextSync(
   }
 
   const hasNVS = programIds.includes(PROGRAM_IDS.NVS);
-  // The CoE/Nodal feature set (curriculum, quiz sessions, visits, PM dashboard,
-  // summary stats) is granted by ANY program in the CoE/Nodal family — including
-  // the non-JNV centre programs (Punjab CoE/Nodal, EMRS CoE), not just JNV
-  // CoE (1) / Nodal (2). A Punjab-CoE teacher must not be treated as NVS-only.
+  // The full LMS feature set (curriculum, quiz sessions, visits, PM dashboard,
+  // summary stats) is granted by ANY non-NVS program — JNV CoE/Nodal plus every
+  // physical-centre program (Punjab CoE/Nodal, EMRS CoE, Uttarakhand CoE, …).
+  // Only NVS-only users are gated out. A Punjab/EMRS/RGNV teacher must not be
+  // treated as NVS-only.
   const hasCoEOrNodal = programIds.some((id) =>
-    COE_NODAL_PROGRAM_IDS.includes(id)
+    PHYSICAL_CENTRE_PROGRAM_IDS.includes(id)
   );
   const isNVSOnly = hasNVS && !hasCoEOrNodal;
 


### PR DESCRIPTION
## Problem
The school **Enrollment tab** rendered empty for **RGNV Raipur** (and any RGNV school) even though the dashboard **school card showed a correct student count**.

## Root cause
RGNV's program — **Uttarakhand CoE (id 88)** — was never added to the hand-maintained `PROGRAM_IDS` list in `constants.ts` when RGNV onboarded. The enrollment tab filters programs-with-students through that list, so program 88 was dropped → no program cards → empty tab. (Punjab CoE/Nodal and EMRS CoE were already in the list; 88 was the only omission.) The data was fine — 68 current-year students.

## Fix
- Add `UTTARAKHAND_COE: 88` to `PROGRAM_IDS` + its label. `PROGRAM_IDS_ORDERED` is derived from `PROGRAM_IDS`, so the enrollment tab picks it up automatically → RGNV shows **Uttarakhand CoE (45)**. Program 42 (STP Test Series UK — not in the program list) stays excluded, matching the card.

## Cleanup (same theme)
- Rename `COE_NODAL_PROGRAM_IDS` → **`PHYSICAL_CENTRE_PROGRAM_IDS`**, defined **once** in `constants.ts` and derived as **every program except NVS** (`Object.values(PROGRAM_IDS).filter(id => id !== NVS)`). As far as LMS features go (curriculum, quiz sessions, visits, PM dashboard, summary stats) all non-NVS programs are equivalent; NVS is the sole exception (NVS-only users are gated out). A newly onboarded program is now included automatically — one less list to keep in sync.
- All consumers (permissions, curriculum-options/summary/config) reference the single definition; test mocks updated.

## Behavioral effect
Only program **88** changes behavior: RGNV now gets the full LMS feature set, like Punjab/EMRS CoE. All other programs are unchanged (all-except-NVS equals the previous set plus 88). NVS-only gating is untouched.

## Tests
Full suite green (2550), typecheck + lint clean.

## Not in scope (tracked separately)
Fully removing the remaining hardcoded program-id lists (the `ARRAY[1,2,64]` roster/mentorship attribution tiebreaker, `PROGRAM_IDS`/labels themselves, and the `admin/schools/[code]` `validProgramIds` validation — which currently rejects assigning Punjab/UK/EMRS programs to a school) is tracked in a separate task; it likely needs program-metadata columns on the db-service `program` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)