### PR TITLE
Bulleted TL;DR, simpler wording, dry_run input

### DIFF
--- a/.github/workflows/biweekly-release.yml
+++ b/.github/workflows/biweekly-release.yml
@@ -22,6 +22,10 @@ on:
       thinking:
         description: Thinking effort (off/minimal/low/medium/high/xhigh/max)
         default: medium
+      dry_run:
+        description: Generate notes but skip the release and Discord post
+        type: boolean
+        default: false
   schedule:
     - cron: "30 3 * * 1" # Mondays 09:00 IST; gate skips every other week
 
@@ -104,7 +108,7 @@ jobs:
 
       - name: Create draft release
         id: release
-        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
         run: |
           TAG="${{ steps.gather.outputs.tag }}"
           # Idempotent re-runs: replace an existing draft for the same tag.
@@ -117,7 +121,7 @@ jobs:
           echo "Draft release: $URL"
 
       - name: Post to Discord
-        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true'
+        if: steps.gate.outputs.run == 'true' && steps.gather.outputs.skip != 'true' && inputs.dry_run != true
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |

--- a/release-notes/system-prompt.md
+++ b/release-notes/system-prompt.md
@@ -4,7 +4,7 @@ Audience: the whole organisation — program staff who never read code AND engin
 
 Output exactly this structure, in markdown, and nothing else (no preamble, no sign-off):
 
-1. An opening paragraph — 2 to 4 plain-language sentences on what changed for users in this release and why it matters. No jargon, no PR numbers, no issue numbers. It is a regular paragraph whose first characters are `**TL;DR:**` (bold text inline). It is NOT a heading: the output's first character must never be `#`.
+1. The opener: a line containing only `**TL;DR**`, then 2 to 4 bullets. Each bullet is one short, plain sentence (about 15 words or fewer) naming one change and who it helps. No jargon, no PR numbers, no issue numbers. `**TL;DR**` is bold text, not a heading — the output's first character must never be `#`.
 2. `## ✨ New` — user-visible features and capabilities.
 3. `## 🐛 Fixes` — bugs fixed, phrased by user impact.
 4. `## 🔧 Maintenance` — refactors, CI, tooling, docs.
@@ -16,4 +16,4 @@ Bullet rules:
 - End every bullet with the PR link and credit: `([#208](url)) — thanks @author`.
 - For a commit-only window, bullets cite commits instead of PRs and the TL;DR says the work landed as direct commits.
 
-Omit any section that has no items. Keep the whole output under 350 words — concise beats complete. Never invent work that is not in the digest.
+Write simply, everywhere: short sentences, everyday words, one idea per bullet, no parenthetical detail-stacking. Readers skim this — a detailed changelog is appended after your output, so you never need to be exhaustive. Omit any section that has no items. Keep the whole output under 250 words. Never invent work that is not in the digest.


### PR DESCRIPTION
Follow-up to #220 per feedback: the TL;DR was a wall of text.

- TL;DR is now 2–4 short bullets (one plain sentence each) instead of a paragraph
- Prompt enforces short sentences and everyday words throughout, 250-word budget
- New `dry_run` dispatch input: generates notes but skips the release + Discord post, so tuning runs stay out of the channel

The draft `Release v2026.07.17` has already been regenerated in the new format (verified with a local Sonnet run, same settings as prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)