### PR TITLE
feat(quiz-sessions): create form (survey) sessions from form templates

### DIFF
--- a/scripts/import_form_template_resources.py
+++ b/scripts/import_form_template_resources.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Create form_template resources in the DB service for LMS form-session creation.
+
+A "form template" is a resource (type=form_template) carrying the content-dependent
+bits a teacher must NOT type: the Google Sheet URL, the exact sheet/tab name, the
+single-page header, and the canonical form flags. The LMS Forms picker lists these;
+selecting one + a batch + a window creates a form session, which the sessionCreator
+Lambda turns into a questionnaire quiz by reading the named sheet tab.
+
+Canonical form values (from quiz-creator Options.ts / form flow):
+  test_type=form, test_format=questionnaire, gurukul_format_type=qa,
+  marking_scheme="1, 0", optional_limits=N/A, stream=Others,
+  show_answers=false, show_scores=false, shuffle=false, is_advanced_format=false.
+
+sessionCreator reads cms_test_id as the full Sheets URL (it takes URL segment 5 as
+the spreadsheet ID; the #gid is ignored) and opens the tab by sheet_name (exact tab
+title). So cms_test_id MUST be the canonical /spreadsheets/d/<ID>/edit form and
+sheet_name MUST match the tab's display name byte-for-byte.
+
+Dry-run by default. Re-run with --upload to POST new resources. Dedup by code.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+RESOURCE_TYPE = "form_template"
+SOURCE = "lms"
+
+# The workbook holding all three form sheets. Canonical /spreadsheets/d/<ID>/edit
+# shape so sessionCreator's split("/")[5] extracts the ID correctly.
+SPREADSHEET_ID = "1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E"
+SHEET_URL = f"https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit"
+
+# Values common to every form template. grade is intentionally omitted for the
+# grade-agnostic Student Profile form (grade comes from the batch at creation);
+# grade-specific baseline forms set it explicitly below.
+COMMON = {
+    "test_type": "form",
+    "test_format": "questionnaire",
+    "gurukul_format_type": "qa",
+    "marking_scheme": "1, 0",
+    "optional_limits": "N/A",
+    "stream": "Others",
+    "course": "Photon",
+    "test_purpose": "baseline",
+    "show_answers": False,
+    "show_scores": False,
+    "shuffle": False,
+    "require_all_questions": False,
+    "is_advanced_format": False,
+    "is_active": True,
+    "cms_link": SHEET_URL,
+    "cms_test_id": SHEET_URL,
+}
+
+# One entry per template. `sheet_name` MUST match the tab title in the workbook.
+# `single_page_header_text` is the form's header; for the grade-agnostic Student
+# Profile it is a base string the create route appends the grade to at session time.
+TEMPLATES = [
+    {
+        "code": "FORM-STUDENT-PROFILE",
+        "name": "Student Profile Questions",
+        "type_params": {
+            **COMMON,
+            "sheet_name": "Student Profile Questions",
+            "single_page_header_text": "Student Profile Form",
+            # grade-agnostic: no `grade` key — sourced from the batch at creation.
+        },
+    },
+    {
+        "code": "FORM-BASELINE-G11",
+        "name": "Baseline Questions G11",
+        "type_params": {
+            **COMMON,
+            "grade": 11,
+            "sheet_name": "Baseline Questions G11",
+            "single_page_header_text": "Student Mentoring Baseline G11",
+        },
+    },
+    {
+        "code": "FORM-BASELINE-G12",
+        "name": "Baseline Questions G12",
+        "type_params": {
+            **COMMON,
+            "grade": 12,
+            "sheet_name": "Baseline Questions G12",
+            "single_page_header_text": "Student Mentoring Baseline G12",
+        },
+    },
+]
+
+
+def resource_payload(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": RESOURCE_TYPE,
+        "subtype": "form",
+        "source": SOURCE,
+        "code": template["code"],
+        "name": [{"resource": template["name"], "lang_code": "en"}],
+        "type_params": template["type_params"],
+    }
+
+
+def load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip("\"'"))
+
+
+def request_json(method: str, url: str, token: str, body: dict[str, Any] | None = None) -> Any:
+    data = None
+    headers = {"Authorization": f"Bearer {token}", "accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+            return json.loads(payload) if payload else None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+
+
+def existing_codes(base_url: str, token: str) -> set[str]:
+    query = urllib.parse.urlencode(
+        {"type": RESOURCE_TYPE, "limit": "500", "sort_by": "code", "sort_order": "asc"}
+    )
+    resources = request_json("GET", f"{base_url.rstrip('/')}/resource?{query}", token)
+    if not isinstance(resources, list):
+        raise RuntimeError("Expected DB service /resource to return a list")
+    return {str(item.get("code")).strip() for item in resources if isinstance(item, dict) and item.get("code")}
+
+
+def upload(payloads: list[dict[str, Any]], base_url: str, token: str) -> None:
+    have = existing_codes(base_url, token)
+    created = skipped = 0
+    for payload in payloads:
+        code = payload["code"]
+        if code in have:
+            print(f"skip existing {code}")
+            skipped += 1
+            continue
+        result = request_json("POST", f"{base_url.rstrip('/')}/resource", token, payload)
+        rid = result.get("id") if isinstance(result, dict) else ""
+        print(f"created {code}: id={rid}")
+        created += 1
+    print(f"\nUpload complete: {created} created, {skipped} skipped.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", type=Path, default=Path(".env.local"))
+    parser.add_argument("--db-url", default=None, help="DB service base URL (default: DB_SERVICE_URL)")
+    parser.add_argument("--db-token", default=None, help="DB service token (default: DB_SERVICE_TOKEN)")
+    parser.add_argument("--jsonl-out", type=Path, default=Path("tmp/form-template-resources.jsonl"))
+    parser.add_argument("--upload", action="store_true", help="POST new resources (default: dry run)")
+    args = parser.parse_args()
+
+    load_env_file(args.env_file)
+    db_url = args.db_url or os.environ.get("DB_SERVICE_URL")
+    db_token = args.db_token or os.environ.get("DB_SERVICE_TOKEN")
+
+    payloads = [resource_payload(t) for t in TEMPLATES]
+
+    args.jsonl_out.parent.mkdir(parents=True, exist_ok=True)
+    with args.jsonl_out.open("w", encoding="utf-8") as f:
+        for payload in payloads:
+            f.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+    print(f"Prepared {len(payloads)} form templates:")
+    for payload in payloads:
+        tp = payload["type_params"]
+        print(
+            f"  {payload['code']:22} sheet_name={tp['sheet_name']!r} "
+            f"grade={tp.get('grade', '(from batch)')} header={tp['single_page_header_text']!r}"
+        )
+    print(f"\nWrote payloads: {args.jsonl_out}")
+    print(f"Target DB: {db_url or '(unset)'}")
+
+    if args.upload:
+        if not db_url or not db_token:
+            raise RuntimeError("Set DB_SERVICE_URL and DB_SERVICE_TOKEN, or pass --db-url/--db-token")
+        upload(payloads, db_url, db_token)
+    else:
+        print("\nDry run only. Re-run with --upload to POST new resources.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/src/app/api/quiz-sessions/form-templates/route.ts
+++ b/src/app/api/quiz-sessions/form-templates/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { requireQuizSessionAccess } from "@/lib/quiz-session-access";
+import {
+  parseQuizTemplateResource,
+  type RawQuizTemplateResource,
+} from "@/lib/quiz-template-resource";
+
+const DB_SERVICE_URL = process.env.DB_SERVICE_URL;
+const DB_SERVICE_TOKEN = process.env.DB_SERVICE_TOKEN;
+
+// Form (survey/questionnaire) templates are stored as their own resource type so
+// they never mix into the quiz-paper picker. They reuse the quiz-template
+// type_params shape (parseQuizTemplateResource already reads sheet_name + cms
+// fields), differing by test_type=form / test_format=questionnaire.
+const RESOURCE_TYPE = "form_template";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await requireQuizSessionAccess(session.user.email, "view");
+  if (!access.ok) {
+    return access.response;
+  }
+
+  if (!DB_SERVICE_URL || !DB_SERVICE_TOKEN) {
+    return NextResponse.json(
+      { error: "DB service is not configured" },
+      { status: 500 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const search = (searchParams.get("search") || "").trim().toLowerCase();
+
+  const response = await fetch(
+    `${DB_SERVICE_URL}/resource?type=${encodeURIComponent(RESOURCE_TYPE)}&limit=1000&sort_by=code&sort_order=asc`,
+    {
+      headers: {
+        Authorization: `Bearer ${DB_SERVICE_TOKEN}`,
+        accept: "application/json",
+      },
+      cache: "no-store",
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Failed to fetch form templates:", errorText);
+    return NextResponse.json(
+      { error: "Failed to fetch form templates" },
+      { status: response.status }
+    );
+  }
+
+  const rawResources = (await response.json()) as RawQuizTemplateResource[];
+
+  // No grade filter: some form templates (e.g. Student Profile) are grade-agnostic
+  // — grade is sourced from the selected batch at session creation, not the template.
+  const templates = rawResources
+    .map(parseQuizTemplateResource)
+    .filter((template) => template.type === RESOURCE_TYPE && template.isActive)
+    .filter((template) =>
+      search
+        ? [template.name, template.code, template.testPurpose]
+            .join(" ")
+            .toLowerCase()
+            .includes(search)
+        : true
+    );
+
+  return NextResponse.json({ templates });
+}

--- a/src/app/api/quiz-sessions/route.test.ts
+++ b/src/app/api/quiz-sessions/route.test.ts
@@ -376,4 +376,130 @@ describe("POST /api/quiz-sessions", () => {
       id: 321,
     });
   });
+
+  it("creates a form session with canonical form metadata from a grade-agnostic template", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 5165,
+          type: "form_template",
+          code: "FORM-STUDENT-PROFILE",
+          name: [{ resource: "Student Profile Questions", lang_code: "en" }],
+          type_params: {
+            // grade-agnostic: no grade key
+            course: "Photon",
+            stream: "Others",
+            test_format: "questionnaire",
+            test_purpose: "baseline",
+            test_type: "form",
+            optional_limits: "N/A",
+            marking_scheme: "1, 0",
+            cms_link:
+              "https://docs.google.com/spreadsheets/d/1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E/edit",
+            cms_test_id:
+              "https://docs.google.com/spreadsheets/d/1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E/edit",
+            sheet_name: "Student Profile Questions",
+            single_page_header_text: "Student Profile Form",
+            require_all_questions: false,
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 777 }));
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          // no stream sent — forms don't require it
+          resourceId: 5165,
+          grade: 11, // from the batch
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: 777 });
+
+    const createPayload = JSON.parse(
+      String((mocks.mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(createPayload.meta_data).toMatchObject({
+      test_type: "form",
+      test_format: "questionnaire",
+      gurukul_format_type: "qa",
+      marking_scheme: "1, 0",
+      stream: "Others",
+      grade: 11,
+      show_answers: false,
+      show_scores: false,
+      shuffle: false,
+      single_page_mode: true,
+      single_page_header_text: "Student Profile Form Grade 11",
+      require_all_questions: false,
+      sheet_name: "Student Profile Questions",
+      cms_test_id:
+        "https://docs.google.com/spreadsheets/d/1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E/edit",
+    });
+    expect(mocks.mockPublishMessage).toHaveBeenCalledWith({ action: "db_id", id: 777 });
+  });
+
+  it("uses the template grade + base header for a grade-specific form template", async () => {
+    const { POST } = await loadRouteModule();
+    mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mocks.mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 5166,
+          type: "form_template",
+          code: "FORM-BASELINE-G11",
+          name: [{ resource: "Baseline Questions G11", lang_code: "en" }],
+          type_params: {
+            grade: 11,
+            course: "Photon",
+            stream: "Others",
+            test_format: "questionnaire",
+            test_purpose: "baseline",
+            test_type: "form",
+            optional_limits: "N/A",
+            marking_scheme: "1, 0",
+            cms_link:
+              "https://docs.google.com/spreadsheets/d/1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E/edit",
+            cms_test_id:
+              "https://docs.google.com/spreadsheets/d/1F_W58M6Uw2U-XsGgK3ocAfnH2ifPcZRCfaNCt9i_c1E/edit",
+            sheet_name: "Baseline Questions G11",
+            single_page_header_text: "Student Mentoring Baseline G11",
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 888 }));
+
+    const res = await POST(
+      jsonRequest("http://localhost/api/quiz-sessions", {
+        method: "POST",
+        body: {
+          resourceId: 5166,
+          parentBatchId: "EnableStudents_11_Engg",
+          classBatchIds: ["EnableStudents_11_Engg_A"],
+          startTime: "2026-04-15T04:30:00.000Z",
+          endTime: "2026-04-15T08:30:00.000Z",
+        },
+      }) as never
+    );
+
+    expect(res.status).toBe(200);
+    const createPayload = JSON.parse(
+      String((mocks.mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(createPayload.meta_data).toMatchObject({
+      grade: 11,
+      single_page_header_text: "Student Mentoring Baseline G11",
+      sheet_name: "Baseline Questions G11",
+    });
+  });
 });

--- a/src/app/api/quiz-sessions/route.ts
+++ b/src/app/api/quiz-sessions/route.ts
@@ -119,7 +119,10 @@ async function fetchQuizTemplateResource(
 
   const rawResource = (await response.json()) as RawQuizTemplateResource;
   const parsed = parseQuizTemplateResource(rawResource);
-  return parsed.type === "quiz_template" ? parsed : null;
+  // Accept both quiz papers and form templates — the create path handles both.
+  return parsed.type === "quiz_template" || parsed.type === "form_template"
+    ? parsed
+    : null;
 }
 
 export async function GET(request: NextRequest) {
@@ -276,7 +279,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  if (!body.stream) {
+  const selectedTemplate = await fetchQuizTemplateResource(Number(body.resourceId));
+  if (!selectedTemplate) {
+    return NextResponse.json(
+      { error: "Selected template was not found" },
+      { status: 404 }
+    );
+  }
+
+  const isForm = selectedTemplate.testType === "form";
+
+  // stream is required for quiz papers (it must match the batch); forms use a
+  // fixed "Others" stream, so it is not required in the form payload.
+  if (!body.stream && !isForm) {
     return NextResponse.json(
       { error: "stream is required" },
       { status: 400 }
@@ -290,22 +305,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const selectedTemplate = await fetchQuizTemplateResource(Number(body.resourceId));
-  if (!selectedTemplate) {
-    return NextResponse.json(
-      { error: "Selected template was not found" },
-      { status: 404 }
-    );
-  }
-
-  if (selectedTemplate.grade === null) {
+  // Form templates (e.g. Student Profile) can be grade-agnostic — grade comes
+  // from the selected batch, sent as body.grade. Quiz papers still require it on
+  // the template.
+  const resolvedGrade = selectedTemplate.grade ?? (isForm ? body.grade ?? null : null);
+  if (resolvedGrade === null) {
     return NextResponse.json(
       { error: "Selected template is missing grade metadata" },
       { status: 400 }
     );
   }
 
-  if (selectedTemplate.stream && selectedTemplate.stream !== body.stream) {
+  // Forms carry a fixed stream ("Others") that intentionally does not match a
+  // batch's engineering/medical stream, so skip the stream-match check for them.
+  if (!isForm && selectedTemplate.stream && selectedTemplate.stream !== body.stream) {
     return NextResponse.json(
       { error: "Selected template stream does not match selected batches" },
       { status: 400 }
@@ -335,10 +348,26 @@ export async function POST(request: NextRequest) {
 
   const sessionName = body.name?.trim() || getDefaultSessionName(selectedTemplate.name);
   const testType = selectedTemplate.testType || "assessment";
-  const shuffle = body.shuffle ?? false;
-  const gurukulFormatType = shuffle ? "qa" : body.gurukulFormatType || "both";
+  const shuffle = isForm ? false : body.shuffle ?? false;
+  // Forms are single-page questionnaires: gurukul_format_type is always "qa".
+  const gurukulFormatType = isForm
+    ? "qa"
+    : shuffle
+      ? "qa"
+      : body.gurukulFormatType || "both";
   const cmsLink = selectedTemplate.cmsLink;
   const cmsSourceId = selectedTemplate.cmsSourceId;
+
+  // Form single-page header: the template carries a base header
+  // (single_page_header_text). For a grade-agnostic template (grade sourced from
+  // the batch) append the grade so the same form reads "… Grade 11" / "… Grade 12"
+  // per batch. Falls back to the template name if no header was set.
+  const formHeaderBase = selectedTemplate.singlePageHeaderText || selectedTemplate.name || "";
+  const formHeaderText = isForm
+    ? selectedTemplate.grade === null
+      ? `${formHeaderBase} Grade ${resolvedGrade}`.trim()
+      : formHeaderBase.trim()
+    : "";
 
   // Resolve the program group + auth type from the selected class batch via the
   // batch→auth_group FK (was hardcoded to EnableStudents/"ID,DOB"). Gurukul
@@ -383,9 +412,10 @@ export async function POST(request: NextRequest) {
       batch_id: Array.isArray(body.classBatchIds)
         ? body.classBatchIds.join(",")
         : body.classBatchIds,
-      grade: selectedTemplate.grade,
+      grade: resolvedGrade,
       course: selectedTemplate.course,
-      stream: body.stream,
+      // Forms carry a fixed canonical stream ("Others"); quizzes use the batch stream.
+      stream: isForm ? "Others" : body.stream,
       resource_id: selectedTemplate.id,
       resource_code: selectedTemplate.code,
       resource_name: selectedTemplate.name,
@@ -395,8 +425,11 @@ export async function POST(request: NextRequest) {
       test_purpose: selectedTemplate.testPurpose,
       test_type: testType,
       gurukul_format_type: gurukulFormatType,
-      marking_scheme:
-        testType === "homework" || testType === "form" ? "1,0" : "4,-1",
+      marking_scheme: isForm
+        ? "1, 0"
+        : testType === "homework"
+          ? "1,0"
+          : "4,-1",
       optional_limits: selectedTemplate.optionalLimits,
       cms_test_id: cmsLink,
       cms_link: cmsLink,
@@ -413,13 +446,19 @@ export async function POST(request: NextRequest) {
       admin_testing_link: "",
       admin_testing_omr_link: "",
       number_of_fields_in_popup_form: "",
-      show_answers: body.showAnswers ?? true,
-      show_scores: body.showScores ?? true,
+      // Forms have no scores and no answer review (the form player short-circuits
+      // both regardless), so both are fixed false — matching the fixtures. Quizzes
+      // keep the caller's choices (defaulting to show both).
+      show_answers: isForm ? false : body.showAnswers ?? true,
+      show_scores: isForm ? false : body.showScores ?? true,
       shuffle,
       next_step_url: "",
       next_step_text: "",
-      single_page_mode: false,
-      single_page_header_text: "",
+      // Forms render as a single page with a header; sessionCreator force-sets
+      // single_page_mode for forms anyway, but set it here for a correct session row.
+      single_page_mode: isForm,
+      single_page_header_text: formHeaderText,
+      require_all_questions: isForm ? selectedTemplate.requireAllQuestions : false,
       test_takers_count: 100,
       status: "pending",
       date_created: utcToISTDate(new Date().toISOString()),

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -89,7 +89,7 @@ const GradeOptions = [11, 12];
 
 // New-CMS chapter-test picker (source toggle inside session creation). Test subtypes +
 // their labels are shared with the server routes via CMS_TEST_TYPE_OPTIONS (@/lib/cms-tests).
-type TestSource = "legacy" | "cms";
+type TestSource = "legacy" | "cms" | "form";
 const EXAM_TRACK_OPTIONS: { value: ExamTrack; label: string }[] = [
   { value: "jee_main", label: "JEE Main" },
   { value: "jee_advanced", label: "JEE Advanced" },
@@ -1064,7 +1064,13 @@ function QuizSessionCreateModal({
   }, [startTime, endTimeEdited]);
 
   useEffect(() => {
-    if (!batchDerivation.stream || !selectedGrade || !testFormat) {
+    // CMS mode has its own picker (not template-based); skip this effect.
+    if (testSource === "cms") return;
+
+    // Form templates are grade-agnostic and stream-fixed, so they load as soon as
+    // Form mode is active — no batch stream / grade / format gating like papers.
+    const isFormMode = testSource === "form";
+    if (!isFormMode && (!batchDerivation.stream || !selectedGrade || !testFormat)) {
       setTemplates([]);
       setSelectedTemplateId(null);
       setTemplateError(null);
@@ -1077,13 +1083,15 @@ function QuizSessionCreateModal({
       setTemplateError(null);
 
       try {
-        const params = new URLSearchParams({
-          grade: selectedGrade,
-          stream: batchDerivation.stream,
-          testFormat,
-        });
+        const url = isFormMode
+          ? `/api/quiz-sessions/form-templates`
+          : `/api/quiz-sessions/templates?${new URLSearchParams({
+              grade: selectedGrade,
+              stream: batchDerivation.stream,
+              testFormat,
+            }).toString()}`;
 
-        const response = await fetch(`/api/quiz-sessions/templates?${params.toString()}`);
+        const response = await fetch(url);
         if (!response.ok) {
           throw new Error("Failed to fetch templates");
         }
@@ -1095,7 +1103,11 @@ function QuizSessionCreateModal({
         console.error(err);
         if (!cancelled) {
           setTemplates([]);
-          setTemplateError("Failed to load papers for the selected batch and format.");
+          setTemplateError(
+            isFormMode
+              ? "Failed to load form templates."
+              : "Failed to load papers for the selected batch and format."
+          );
         }
       } finally {
         if (!cancelled) {
@@ -1109,6 +1121,7 @@ function QuizSessionCreateModal({
       cancelled = true;
     };
   }, [
+    testSource,
     batchDerivation.stream,
     selectedGrade,
     testFormat,
@@ -1124,6 +1137,17 @@ function QuizSessionCreateModal({
     () => templates.find((template) => template.id === selectedTemplateId) ?? null,
     [selectedTemplateId, templates]
   );
+
+  const isForm = testSource === "form";
+
+  // Forms pick grade first (like legacy papers), then show templates that fit:
+  // grade-specific templates only under their own grade; grade-agnostic ones
+  // (grade === null, e.g. Student Profile) under any selected grade.
+  const formTemplatesForGrade = useMemo(() => {
+    if (!isForm || !selectedGrade) return [];
+    const g = Number(selectedGrade);
+    return templates.filter((t) => t.grade === null || t.grade === g);
+  }, [isForm, selectedGrade, templates]);
 
   // CMS cascade: fetch in-syllabus chapters once exam-track + grade + subject are chosen.
   // Only chapter tests drill by chapter; major tests skip this step entirely.
@@ -1270,6 +1294,10 @@ function QuizSessionCreateModal({
         return "Chapter is required.";
       }
       if (selectedCmsTestId === null) return "Please select a CMS test.";
+    } else if (testSource === "form") {
+      // Grade is chosen first, then a form is picked from the grade-matching list.
+      if (!selectedGrade) return "Grade is required.";
+      if (!selectedTemplate) return "Please select a form.";
     } else {
       if (!selectedGrade) return "Grade is required.";
       if (!testFormat) return "Test format is required.";
@@ -1361,12 +1389,17 @@ function QuizSessionCreateModal({
         return;
       }
 
-      if (!selectedTemplate || selectedTemplate.grade === null) return;
+      if (!selectedTemplate) return;
+      // Grade: quiz papers require it on the template; forms fall back to the
+      // batch-derived grade when the template is grade-agnostic.
+      const resolvedGrade =
+        selectedTemplate.grade ?? (isForm ? Number(selectedGrade) || null : null);
+      if (resolvedGrade === null) return;
 
       const payload = {
         name: name.trim() || getDefaultSessionName(selectedTemplate.name),
         resourceId: selectedTemplate.id,
-        grade: selectedTemplate.grade,
+        grade: resolvedGrade,
         parentBatchId: batchDerivation.parentBatchId,
         classBatchIds,
         stream: batchDerivation.stream,
@@ -1479,6 +1512,7 @@ function QuizSessionCreateModal({
                       [
                         { value: "legacy", label: "Legacy paper" },
                         { value: "cms", label: "New CMS Test" },
+                        { value: "form", label: "Form / Survey" },
                       ] as { value: TestSource; label: string }[]
                     ).map((option) => (
                       <button
@@ -1626,6 +1660,95 @@ function QuizSessionCreateModal({
                       })}
                     </div>
                   )}
+                  </div>
+                  )}
+
+                  {testSource === "form" && (
+                  <div className="space-y-4">
+                    <div>
+                      <label
+                        htmlFor="form-session-grade"
+                        className="mb-2 block text-xs font-bold uppercase tracking-wide text-text-muted"
+                      >
+                        Grade
+                      </label>
+                      <select
+                        id="form-session-grade"
+                        value={selectedGrade}
+                        onChange={(event) => {
+                          setSelectedGrade(event.target.value);
+                          setSelectedTemplateId(null);
+                        }}
+                        className="min-h-[44px] w-full rounded-lg border-2 border-border bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                      >
+                        <option value="">Select grade</option>
+                        {GradeOptions.map((grade) => (
+                          <option key={grade} value={grade}>
+                            {grade}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    {loadingTemplates ? (
+                      <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                        Loading forms...
+                      </div>
+                    ) : templateError ? (
+                      <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-sm text-red-700">
+                        {templateError}
+                      </div>
+                    ) : !selectedGrade ? (
+                      <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                        Select a grade to see available forms.
+                      </div>
+                    ) : formTemplatesForGrade.length === 0 ? (
+                      <div className="rounded-lg border border-border bg-bg-card-alt px-3 py-3 text-sm text-text-secondary">
+                        No forms are available for this grade.
+                      </div>
+                    ) : (
+                      <div className="max-h-72 overflow-y-auto rounded-lg border border-border">
+                        {formTemplatesForGrade.map((template) => {
+                          const isSelected = template.id === selectedTemplateId;
+                          return (
+                            <div
+                              key={template.id}
+                              role="button"
+                              aria-pressed={isSelected}
+                              tabIndex={0}
+                              onClick={() => toggleTemplate(template.id)}
+                              onKeyDown={(event) => {
+                                if (event.key === "Enter" || event.key === " ") {
+                                  event.preventDefault();
+                                  toggleTemplate(template.id);
+                                }
+                              }}
+                              className={`flex w-full items-start gap-3 border-b border-border px-3 py-3 text-left last:border-b-0 ${
+                                isSelected
+                                  ? "bg-success-bg"
+                                  : "bg-bg-card hover:bg-hover-bg"
+                              }`}
+                            >
+                              <span
+                                className={`mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center border text-[11px] leading-none ${
+                                  isSelected
+                                    ? "border-accent bg-accent text-text-on-accent"
+                                    : "border-border bg-bg-card text-transparent"
+                                }`}
+                                aria-hidden="true"
+                              >
+                                ✓
+                              </span>
+                              <div className="min-w-0 flex-1">
+                                <div className="text-sm font-semibold text-text-primary">
+                                  {template.name}
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
                   )}
 
@@ -1939,66 +2062,73 @@ function QuizSessionCreateModal({
                           />
                         </div>
 
-                        <label className="flex items-center gap-2 text-sm text-text-primary">
-                          <input
-                            type="checkbox"
-                            checked={showScores}
-                            onChange={(event) => setShowScores(event.target.checked)}
-                            className="h-4 w-4 accent-accent"
-                          />
-                          Show scores after submission
-                        </label>
-                        <label className="flex items-center gap-2 text-sm text-text-primary">
-                          <input
-                            type="checkbox"
-                            checked={showAnswers}
-                            onChange={(event) => setShowAnswers(event.target.checked)}
-                            className="h-4 w-4 accent-accent"
-                          />
-                          Show answers after submission
-                        </label>
-                        <label className="flex items-center gap-2 text-sm text-text-primary">
-                          <input
-                            type="checkbox"
-                            checked={shuffle}
-                            onChange={(event) => {
-                              const checked = event.target.checked;
-                              setShuffle(checked);
-                              if (checked) setGurukulFormatType(QA_GURUKUL_FORMAT);
-                            }}
-                            className="h-4 w-4 accent-accent"
-                          />
-                          Shuffle question order
-                        </label>
+                        {/* Forms have fixed semantics — always q&a, no shuffle,
+                            review always on, no scores — so these quiz-only
+                            controls are hidden; the server sends the fixed values. */}
+                        {!isForm && (
+                          <>
+                            <label className="flex items-center gap-2 text-sm text-text-primary">
+                              <input
+                                type="checkbox"
+                                checked={showScores}
+                                onChange={(event) => setShowScores(event.target.checked)}
+                                className="h-4 w-4 accent-accent"
+                              />
+                              Show scores after submission
+                            </label>
+                            <label className="flex items-center gap-2 text-sm text-text-primary">
+                              <input
+                                type="checkbox"
+                                checked={showAnswers}
+                                onChange={(event) => setShowAnswers(event.target.checked)}
+                                className="h-4 w-4 accent-accent"
+                              />
+                              Show answers after submission
+                            </label>
+                            <label className="flex items-center gap-2 text-sm text-text-primary">
+                              <input
+                                type="checkbox"
+                                checked={shuffle}
+                                onChange={(event) => {
+                                  const checked = event.target.checked;
+                                  setShuffle(checked);
+                                  if (checked) setGurukulFormatType(QA_GURUKUL_FORMAT);
+                                }}
+                                className="h-4 w-4 accent-accent"
+                              />
+                              Shuffle question order
+                            </label>
 
-                        <div className="space-y-2">
-                          <div className="text-xs font-bold uppercase tracking-wide text-text-muted">
-                            Gurukul Format
-                          </div>
-                          <div className="inline-flex w-full flex-wrap overflow-hidden rounded-lg border border-border sm:w-auto">
-                            {GurukulFormatOptions.map((option) => {
-                              const selected = gurukulFormatType === option.value;
-                              return (
-                                <button
-                                  key={option.value}
-                                  type="button"
-                                  onClick={() => {
-                                    if (shuffle && option.value !== QA_GURUKUL_FORMAT) return;
-                                    setGurukulFormatType(option.value);
-                                  }}
-                                  disabled={shuffle && option.value !== QA_GURUKUL_FORMAT}
-                                  className={`min-h-[44px] px-3 py-2 text-xs font-bold uppercase tracking-wide disabled:cursor-not-allowed disabled:opacity-50 ${
-                                    selected
-                                      ? "bg-accent text-text-on-accent"
-                                      : "bg-bg-card text-text-primary hover:bg-hover-bg"
-                                  }`}
-                                >
-                                  {option.label}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </div>
+                            <div className="space-y-2">
+                              <div className="text-xs font-bold uppercase tracking-wide text-text-muted">
+                                Gurukul Format
+                              </div>
+                              <div className="inline-flex w-full flex-wrap overflow-hidden rounded-lg border border-border sm:w-auto">
+                                {GurukulFormatOptions.map((option) => {
+                                  const selected = gurukulFormatType === option.value;
+                                  return (
+                                    <button
+                                      key={option.value}
+                                      type="button"
+                                      onClick={() => {
+                                        if (shuffle && option.value !== QA_GURUKUL_FORMAT) return;
+                                        setGurukulFormatType(option.value);
+                                      }}
+                                      disabled={shuffle && option.value !== QA_GURUKUL_FORMAT}
+                                      className={`min-h-[44px] px-3 py-2 text-xs font-bold uppercase tracking-wide disabled:cursor-not-allowed disabled:opacity-50 ${
+                                        selected
+                                          ? "bg-accent text-text-on-accent"
+                                          : "bg-bg-card text-text-primary hover:bg-hover-bg"
+                                      }`}
+                                    >
+                                      {option.label}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          </>
+                        )}
                       </div>
                     ) : null}
                   </div>
@@ -2441,6 +2571,10 @@ function QuizSessionDetailsModal({
                   label="Test Code"
                   value={getMetaString(session.meta_data, "test_code") || "-"}
                   mono
+                />
+                <InfoRow
+                  label="Grade"
+                  value={getMetaScalar(session.meta_data, "grade") || "-"}
                 />
                 <InfoRow
                   label="Ranking Cutoff"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,7 @@ import { getSchoolByPasscode } from "./permissions";
 export const DEV_LOGIN_PERSONAS = {
   admin: { email: "pritam@avantifellows.org", name: "Dev Admin" },
   program_manager: { email: "deepansh.mathur96@gmail.com", name: "Dev PM" },
-  teacher: { email: "sanghamitrapatil06@gmail.com", name: "Dev Teacher" },
+  teacher: { email: "teja.surya59@gmail.com", name: "Dev Teacher" },
   read_only: { email: "lokesh@avantifellows.org", name: "Dev Read-Only" },
 } as const;
 

--- a/src/lib/quiz-template-resource.ts
+++ b/src/lib/quiz-template-resource.ts
@@ -21,6 +21,8 @@ export interface QuizTemplateTypeParams {
   test_code?: string;
   test_name?: string;
   sheet_name?: string;
+  single_page_header_text?: string;
+  require_all_questions?: boolean;
 }
 
 export interface RawQuizTemplateResource {
@@ -54,6 +56,8 @@ export interface QuizTemplateResource {
   rankingCutoffDate: string;
   isActive: boolean;
   sheetName: string;
+  singlePageHeaderText: string;
+  requireAllQuestions: boolean;
 }
 
 function parseJsonIfNeeded<T>(value: T | string | null | undefined): T | null {
@@ -133,5 +137,7 @@ export function parseQuizTemplateResource(
     rankingCutoffDate: `${typeParams.ranking_cutoff_date || ""}`.trim(),
     isActive: typeParams.is_active !== false,
     sheetName: `${typeParams.sheet_name || ""}`.trim(),
+    singlePageHeaderText: `${typeParams.single_page_header_text || ""}`.trim(),
+    requireAllQuestions: typeParams.require_all_questions === true,
   };
 }


### PR DESCRIPTION
Lets teachers create **form / questionnaire sessions** the same way they create quiz sessions: pick a grade + batch + timing, choose a form template, submit. The session is written to the DB service and the sessionCreator Lambda builds the questionnaire quiz by reading the template's named Google Sheet tab.

## What a form template is
A new resource type (`form_template`) carrying the content-dependent bits a teacher must NOT type: the Google Sheet URL, the exact sheet tab name, the single-page header, and canonical form flags. Teachers only pick a template + grade + batch + window.

Three templates seeded via `scripts/import_form_template_resources.py` (dry-run default, `--upload` to POST): **Student Profile Questions** (grade-agnostic), **Baseline Questions G11**, **Baseline Questions G12**. Already on staging; run `--upload` against prod before shipping there.

## Changes
- **`form-templates` API** — `GET /api/quiz-sessions/form-templates` lists active form templates (no grade hard-filter; some are grade-agnostic).
- **Create route** — handles a form template: grade comes from the batch for grade-agnostic templates; sets `single_page_mode` + header (grade-suffixed for agnostic) + `require_all_questions`; forces canonical form values (`stream=Others`, `show_scores/show_answers/shuffle=false`, `gurukul_format_type=qa`, `marking_scheme="1, 0"`). `fetchQuizTemplateResource` now accepts `form_template`.
- **UI** — new "Form / Survey" source mode in the create flow: grade dropdown first, then a grade-filtered form list; quiz-only controls (scores/answers/shuffle/format) hidden for forms. Session detail modal now shows Grade.
- **Parser** — `quiz-template-resource` exposes `single_page_header_text` + `require_all_questions`.
- **auth.ts** — point the Dev Teacher persona at a real seated teacher account.

## Verification
Form semantics confirmed against quiz-backend/frontend (forms have no scores, no answer review, no shuffle; `qa` format only). Verified end-to-end on staging — a real form session created against a batch. Full suite green (2667); typecheck + lint clean.

## Ship checklist
- [ ] Run `import_form_template_resources.py --upload` against **prod** db-service (templates are staging-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)