### PR TITLE
Restore centre-program Dropout for teachers (admin/PM/PA-only since #162)

### DIFF
--- a/.mex/context/student-addition.md
+++ b/.mex/context/student-addition.md
@@ -18,7 +18,7 @@ edges:
     condition: when adding LMS API routes for create or bulk upload
   - target: patterns/db-service-write.md
     condition: when proxying student writes to the DB Service
-last_updated: 2026-07-22
+last_updated: 2026-07-24
 ---
 
 # Student Addition
@@ -101,6 +101,7 @@ Enrollment date handling is decided: LMS supplies DB Service `start_date` and `a
 - The enrollment tab uses all current batch program IDs, so a student enrolled in CoE and NVS appears in both program views and counts. Program-dropout audits provide `dropout_program_ids`, allowing the same student to appear as CoE Dropout and NVS Active at the same time.
 - The enrollment tab applies Grade and Stream filters together. For NVS, allowed write actors can export an Excel workbook with `Active` and `Dropout` sheets: Active follows both filters, while Dropout always contains every NVS dropout. The export mirrors the upload fields and appends historical APAAR ID and generated Student ID as the final columns.
 - Dropout accepts the opaque `student_pk_id` plus an explicit `program_id`. NVS reuses the Centre-free JNV-only existing-Student gate and derives Student ID or PEN server-side; other Programs retain their existing Centre-based Program dropout gate and Student ID or historical APAAR fallback. Non-admin actors need the target Program in their resolved scope, while the existing global-admin exception remains for newer centre Programs that are not in the hand-maintained JNV Program constants. Both paths proxy LMS `POST /api/student/dropout` to the DB Service program-dropout contract at `PATCH /api/dropout`.
+- Actor role gate differs by path (2026-07): NVS dropout stays admin/PM/PA-only (`requireStudentWriteActor`), but **Centre-program dropout follows the general `students=edit` matrix gate — teachers included** (`requireStudentProgramDropoutAccess` now uses `requireStudentEditActor`, mirroring the restored per-student Edit). Teachers had lost centre dropout in the July program-specific rework (`3386c35`) when it inherited the student-addition allow-list; per-program ownership (`actorHasProgramAccess`, admin bypass) still scopes a teacher to centres they manage. UI mirrors this: `StudentTable.canDropoutFromSelectedProgram` uses `canDropoutStudent` (admin/PM/PA) for NVS and `canEditStudent` (teacher-inclusive) for centre programs; NVS undo is unchanged.
 - LMS-audited DB Service dropout closes only the selected program batch and its group membership. It preserves other program batches, grade, school, and global status; when no current batch remains it applies the existing global dropout flow. Generic non-LMS `/api/dropout` callers retain the existing global behavior.
 - New LMS-audited NVS dropouts can be undone only in the same school and only when the exact prior NVS batch still exists, is open, and no other NVS batch is current. Undo restores that exact batch and membership; if NVS was the final active program, it also restores the exact school/grade records ended by global dropout and clears the generated dropout status. Legacy dropouts without the new audit metadata cannot be undone, and every undo writes a separate audit record.
 - Remaining LMS write proxy not safe enough for school rollout: `src/app/api/student/route.ts` only checks `session` before proxying.

--- a/src/components/StudentTable.test.tsx
+++ b/src/components/StudentTable.test.tsx
@@ -574,6 +574,50 @@ describe("StudentTable - Dropout button", () => {
     expect(screen.getByRole("button", { name: "Dropout" })).toBeInTheDocument();
   });
 
+  it("shows centre-program Dropout for a teacher (canDropoutStudent off, students=edit on)", () => {
+    render(
+      <StudentTable
+        students={[
+          makeStudent({
+            program_id: PROGRAM_IDS.COE,
+            student_program_ids: [PROGRAM_IDS.COE],
+          }),
+        ]}
+        selectedProgramId={PROGRAM_IDS.COE}
+        grades={defaultGrades}
+        canEditStudent
+        canDropoutStudent={false}
+        isAdmin={false}
+        userProgramIds={[PROGRAM_IDS.COE]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Dropout" })).toBeInTheDocument();
+  });
+
+  it("keeps NVS Dropout hidden for a teacher even when they manage NVS", () => {
+    render(
+      <StudentTable
+        students={[
+          makeStudent({
+            program_id: PROGRAM_IDS.NVS,
+            student_program_ids: [PROGRAM_IDS.NVS],
+          }),
+        ]}
+        selectedProgramId={PROGRAM_IDS.NVS}
+        grades={defaultGrades}
+        canEditStudent
+        canDropoutStudent={false}
+        isAdmin={false}
+        userProgramIds={[PROGRAM_IDS.NVS]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Dropout" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows Dropout button for active editable student", () => {
     render(
       <StudentTable

--- a/src/components/StudentTable.tsx
+++ b/src/components/StudentTable.tsx
@@ -588,7 +588,17 @@ export default function StudentTable({
   };
 
   const canDropoutFromSelectedProgram = (student: Student): boolean => {
-    if (!canDropoutStudent || effectiveProgramId == null) return false;
+    if (effectiveProgramId == null) return false;
+    // NVS dropout stays admin/PM/PA (canDropoutStudent). Centre-program dropout
+    // follows the general students=edit gate (canEditStudentEntry), so a teacher
+    // can drop a student from a centre they manage — matching the server's
+    // requireStudentProgramDropoutAccess. Per-program ownership is enforced by
+    // userCanManageProgram below.
+    const allowed =
+      effectiveProgramId === PROGRAM_IDS.NVS
+        ? canDropoutStudent
+        : canEditStudentEntry;
+    if (!allowed) return false;
     if (dropoutProgramIds && !dropoutProgramIds.includes(effectiveProgramId))
       return false;
     if (isPasscodeUser || !student.student_pk_id) return false;

--- a/src/lib/student-addition-access.test.ts
+++ b/src/lib/student-addition-access.test.ts
@@ -663,4 +663,58 @@ describe("requireStudentProgramDropoutAccess", () => {
       await requireStudentProgramDropoutAccess(session, "100", nonJnvProgramId),
     ).toEqual({ ok: false, status: 403, error: "Forbidden" });
   });
+
+  it("allows a teacher to drop from a centre program they manage", async () => {
+    mockGetResolvedPermission.mockResolvedValue(
+      permission({ role: "teacher", program_ids: [nonJnvProgramId] }),
+    );
+    mockGetProgramContextSync.mockReturnValue({
+      hasAccess: true,
+      programIds: [nonJnvProgramId],
+      isNVSOnly: false,
+      hasCoEOrNodal: true,
+    });
+
+    expect(
+      (await requireStudentProgramDropoutAccess(session, "100", nonJnvProgramId))
+        .ok,
+    ).toBe(true);
+  });
+
+  it("denies a teacher who does not manage the target centre program", async () => {
+    mockGetResolvedPermission.mockResolvedValue(
+      permission({ role: "teacher", program_ids: [PROGRAM_IDS.NVS] }),
+    );
+    mockGetProgramContextSync.mockReturnValue({
+      hasAccess: true,
+      programIds: [PROGRAM_IDS.NVS],
+      isNVSOnly: true,
+      hasCoEOrNodal: false,
+    });
+
+    expect(
+      await requireStudentProgramDropoutAccess(session, "100", nonJnvProgramId),
+    ).toEqual({ ok: false, status: 403, error: "Forbidden" });
+  });
+
+  it("denies a read-only teacher (no students edit) from centre dropout", async () => {
+    mockGetResolvedPermission.mockResolvedValue(
+      permission({ role: "teacher", program_ids: [nonJnvProgramId] }),
+    );
+    mockGetProgramContextSync.mockReturnValue({
+      hasAccess: true,
+      programIds: [nonJnvProgramId],
+      isNVSOnly: false,
+      hasCoEOrNodal: true,
+    });
+    mockGetFeatureAccess.mockReturnValue({
+      access: "view",
+      canView: true,
+      canEdit: false,
+    });
+
+    expect(
+      await requireStudentProgramDropoutAccess(session, "100", nonJnvProgramId),
+    ).toEqual({ ok: false, status: 403, error: "Forbidden" });
+  });
 });

--- a/src/lib/student-addition-access.ts
+++ b/src/lib/student-addition-access.ts
@@ -211,7 +211,13 @@ export async function requireStudentProgramDropoutAccess(
   studentPkId: number | string,
   programId: number,
 ): Promise<StudentProgramDropoutAccessResult> {
-  const actor = await requireStudentWriteActor(session);
+  // Centre-program dropout follows the general students=edit gate (teachers
+  // included), NOT the stricter admin/PM/PA student-addition actor. Teachers
+  // may drop a student from a centre program they manage — per-program
+  // ownership is still enforced below via actorHasProgramAccess. NVS dropout is
+  // unaffected: it routes through requireStudentAdditionStudentAccess, which
+  // keeps the admin/PM/PA-only requireStudentWriteActor.
+  const actor = await requireStudentEditActor(session);
   if (!actor.ok) return actor;
 
   const { email, permission } = actor;


### PR DESCRIPTION
## Problem

Staff tagged to JNV Chandrapur (and any JNV school running **CoE/Nodal centres**) reported that the **Dropout** control never appears for their students. The seats there are mostly `teacher`-role users; the admin and program managers see Dropout, teachers don't.

Teachers **do** have `students: edit` in the feature matrix and can edit these students — but they cannot drop them, which is the inconsistency users are hitting.

## Root cause — introduced by #162

Dropout originally (Nov 2025) rode on the general `students: edit` permission, which includes teachers. **PR #162** ("Implement NVS student addition workflows", issue-155) commit `3386c35` — "Make student dropout program-specific" — re-gated dropout on the NVS student-addition actor set (`admin | program_manager | program_admin`), decoupling it from `students: edit`. That was correct for NVS self-service addition (teachers don't add students), but it also swept up **centre-program** dropout.

Notably, per-student **Edit** was later restored to teachers (#226 / `requireStudentEditActor`), but **dropout was left on the stricter gate** — so today a teacher can edit a centre student but not drop them.

## Fix (centre programs only — NVS untouched)

- **Server** (`src/lib/student-addition-access.ts`): `requireStudentProgramDropoutAccess` now uses `requireStudentEditActor` (`students=edit`, teacher-inclusive, passcode excluded) instead of `requireStudentWriteActor` (admin/PM/PA). Every downstream check is unchanged — school access, `centre_program_ids` membership, current program enrollment, and per-program ownership (`actorHasProgramAccess`, admin bypass). A teacher is therefore confined to **centre programs they manage at schools they can access**.
- **UI** (`src/components/StudentTable.tsx`): `canDropoutFromSelectedProgram` picks the gate by program — NVS keeps `canDropoutStudent` (admin/PM/PA); centre programs use `canEditStudent` (teacher-inclusive). NVS "Undo Dropout" is untouched.

NVS dropout stays admin/PM/PA-only: the route dispatches `program_id === NVS` to the separate, unchanged `requireStudentAdditionStudentAccess` path, so NVS never reaches the loosened gate on either side.

## Scoping

Teachers are scoped to programs they're tagged to (matching per-student Edit), not "any centre program at the school" — the safer default.

## Tests

- Server: teacher allowed on a managed centre program; denied on an unmanaged program; read-only teacher denied; NVS gate unchanged.
- UI: teacher sees centre Dropout; teacher still doesn't see NVS Dropout.
- Full affected suites pass (`student-addition-access`, `StudentTable`, `dropout/route`, `school/[udise]/page`); `tsc`/`eslint` clean on changed files.

## Effect at JNV Chandrapur

Teachers seated at the CoE (program 1) and Nodal (program 2) centres will now see **Dropout** for students in the programs they hold seats in. NVS students there remain admin/PM/PA-only.

## Review

A correctness/security pass over the diff came back clean — no way for a teacher to drop a student outside their program∩school scope, and the NVS path is verified unaffected on both server and UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)