### PR TITLE
Biweekly LLM-generated release notes (release runner)

### DIFF
--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -1,8 +1,10 @@
-name: Weekly Release
+name: Biweekly Release
 
-# Prototype (issue #219): weekly LLM-written release notes.
-# Run locally with act until trusted:
-#   act workflow_dispatch -W .github/workflows/weekly-release.yml \
+# Biweekly LLM-written release notes (issue #219).
+# GitHub cron can't express "every 14 days", so a weekly cron fires and the
+# gate step runs the job only on odd epoch-weeks: Jul 27 2026, Aug 10, … .
+# Manual runs bypass the gate. Local run:
+#   act workflow_dispatch -W .github/workflows/biweekly-release.yml \
 #     --secret-file .secrets --input provider=openrouter \
 #     -P ubuntu-latest=catthehacker/ubuntu:act-latest
 
@@ -16,27 +18,39 @@ on:
         default: anthropic
       window_days:
         description: Days of history to include
-        default: "7"
+        default: "14"
       thinking:
         description: Thinking effort (off/minimal/low/medium/high/xhigh/max)
         default: medium
-  # Enable after the prototype is trusted (Mondays 09:00 IST):
-  # schedule:
-  #   - cron: "30 3 * * 1"
+  schedule:
+    - cron: "30 3 * * 1" # Mondays 09:00 IST; gate skips every other week
 
 permissions:
   contents: write
 
 jobs:
-  weekly-release:
+  biweekly-release:
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Biweekly gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
+             [ $(( $(date +%s) / 86400 / 7 % 2 )) -eq 1 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Off week — the biweekly cadence runs next Monday. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.run == 'true'
 
       - name: Ensure gh and jq (preinstalled on hosted runners; act image lacks gh)
+        if: steps.gate.outputs.run == 'true'
         run: |
           command -v jq >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq jq; }
           if ! command -v gh >/dev/null; then
@@ -44,20 +58,21 @@ jobs:
             sudo mv /tmp/gh_*/bin/gh /usr/local/bin/gh
           fi
 
-      - name: Gather last week's work
+      - name: Gather the release window's work
         id: gather
+        if: steps.gate.outputs.run == 'true'
         env:
-          WINDOW_DAYS: ${{ inputs.window_days || '7' }}
+          WINDOW_DAYS: ${{ inputs.window_days || '14' }}
         run: bash release-notes/gather.sh
 
       - name: Set up Node
-        if: steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install pi
-        if: steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
         # Pinned: the project moved from @mariozechner/pi-coding-agent (stuck at
         # 0.73.x, breaks on claude-sonnet-5 thinking) to @earendil-works.
         # 0.80.3+ speaks Anthropic adaptive thinking. --force overwrites a stale
@@ -65,7 +80,7 @@ jobs:
         run: npm install -g --force @earendil-works/pi-coding-agent@0.80.10
 
       - name: Generate release notes
-        if: steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -89,7 +104,7 @@ jobs:
 
       - name: Create draft release
         id: release
-        if: steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
         run: |
           TAG="${{ steps.gather.outputs.tag }}"
           # Idempotent re-runs: replace an existing draft for the same tag.
@@ -97,17 +112,17 @@ jobs:
             --jq ".[] | select(.tagName == \"$TAG\" and .isDraft) | .tagName")
           [ -n "$EXISTING" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
           URL=$(gh release create "$TAG" --repo "$GH_REPO" --draft \
-            --title "Weekly release $TAG" --notes-file out/notes.md)
+            --title "Release $TAG" --notes-file out/notes.md)
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Draft release: $URL"
 
       - name: Post to Discord
-        if: steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           jq -n \
-            --arg title "${GH_REPO#*/} — weekly release ${{ steps.gather.outputs.tag }} (draft)" \
+            --arg title "${GH_REPO#*/} — release ${{ steps.gather.outputs.tag }} (draft)" \
             --arg url "${{ steps.release.outputs.url }}" \
             --arg desc "$(head -c 4000 out/notes.md)" \
             '{embeds: [{title: $title, url: $url, description: $desc, color: 5793266}]}' \

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -82,6 +82,8 @@ jobs:
              --system-prompt "$(cat release-notes/system-prompt.md)" \
              "$(cat out/context.md)" > out/notes.md
           test -s out/notes.md
+          printf '\n' >> out/notes.md
+          cat out/changelog.md >> out/notes.md
           echo "--- Generated notes ---"
           cat out/notes.md
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -17,6 +17,9 @@ on:
       window_days:
         description: Days of history to include
         default: "7"
+      thinking:
+        description: Thinking effort (off/minimal/low/medium/high/xhigh/max)
+        default: medium
   # Enable after the prototype is trusted (Mondays 09:00 IST):
   # schedule:
   #   - cron: "30 3 * * 1"
@@ -55,7 +58,11 @@ jobs:
 
       - name: Install pi
         if: steps.gather.outputs.skip != 'true'
-        run: npm install -g @mariozechner/pi-coding-agent
+        # Pinned: the project moved from @mariozechner/pi-coding-agent (stuck at
+        # 0.73.x, breaks on claude-sonnet-5 thinking) to @earendil-works.
+        # 0.80.3+ speaks Anthropic adaptive thinking. --force overwrites a stale
+        # `pi` bin left in act's reused tool cache by the old package name.
+        run: npm install -g --force @earendil-works/pi-coding-agent@0.80.10
 
       - name: Generate release notes
         if: steps.gather.outputs.skip != 'true'
@@ -63,16 +70,15 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PROVIDER: ${{ inputs.provider || 'anthropic' }}
+          THINKING: ${{ inputs.thinking || 'medium' }}
         run: |
           if [ "$PROVIDER" = "openrouter" ]; then
             MODEL="deepseek/deepseek-v4-flash"
           else
             MODEL="claude-sonnet-5"
           fi
-          # --thinking off: claude-sonnet-5 rejects pi 0.70.x's legacy thinking
-          # param unless disabled; notes-writing doesn't need it anyway.
           pi -p --no-session --no-tools --no-skills --no-extensions --no-context-files \
-             --thinking off --provider "$PROVIDER" --model "$MODEL" \
+             --thinking "$THINKING" --provider "$PROVIDER" --model "$MODEL" \
              --system-prompt "$(cat release-notes/system-prompt.md)" \
              "$(cat out/context.md)" > out/notes.md
           test -s out/notes.md

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,106 @@
+name: Weekly Release
+
+# Prototype (issue #219): weekly LLM-written release notes.
+# Run locally with act until trusted:
+#   act workflow_dispatch -W .github/workflows/weekly-release.yml \
+#     --secret-file .secrets --input provider=openrouter \
+#     -P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: LLM provider
+        type: choice
+        options: [anthropic, openrouter]
+        default: anthropic
+      window_days:
+        description: Days of history to include
+        default: "7"
+  # Enable after the prototype is trusted (Mondays 09:00 IST):
+  # schedule:
+  #   - cron: "30 3 * * 1"
+
+permissions:
+  contents: write
+
+jobs:
+  weekly-release:
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure gh and jq (preinstalled on hosted runners; act image lacks gh)
+        run: |
+          command -v jq >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq jq; }
+          if ! command -v gh >/dev/null; then
+            curl -fsSL https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_linux_amd64.tar.gz | tar -xz -C /tmp
+            sudo mv /tmp/gh_*/bin/gh /usr/local/bin/gh
+          fi
+
+      - name: Gather last week's work
+        id: gather
+        env:
+          WINDOW_DAYS: ${{ inputs.window_days || '7' }}
+        run: bash release-notes/gather.sh
+
+      - name: Set up Node
+        if: steps.gather.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pi
+        if: steps.gather.outputs.skip != 'true'
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Generate release notes
+        if: steps.gather.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          PROVIDER: ${{ inputs.provider || 'anthropic' }}
+        run: |
+          if [ "$PROVIDER" = "openrouter" ]; then
+            MODEL="deepseek/deepseek-v4-flash"
+          else
+            MODEL="claude-sonnet-5"
+          fi
+          # --thinking off: claude-sonnet-5 rejects pi 0.70.x's legacy thinking
+          # param unless disabled; notes-writing doesn't need it anyway.
+          pi -p --no-session --no-tools --no-skills --no-extensions --no-context-files \
+             --thinking off --provider "$PROVIDER" --model "$MODEL" \
+             --system-prompt "$(cat release-notes/system-prompt.md)" \
+             "$(cat out/context.md)" > out/notes.md
+          test -s out/notes.md
+          echo "--- Generated notes ---"
+          cat out/notes.md
+
+      - name: Create draft release
+        id: release
+        if: steps.gather.outputs.skip != 'true'
+        run: |
+          TAG="${{ steps.gather.outputs.tag }}"
+          # Idempotent re-runs: replace an existing draft for the same tag.
+          EXISTING=$(gh release list --repo "$GH_REPO" --json tagName,isDraft \
+            --jq ".[] | select(.tagName == \"$TAG\" and .isDraft) | .tagName")
+          [ -n "$EXISTING" ] && gh release delete "$TAG" --repo "$GH_REPO" --yes
+          URL=$(gh release create "$TAG" --repo "$GH_REPO" --draft \
+            --title "Weekly release $TAG" --notes-file out/notes.md)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Draft release: $URL"
+
+      - name: Post to Discord
+        if: steps.gather.outputs.skip != 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          jq -n \
+            --arg title "${GH_REPO#*/} — weekly release ${{ steps.gather.outputs.tag }} (draft)" \
+            --arg url "${{ steps.release.outputs.url }}" \
+            --arg desc "$(head -c 4000 out/notes.md)" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 5793266}]}' \
+          | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ centre_name_mapping_template.csv
 
 # Roster data (PII) — regenerated locally from the sheet/DB, never committed
 scripts/data/pm/
+
+# release-runner prototype
+.secrets
+out/

--- a/release-notes/gather.sh
+++ b/release-notes/gather.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Gather last week's merged work into a digest for the release-notes LLM.
+#
+# Walks: merged PRs -> closingIssuesReferences -> native sub-issue parent
+# (the PRD issue), deduping parents. PRs with no linked issues contribute
+# their body alone. Falls back to raw commits when no PRs merged; skips
+# the release entirely when there are neither.
+#
+# Env:   GITHUB_TOKEN (required), GH_REPO (owner/repo), WINDOW_DAYS (default 7),
+#        DEFAULT_BRANCH (default main), OUT_DIR (default out)
+# Writes: $OUT_DIR/context.md
+# Outputs (GITHUB_OUTPUT): skip=true|false, mode=prs|commits, tag=vYYYY.MM.DD
+
+set -euo pipefail
+
+REPO="${GH_REPO:?GH_REPO required (owner/repo)}"
+WINDOW_DAYS="${WINDOW_DAYS:-7}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+OUT_DIR="${OUT_DIR:-out}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+PR_BODY_LIMIT=2000
+PARENT_BODY_LIMIT=3000
+
+mkdir -p "$OUT_DIR"
+CONTEXT="$OUT_DIR/context.md"
+
+# GNU date (CI) with BSD/macOS fallback for local runs outside a container.
+SINCE_DATE=$(date -u -d "-${WINDOW_DAYS} days" +%Y-%m-%d 2>/dev/null || date -u -v-"${WINDOW_DAYS}"d +%Y-%m-%d)
+SINCE_ISO="${SINCE_DATE}T00:00:00Z"
+TAG="v$(date -u +%Y.%m.%d)"
+
+echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+prs=$(gh pr list --repo "$REPO" --state merged \
+  --search "merged:>=$SINCE_DATE base:$DEFAULT_BRANCH" \
+  --json number,title,url,body,mergedAt,author --limit 100)
+
+pr_count=$(jq 'length' <<<"$prs")
+
+if [ "$pr_count" -gt 0 ]; then
+  echo "Found $pr_count merged PRs since $SINCE_DATE" >&2
+  {
+    echo "# Work merged into $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+    echo
+    echo "## Merged pull requests"
+  } > "$CONTEXT"
+
+  owner="${REPO%/*}"; name="${REPO#*/}"
+  parents="$OUT_DIR/parents.jsonl"; : > "$parents"
+
+  for pr in $(jq -r '.[].number' <<<"$prs"); do
+    jq -r --argjson n "$pr" --argjson limit "$PR_BODY_LIMIT" '
+      .[] | select(.number == $n) |
+      "\n### PR #\(.number): \(.title)\nAuthor: @\(.author.login) · Merged: \(.mergedAt) · \(.url)\n\n\(.body // "" | .[0:$limit])\n"
+    ' <<<"$prs" >> "$CONTEXT"
+
+    linked=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$pr:Int!){
+        repository(owner:$owner,name:$name){
+          pullRequest(number:$pr){
+            closingIssuesReferences(first:10){
+              nodes{ number title parent{ number title body } }
+            }}}}' \
+      -f owner="$owner" -f name="$name" -F pr="$pr" \
+      --jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
+
+    if [ "$(jq 'length' <<<"$linked")" -gt 0 ]; then
+      echo "Closes issues:" >> "$CONTEXT"
+      jq -r '.[] | "- #\(.number) \(.title)\(if .parent then " (part of initiative #\(.parent.number): \(.parent.title))" else "" end)"' \
+        <<<"$linked" >> "$CONTEXT"
+      jq -c '.[] | select(.parent) | .parent' <<<"$linked" >> "$parents"
+    fi
+  done
+
+  if [ -s "$parents" ]; then
+    {
+      echo
+      echo "## Parent initiatives (the why behind the PRs)"
+    } >> "$CONTEXT"
+    jq -rs --argjson limit "$PARENT_BODY_LIMIT" '
+      unique_by(.number) | .[] |
+      "\n### Initiative #\(.number): \(.title)\n\n\(.body // "" | .[0:$limit])\n"
+    ' "$parents" >> "$CONTEXT"
+  fi
+
+  echo "mode=prs" >> "$GITHUB_OUTPUT"
+  echo "skip=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "No merged PRs since $SINCE_DATE; checking commits on $DEFAULT_BRANCH" >&2
+commits=$(gh api "repos/$REPO/commits?since=$SINCE_ISO&sha=$DEFAULT_BRANCH&per_page=100" \
+  --jq '[.[] | select(.commit.message | startswith("Merge pull request") | not)]')
+
+commit_count=$(jq 'length' <<<"$commits")
+
+if [ "$commit_count" -eq 0 ]; then
+  echo "Quiet week: no PRs, no commits. Skipping release." >&2
+  echo "mode=none" >> "$GITHUB_OUTPUT"
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Found $commit_count commits since $SINCE_DATE" >&2
+{
+  echo "# Work committed to $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
+  echo
+  echo "No pull requests were merged this week; these are direct commits."
+  echo
+  jq -r '.[] | "- \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name) (\(.html_url))"' <<<"$commits"
+} > "$CONTEXT"
+
+echo "mode=commits" >> "$GITHUB_OUTPUT"
+echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/release-notes/gather.sh
+++ b/release-notes/gather.sh
@@ -40,6 +40,15 @@ pr_count=$(jq 'length' <<<"$prs")
 
 if [ "$pr_count" -gt 0 ]; then
   echo "Found $pr_count merged PRs since $SINCE_DATE" >&2
+
+  # Deterministic changelog appended verbatim after the LLM's narrative notes.
+  {
+    echo "## 📋 Changelog"
+    echo
+    jq -r 'sort_by(.mergedAt) | reverse | .[] |
+      "- [#\(.number)](\(.url)) \(.title) — @\(.author.login)"' <<<"$prs"
+  } > "$OUT_DIR/changelog.md"
+
   {
     echo "# Work merged into $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
     echo
@@ -103,6 +112,11 @@ if [ "$commit_count" -eq 0 ]; then
 fi
 
 echo "Found $commit_count commits since $SINCE_DATE" >&2
+{
+  echo "## 📋 Changelog"
+  echo
+  jq -r '.[] | "- [`\(.sha[0:7])`](\(.html_url)) \(.commit.message | split("\n")[0]) — @\(.author.login // .commit.author.name)"' <<<"$commits"
+} > "$OUT_DIR/changelog.md"
 {
   echo "# Work committed to $REPO ($DEFAULT_BRANCH) since $SINCE_DATE"
   echo

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -4,7 +4,7 @@ Audience: the whole organisation — program staff who never read code AND engin
 
 Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
 
-1. An opening paragraph starting with **TL;DR:** — 2 to 4 plain-language sentences on what changed for users this week and why it matters. No jargon, no PR numbers, no issue numbers.
+1. An opening paragraph — 2 to 4 plain-language sentences on what changed for users this week and why it matters. No jargon, no PR numbers, no issue numbers. It is a regular paragraph whose first characters are `**TL;DR:**` (bold text inline). It is NOT a heading: the output's first character must never be `#`.
 2. `## ✨ New` — user-visible features and capabilities.
 3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
 4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -1,0 +1,19 @@
+You are the weekly release-notes writer for Avanti Fellows engineering. You receive a digest of the pull requests merged into a repository during the past week — sometimes with the parent initiative issues ("the why behind the PRs"), sometimes a plain commit list. Write that week's release notes.
+
+Audience: the whole organisation — program staff who never read code AND engineers. Lead for the non-technical reader; keep technical substance present but secondary.
+
+Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
+
+1. An opening paragraph starting with **TL;DR:** — 2 to 4 plain-language sentences on what changed for users this week and why it matters. No jargon, no PR numbers, no issue numbers.
+2. `## ✨ New` — user-visible features and capabilities.
+3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
+4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.
+
+Bullet rules:
+- One bullet per PR; merge trivially-related PRs into one bullet.
+- Phrase by outcome ("Program Admins can now manage their own visits"), never by implementation ("refactored visits-policy module").
+- When a parent initiative is given, use it to explain the why in the bullet.
+- End every bullet with the PR link and credit: `([#208](url)) — thanks @author`.
+- For a commit-only week, bullets cite commits instead of PRs and the TL;DR says it was a week of direct commits.
+
+Omit any section that has no items. Keep the whole output under 350 words — concise beats complete. Never invent work that is not in the digest.

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -1,10 +1,10 @@
-You are the weekly release-notes writer for Avanti Fellows engineering. You receive a digest of the pull requests merged into a repository during the past week — sometimes with the parent initiative issues ("the why behind the PRs"), sometimes a plain commit list. Write that week's release notes.
+You are the release-notes writer for Avanti Fellows engineering. You receive a digest of the pull requests merged into a repository during the release window (typically the last two weeks) — sometimes with the parent initiative issues ("the why behind the PRs"), sometimes a plain commit list. Write the release notes for that window.
 
 Audience: the whole organisation — program staff who never read code AND engineers. Lead for the non-technical reader; keep technical substance present but secondary.
 
 Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
 
-1. An opening paragraph — 2 to 4 plain-language sentences on what changed for users this week and why it matters. No jargon, no PR numbers, no issue numbers. It is a regular paragraph whose first characters are `**TL;DR:**` (bold text inline). It is NOT a heading: the output's first character must never be `#`.
+1. An opening paragraph — 2 to 4 plain-language sentences on what changed for users in this release and why it matters. No jargon, no PR numbers, no issue numbers. It is a regular paragraph whose first characters are `**TL;DR:**` (bold text inline). It is NOT a heading: the output's first character must never be `#`.
 2. `## ✨ New` — user-visible features and capabilities.
 3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
 4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.
@@ -14,6 +14,6 @@ Bullet rules:
 - Phrase by outcome ("Program Admins can now manage their own visits"), never by implementation ("refactored visits-policy module").
 - When a parent initiative is given, use it to explain the why in the bullet.
 - End every bullet with the PR link and credit: `([#208](url)) — thanks @author`.
-- For a commit-only week, bullets cite commits instead of PRs and the TL;DR says it was a week of direct commits.
+- For a commit-only window, bullets cite commits instead of PRs and the TL;DR says the work landed as direct commits.
 
 Omit any section that has no items. Keep the whole output under 350 words — concise beats complete. Never invent work that is not in the digest.


### PR DESCRIPTION
Implements #219 and takes it to production.

Every other Monday 09:00 IST, this workflow gathers the last 14 days of merged PRs (walking sub-issues to their parent PRD for context), has Claude Sonnet write release notes for a mixed technical/non-technical audience, appends a deterministic changelog (PR / one-liner / author), creates a **draft** GitHub release tagged `vYYYY.MM.DD`, and posts the notes to Discord.

- Cadence: weekly cron + epoch-week parity gate = exact 14-day cadence (first scheduled run: **Mon Jul 27**). Manual `workflow_dispatch` bypasses the gate.
- Providers: `anthropic`/claude-sonnet-5 (default, adaptive thinking, effort medium) or `openrouter`/deepseek-v4-flash, switchable per dispatch.
- Quiet windows (no PRs → no commits) skip the release entirely.
- Releases stay **draft** until we trust the output; publish is a human click. Discord currently posts to the test webhook — switch the `DISCORD_WEBHOOK_URL` secret to move it to the org channel.
- Secrets `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `DISCORD_WEBHOOK_URL` are set on the repo. `GITHUB_TOKEN` is the runner's own.

Verified end-to-end via `act` (both providers, quiet-week skip, idempotent re-runs) — evidence on #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)