### PR TITLE
Remove Holistic Phase question limit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -360,7 +360,7 @@ _Avoid_: Academic Mentor-Mentee Mapping, shared mentorship mapping, evergreen as
 - **Phase Guidance** has no separate Publish action: Opening the Phase exposes saved Guidance to Mentors, and saving an Open but unstarted Phase warns the Admin and updates the Mentor view immediately
 - Each **Phase Guidance** Save records mutation actor/time and rejects stale concurrent edits without discarding the second Admin's unsaved text
 - V1 does not retain or expose pre-freeze **Phase Guidance** revisions; each Save replaces current content, the first persisted Notes data freezes the final content with the historical Phase, and Copy Previous Year creates an independent editable copy
-- Each **Holistic Phase** has 1-4 ordered, stable-ID **Post-Session Questions**, all free-text in v1; Admins explicitly Save the current set, and v1 has no question-version browser
+- Each **Holistic Phase** has one or more ordered, stable-ID **Post-Session Questions**, all free-text in v1; Admins explicitly Save the current set, and v1 has no question-version browser
 - Before the Phase starts, Admins may add, edit, remove, and reorder **Post-Session Questions**; after the first non-empty Notes draft autosaves, the question set is read-only
 - Only an active Staff Management Teacher assigned to a launch School in Program 1 is eligible to be a **Holistic Mentor** in v1
 - Holistic Mentor eligibility and Mapping access are scoped independently to each launch School where the Teacher has an active Teacher seat; a Teacher with multiple eligible seats can use each School's mapping roster, including before they have any assigned Mentees

--- a/src/app/api/holistic-mentorship/students/[studentId]/phases/[phaseId]/route.test.ts
+++ b/src/app/api/holistic-mentorship/students/[studentId]/phases/[phaseId]/route.test.ts
@@ -143,6 +143,10 @@ describe("Holistic Student Phase API", () => {
     });
     mockSave.mockResolvedValue({ ok: true, changed: true, revision: 3 });
 
+    const answers = Array.from({ length: 5 }, (_, index) => ({
+      question_id: 91 + index,
+      answer: `Answer ${index + 1}`,
+    }));
     const response = await PATCH(new Request(
       "http://localhost/api/holistic-mentorship/students/41/phases/73?school_code=SCH001&academic_year=2026-2027",
       {
@@ -150,7 +154,7 @@ describe("Holistic Student Phase API", () => {
         body: JSON.stringify({
           action: "draft",
           expected_revision: 2,
-          answers: [{ question_id: 91, answer: "A weekly plan" }],
+          answers,
         }),
       }
     ) as never, context);
@@ -169,7 +173,7 @@ describe("Holistic Student Phase API", () => {
       academicYear: "2026-2027",
       actorUserId: 9,
       expectedRevision: 2,
-      answers: [{ questionId: 91, answer: "A weekly plan" }],
+      answers: answers.map(({ question_id, answer }) => ({ questionId: question_id, answer })),
       expectedMappingId: undefined,
       expectedPhaseRevision: undefined,
       confirmed: false,

--- a/src/app/api/holistic-mentorship/students/[studentId]/phases/[phaseId]/route.ts
+++ b/src/app/api/holistic-mentorship/students/[studentId]/phases/[phaseId]/route.ts
@@ -62,7 +62,7 @@ function parseAnswer(value: unknown): { questionId: number; answer: string } | n
 }
 
 function parseAnswers(value: unknown): Array<{ questionId: number; answer: string }> | null {
-  if (!Array.isArray(value) || value.length > 4) return null;
+  if (!Array.isArray(value)) return null;
   const answers = value.map(parseAnswer);
   if (answers.some((answer) => !answer)) return null;
   const parsed = answers as Array<{ questionId: number; answer: string }>;

--- a/src/components/holistic-mentorship/PhasePlanSetup.test.tsx
+++ b/src/components/holistic-mentorship/PhasePlanSetup.test.tsx
@@ -72,6 +72,25 @@ describe("PhasePlanSetup", () => {
     });
   });
 
+  it("allows more than four Questions", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ plan: {
+      id: 7, academicYear: "2026-2027", editable: true, phases: [{
+        id: 21, number: 1, grade: 11, title: "Saved title", state: "locked",
+        guidanceMarkdown: "Saved Guidance", revision: 2, frozen: false,
+        everOpened: false, used: false, active: false,
+        questions: [1, 2, 3, 4].map((id) => ({ id, text: `Question ${id}` })),
+      }],
+    } }) }));
+    render(<PhasePlanSetup />);
+
+    await user.click(await screen.findByRole("button", { name: /Saved title/ }));
+    await user.click(screen.getByRole("button", { name: "Add Question" }));
+
+    expect(screen.getByLabelText("Question 5")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add Question" })).toBeEnabled();
+  });
+
   it("disables Save and Discard until the draft has unsaved changes", async () => {
     const user = userEvent.setup();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ plan: {

--- a/src/components/holistic-mentorship/PhasePlanSetup.tsx
+++ b/src/components/holistic-mentorship/PhasePlanSetup.tsx
@@ -471,15 +471,13 @@ function QuestionsEditor({ draft, readOnly, onChange }: {
     <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
       <h4 className="text-xs font-extrabold uppercase tracking-wide text-text-secondary">Post-Session Questions</h4>
       {!readOnly && <Button type="button" variant="secondary" className="text-xs"
-        disabled={draft.questions.length === 4}
-        title={draft.questions.length === 4 ? "Maximum 4 questions" : undefined}
         onClick={() => onChange({ ...draft, questions: [...draft.questions, { text: "" }] })}>
         <Plus className="h-4 w-4" /> Add Question
       </Button>}
     </div>
     <fieldset className="space-y-2" disabled={readOnly}>
       <legend className="sr-only">Questions</legend>
-      {draft.questions.map((question, index) => <QuestionEditorRow key={question.id ?? index}
+      {draft.questions.map((question, index) => <QuestionEditorRow key={question.id ? `saved-${question.id}` : `new-${index}`}
         draft={draft} index={index} question={question} onChange={onChange} />)}
       {draft.questions.length === 0 && <InlineAlert tone="warning" icon={<TriangleAlert className="h-4 w-4" />}
         title="No Questions yet." copy="Add at least one Question before Opening this Phase." />}

--- a/src/lib/holistic-phase-plans.test.ts
+++ b/src/lib/holistic-phase-plans.test.ts
@@ -114,11 +114,11 @@ describe("Holistic Phase Plans", () => {
     expect(client.query.mock.calls.at(-1)?.[1]).toEqual([7, 21, "definition_updated", 9, actor.actorEmail]);
   });
 
-  it("opens a complete Phase out of sequence and records the confirmed actor transition", async () => {
+  it("opens a complete Phase with more than four Questions", async () => {
     const client = {
       query: vi.fn()
         .mockResolvedValueOnce({ rows: [{ id: "21", revision: 2, state: "locked", academic_year: "2026-2027", frozen_at: null, ever_opened: false, used: false }] })
-        .mockResolvedValueOnce({ rows: [{ grade: "11", title: "Belonging", guidance_markdown: "Discuss goals", question_count: "2", valid_question_count: "2" }] })
+        .mockResolvedValueOnce({ rows: [{ grade: "11", title: "Belonging", guidance_markdown: "Discuss goals", question_count: "5", valid_question_count: "5" }] })
         .mockResolvedValueOnce({ rows: [{ revision: 3 }] })
         .mockResolvedValueOnce({ rows: [] }),
     };
@@ -142,14 +142,14 @@ describe("Holistic Phase Plans", () => {
     expect(client.query).toHaveBeenCalledTimes(2);
   });
 
-  it.each([
-    ["an unsupported Grade", { grade: "10", question_count: "1", valid_question_count: "1" }],
-    ["more than four Questions", { grade: "11", question_count: "5", valid_question_count: "5" }],
-  ])("does not open a Phase with %s", async (_case, definition) => {
+  it("does not open a Phase with an unsupported Grade", async () => {
     const client = {
       query: vi.fn()
         .mockResolvedValueOnce({ rows: [{ id: "21", revision: 2, state: "locked", academic_year: "2026-2027", frozen_at: null, ever_opened: false, used: false }] })
-        .mockResolvedValueOnce({ rows: [{ title: "Belonging", guidance_markdown: "Discuss goals", ...definition }] }),
+        .mockResolvedValueOnce({ rows: [{
+          grade: "10", title: "Belonging", guidance_markdown: "Discuss goals",
+          question_count: "1", valid_question_count: "1",
+        }] }),
     };
     mockWithTransaction.mockImplementation(async (fn) => fn(client as never));
 

--- a/src/lib/holistic-phase-plans.ts
+++ b/src/lib/holistic-phase-plans.ts
@@ -163,8 +163,8 @@ function validateDefinition(
   if (![11, 12].includes(input.grade)) return "Grade must be 11 or 12";
   if (!input.title.trim()) return "Title is required";
   if (input.title.trim().length > 120) return "Title must be 120 characters or fewer";
-  if (input.questions.length < 1 || input.questions.length > 4 || input.questions.some((q) => !q.text.trim())) {
-    return "One to four non-empty Questions are required";
+  if (input.questions.length < 1 || input.questions.some((q) => !q.text.trim())) {
+    return "At least one non-empty Question is required";
   }
   return validateHolisticGuidance(input.guidanceMarkdown);
 }
@@ -493,7 +493,6 @@ function completeOpenDefinition(current: OpenDefinitionRow | undefined): current
   if (!current.guidance_markdown.trim()) return false;
   const questionCount = Number(current.question_count);
   if (questionCount < 1) return false;
-  if (questionCount > 4) return false;
   return questionCount === Number(current.valid_question_count);
 }
 

--- a/src/lib/holistic-progress.test.ts
+++ b/src/lib/holistic-progress.test.ts
@@ -139,6 +139,7 @@ describe("Holistic progress", () => {
         { position: 2, question: "What changed?", answer: "A comma, and a \"quote\"" },
         { position: 3, question: "Next step?", answer: "Line one\nLine two" },
         { position: 4, question: "Support?", answer: "@external" },
+        { position: 5, question: "Anything else?", answer: "Keep going" },
       ],
     };
 
@@ -155,6 +156,8 @@ describe("Holistic progress", () => {
     expect(csv).toContain("\"A comma, and a \"\"quote\"\"\"");
     expect(csv).toContain("\"Line one\nLine two\"");
     expect(csv).toContain("\"'@external\"");
+    expect(csv).toContain("Question 5,Answer 5");
+    expect(csv).toContain("Anything else?,Keep going");
     expect(csv).not.toContain("studentId");
     expect(csv).not.toContain("Student Profile");
   });

--- a/src/lib/holistic-progress.ts
+++ b/src/lib/holistic-progress.ts
@@ -355,14 +355,22 @@ function csvCell(value: string | number | null): string {
 }
 
 export function formatHolisticProgressCsv(academicYear: string, rows: HolisticProgressRow[]): string {
+  const questionCount = rows.reduce(
+    (maximum, row) => row.answers.reduce((rowMaximum, answer) => Math.max(rowMaximum, answer.position), maximum),
+    0
+  );
   const header = [
     "Academic Year", "Program ID", "Program Name", "School", "UDISE Code", "Student Name", "Student External ID",
     "Grade", "Mentor Name", "Mentor Email", "Phase", "Phase Title", "Availability", "Progress",
-    "Completed At", "Question 1", "Answer 1", "Question 2", "Answer 2", "Question 3", "Answer 3",
-    "Question 4", "Answer 4", "Notes Author Name", "Notes Author Email", "Notes Last Edited At",
+    "Completed At",
+    ...Array.from({ length: questionCount }, (_, index) => [`Question ${index + 1}`, `Answer ${index + 1}`]).flat(),
+    "Notes Author Name", "Notes Author Email", "Notes Last Edited At",
   ];
   const body = rows.map((row) => {
-    const answers = Array.from({ length: 4 }, (_, index) => row.answers.find(({ position }) => position === index + 1));
+    const answers = Array.from(
+      { length: questionCount },
+      (_, index) => row.answers.find(({ position }) => position === index + 1)
+    );
     return [
       academicYear, PROGRAM_IDS.COE, PROGRAM_ID_TO_LABEL[PROGRAM_IDS.COE], row.schoolName, row.schoolCode,
       row.studentName, row.externalStudentId,


### PR DESCRIPTION
## Summary
- allow Admins to add more than four Questions to a Holistic Phase
- accept and save matching Notes answers for every configured Question
- export all configured Question/Answer pairs instead of truncating CSV after four

## Dependency
Deploy avantifellows/db-service#657 before this PR.

## Verification
- `npm run lint`
- `npm test -- --run` (2,975 passed, 3 skipped)
- `npm run build`