### PR TITLE
Add opt-in school visit GPS diagnostics

### DIFF
--- a/.mex/context/visits.md
+++ b/.mex/context/visits.md
@@ -18,7 +18,7 @@ edges:
     condition: when adding a new visit action type
   - target: context/data-access.md
     condition: when writing visit rows (direct Postgres, not the DB Service)
-last_updated: 2026-07-15
+last_updated: 2026-07-28
 ---
 
 # PM School Visits
@@ -54,6 +54,12 @@ Role semantics: **PM owner** = read/write own; **admin** = scoped read/write; **
 
 ## GPS — `src/lib/geo-validation.ts`
 `validateGpsReading(body, "start"|"end")` reads `${prefix}_lat/_lng/_accuracy`. Rejects (422) accuracy > 500m or out-of-range lat/lng; warns (still accepts) between 100–500m. **Never log lat/lng.** Routes that need GPS: create visit, action start, action end, complete visit.
+
+Client-side GPS capture lives in `src/lib/geolocation.ts`. Add `?debugGps=1` to a
+Visit page URL to enable structured `[GPS diagnostics]` browser-console events
+for permission state, browser/device context, network hints, readings, errors,
+timeouts, and cleanup. Diagnostics include accuracy but never latitude or
+longitude.
 
 ## The action-type registry (7 types)
 Types: `principal_interaction`, `classroom_observation`, `group_student_discussion`,

--- a/src/lib/geolocation.test.ts
+++ b/src/lib/geolocation.test.ts
@@ -41,14 +41,22 @@ describe("getAccurateLocation", () => {
     vi.useRealTimers();
   });
 
-  function setSecureOrigin(secure: boolean) {
+  function setSecureOrigin(secure: boolean, search = "") {
     if (secure) {
       vi.stubGlobal("window", {
-        location: { protocol: "https:", hostname: "app.example.com" },
+        location: {
+          protocol: "https:",
+          hostname: "app.example.com",
+          search,
+        },
       });
     } else {
       vi.stubGlobal("window", {
-        location: { protocol: "http:", hostname: "app.example.com" },
+        location: {
+          protocol: "http:",
+          hostname: "app.example.com",
+          search,
+        },
       });
     }
   }
@@ -134,6 +142,115 @@ describe("getAccurateLocation", () => {
 
     const { promise } = getAccurateLocation();
     await expect(promise).rejects.toMatchObject({ code: "POSITION_UNAVAILABLE" });
+  });
+
+  it("logs opt-in diagnostics for unavailable positions", async () => {
+    setSecureOrigin(true, "?debugGps=1");
+    const permissionStatus = {
+      state: "granted",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    vi.stubGlobal("navigator", {
+      userAgent: "Chrome test",
+      platform: "MacIntel",
+      language: "en-IN",
+      onLine: true,
+      cookieEnabled: true,
+      geolocation: {
+        watchPosition: mockWatchPosition,
+        clearWatch: mockClearWatch,
+      },
+      permissions: {
+        query: vi.fn().mockResolvedValue(permissionStatus),
+      },
+      connection: {
+        effectiveType: "4g",
+        downlink: 10,
+        rtt: 50,
+        saveData: false,
+      },
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockWatchPosition.mockImplementation(
+      (_success: PositionCallback, onError: PositionErrorCallback) => {
+        onError({
+          code: 2,
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+          message: "Core Location unavailable",
+        } as GeolocationPositionError);
+        return 7;
+      }
+    );
+
+    const { promise } = getAccurateLocation();
+    await expect(promise).rejects.toMatchObject({
+      code: "POSITION_UNAVAILABLE",
+    });
+    await Promise.resolve();
+
+    const logs = [...info.mock.calls, ...warn.mock.calls, ...error.mock.calls]
+      .filter(([prefix]) => prefix === "[GPS diagnostics]")
+      .map(([, details]) => details as Record<string, unknown>);
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "attempt-started",
+          platform: "MacIntel",
+          permissionsApiSupported: true,
+        }),
+        expect.objectContaining({
+          event: "position-error",
+          errorName: "POSITION_UNAVAILABLE",
+          browserMessage: "Core Location unavailable",
+        }),
+        expect.objectContaining({
+          event: "settled",
+          outcome: "reject",
+          code: "POSITION_UNAVAILABLE",
+        }),
+        expect.objectContaining({
+          event: "permission-state",
+          state: "granted",
+        }),
+      ])
+    );
+  });
+
+  it("never includes coordinates in opt-in diagnostics", async () => {
+    setSecureOrigin(true, "?debugGps=1");
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    mockWatchPosition.mockImplementation((success: PositionCallback) => {
+      success({
+        coords: { latitude: 23.0, longitude: 72.5, accuracy: 50 },
+      } as GeolocationPosition);
+      return 8;
+    });
+
+    const { promise } = getAccurateLocation();
+    await expect(promise).resolves.toEqual({
+      lat: 23.0,
+      lng: 72.5,
+      accuracy: 50,
+    });
+
+    const positionLog = info.mock.calls
+      .filter(([prefix]) => prefix === "[GPS diagnostics]")
+      .map(([, details]) => details as Record<string, unknown>)
+      .find((details) => details.event === "position-received");
+    expect(positionLog).toBeDefined();
+    expect(positionLog).not.toHaveProperty("lat");
+    expect(positionLog).not.toHaveProperty("lng");
+    expect(positionLog).not.toHaveProperty("latitude");
+    expect(positionLog).not.toHaveProperty("longitude");
+    expect(positionLog).toMatchObject({
+      coordinatesFinite: true,
+      accuracyMeters: 50,
+    });
   });
 
   it("resolves with best reading on timeout when accuracy <= 500m", async () => {

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -4,6 +4,17 @@
 const TIMEOUT_MS = 60_000;
 const MAX_ACCURACY_METERS = 500;
 const GOOD_ACCURACY_METERS = 100;
+const GPS_DEBUG_PARAM = "debugGps";
+
+let gpsAttemptSequence = 0;
+
+interface NetworkInformation {
+  type?: string;
+  effectiveType?: string;
+  downlink?: number;
+  rtt?: number;
+  saveData?: boolean;
+}
 
 export interface LocationResult {
   lat: number;
@@ -19,6 +30,109 @@ export interface LocationError {
 export interface AccurateLocationHandle {
   promise: Promise<LocationResult>;
   cancel: () => void;
+}
+
+function getConnectionDiagnostics() {
+  const connection = (
+    navigator as Navigator & { connection?: NetworkInformation }
+  ).connection;
+  if (!connection) return null;
+
+  return {
+    type: connection.type,
+    effectiveType: connection.effectiveType,
+    downlinkMbps: connection.downlink,
+    roundTripTimeMs: connection.rtt,
+    saveData: connection.saveData,
+  };
+}
+
+function getDocumentDiagnostics() {
+  if (typeof document === "undefined") {
+    return { visibilityState: null, documentFocused: null };
+  }
+  return {
+    visibilityState: document.visibilityState,
+    documentFocused: document.hasFocus(),
+  };
+}
+
+function getEnvironmentDiagnostics() {
+  return {
+    protocol: window.location.protocol,
+    hostname: window.location.hostname,
+    secureOrigin: isSecureOrigin(),
+    isSecureContext: window.isSecureContext,
+    topLevelContext: window.top === window.self,
+    ...getDocumentDiagnostics(),
+    userAgent: navigator.userAgent,
+    platform: navigator.platform,
+    language: navigator.language,
+    online: navigator.onLine,
+    cookieEnabled: navigator.cookieEnabled,
+    geolocationSupported: Boolean(navigator.geolocation),
+    permissionsApiSupported: Boolean(navigator.permissions?.query),
+    connection: getConnectionDiagnostics(),
+  };
+}
+
+function createGpsDiagnostics() {
+  const enabled =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get(GPS_DEBUG_PARAM) === "1";
+  const startedAt = Date.now();
+  const attemptId = `${startedAt.toString(36)}-${++gpsAttemptSequence}`;
+  const diagnostics = {
+    enabled,
+    permissionState: "unknown" as PermissionState | "unknown",
+    write(
+      level: "info" | "warn" | "error",
+      event: string,
+      details: Record<string, unknown> = {}
+    ) {
+      if (!enabled) return;
+      console[level]("[GPS diagnostics]", {
+        attemptId,
+        event,
+        elapsedMs: Date.now() - startedAt,
+        ...details,
+      });
+    },
+  };
+
+  if (!enabled) return diagnostics;
+
+  diagnostics.write("info", "attempt-started", getEnvironmentDiagnostics());
+
+  return diagnostics;
+}
+
+type GpsDiagnostics = ReturnType<typeof createGpsDiagnostics>;
+
+function logGeolocationPermission(diagnostics: GpsDiagnostics) {
+  if (!diagnostics.enabled || !navigator.permissions?.query) return;
+
+  void navigator.permissions
+    .query({ name: "geolocation" })
+    .then((status) => {
+      diagnostics.permissionState = status.state;
+      diagnostics.write("info", "permission-state", {
+        state: status.state,
+      });
+    })
+    .catch((error: unknown) => {
+      diagnostics.write("warn", "permission-query-failed", {
+        errorName: error instanceof Error ? error.name : null,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+function positionErrorName(error: GeolocationPositionError): string {
+  if (error.code === error.PERMISSION_DENIED) return "PERMISSION_DENIED";
+  if (error.code === error.POSITION_UNAVAILABLE) return "POSITION_UNAVAILABLE";
+  if (error.code === error.TIMEOUT) return "TIMEOUT";
+  return "UNKNOWN";
 }
 
 function isSecureOrigin(): boolean {
@@ -40,7 +154,13 @@ export function getAccurateLocation(): AccurateLocationHandle {
   let cancelFn: () => void = () => {};
 
   const promise = new Promise<LocationResult>((resolve, reject) => {
-    if (!isSecureOrigin()) {
+    const diagnostics = createGpsDiagnostics();
+    const secureOrigin = isSecureOrigin();
+
+    if (!secureOrigin) {
+      diagnostics.write("error", "preflight-failed", {
+        code: "INSECURE_ORIGIN",
+      });
       reject({
         code: "INSECURE_ORIGIN",
         message: "Location requires HTTPS. Please access the app via a secure connection.",
@@ -49,6 +169,9 @@ export function getAccurateLocation(): AccurateLocationHandle {
     }
 
     if (!navigator.geolocation) {
+      diagnostics.write("error", "preflight-failed", {
+        code: "NOT_SUPPORTED",
+      });
       reject({
         code: "NOT_SUPPORTED",
         message: "Geolocation is not supported by this browser.",
@@ -60,8 +183,14 @@ export function getAccurateLocation(): AccurateLocationHandle {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let bestReading: LocationResult | null = null;
     let settled = false;
+    let readingCount = 0;
+    let errorCount = 0;
 
     const cleanup = () => {
+      diagnostics.write("info", "cleanup", {
+        watchActive: watchId !== null,
+        timeoutActive: timeoutId !== null,
+      });
       if (watchId !== null) {
         navigator.geolocation.clearWatch(watchId);
         watchId = null;
@@ -78,6 +207,26 @@ export function getAccurateLocation(): AccurateLocationHandle {
     ) => {
       if (settled) return;
       settled = true;
+      diagnostics.write(
+        action === "resolve" ? "info" : "error",
+        "settled",
+        {
+          outcome: action,
+          code:
+            action === "resolve"
+              ? "SUCCESS"
+              : (value as LocationError).code,
+          accuracyMeters:
+            action === "resolve"
+              ? Math.round((value as LocationResult).accuracy)
+              : null,
+          readingCount,
+          errorCount,
+          bestAccuracyMeters:
+            bestReading === null ? null : Math.round(bestReading.accuracy),
+          permissionState: diagnostics.permissionState,
+        }
+      );
       cleanup();
       if (action === "resolve") {
         resolve(value as LocationResult);
@@ -87,14 +236,24 @@ export function getAccurateLocation(): AccurateLocationHandle {
     };
 
     cancelFn = () => {
+      diagnostics.write("warn", "cancel-requested");
       settle("reject", {
         code: "TIMEOUT",
         message: "Location request was cancelled.",
       });
     };
 
+    logGeolocationPermission(diagnostics);
+
     // Timeout: resolve with best reading if acceptable, otherwise reject
     timeoutId = setTimeout(() => {
+      diagnostics.write("warn", "outer-timeout", {
+        hasReading: bestReading !== null,
+        bestAccuracyMeters:
+          bestReading === null ? null : Math.round(bestReading.accuracy),
+        readingCount,
+        errorCount,
+      });
       if (bestReading && bestReading.accuracy <= MAX_ACCURACY_METERS) {
         settle("resolve", bestReading);
       } else {
@@ -107,9 +266,19 @@ export function getAccurateLocation(): AccurateLocationHandle {
       }
     }, TIMEOUT_MS);
 
+    diagnostics.write("info", "watch-requested", {
+      enableHighAccuracy: true,
+      maximumAgeMs: 0,
+      browserTimeoutMs: TIMEOUT_MS,
+      appTimeoutMs: TIMEOUT_MS,
+      goodAccuracyMeters: GOOD_ACCURACY_METERS,
+      maximumAcceptedAccuracyMeters: MAX_ACCURACY_METERS,
+    });
+
     watchId = navigator.geolocation.watchPosition(
       (position) => {
         const { latitude, longitude, accuracy } = position.coords;
+        readingCount += 1;
         const reading: LocationResult = {
           lat: latitude,
           lng: longitude,
@@ -117,9 +286,25 @@ export function getAccurateLocation(): AccurateLocationHandle {
         };
 
         // Keep the best (most accurate) reading
-        if (!bestReading || accuracy < bestReading.accuracy) {
+        const improvedBest =
+          bestReading === null || accuracy < bestReading.accuracy;
+        if (improvedBest) {
           bestReading = reading;
         }
+
+        diagnostics.write("info", "position-received", {
+          readingCount,
+          coordinatesFinite:
+            Number.isFinite(latitude) && Number.isFinite(longitude),
+          accuracyMeters: Math.round(accuracy),
+          improvedBest,
+          bestAccuracyMeters: Math.round((bestReading ?? reading).accuracy),
+          goodEnough: accuracy <= GOOD_ACCURACY_METERS,
+          positionAgeMs:
+            typeof position.timestamp === "number"
+              ? Math.max(0, Date.now() - position.timestamp)
+              : null,
+        });
 
         // Good enough — resolve immediately
         if (accuracy <= GOOD_ACCURACY_METERS) {
@@ -127,6 +312,22 @@ export function getAccurateLocation(): AccurateLocationHandle {
         }
       },
       (error) => {
+        errorCount += 1;
+        diagnostics.write(
+          error.code === error.PERMISSION_DENIED ? "error" : "warn",
+          "position-error",
+          {
+            errorCount,
+            errorCode: error.code,
+            errorName: positionErrorName(error),
+            browserMessage: error.message,
+            permissionState: diagnostics.permissionState,
+            hasReading: bestReading !== null,
+            bestAccuracyMeters:
+              bestReading === null ? null : Math.round(bestReading.accuracy),
+          }
+        );
+
         switch (error.code) {
           case error.PERMISSION_DENIED:
             settle("reject", {
@@ -151,6 +352,10 @@ export function getAccurateLocation(): AccurateLocationHandle {
         timeout: TIMEOUT_MS,
       }
     );
+    diagnostics.write("info", "watch-registered", {
+      watchId,
+      alreadySettled: settled,
+    });
   });
 
   return { promise, cancel: () => cancelFn() };


### PR DESCRIPTION
## Why

One Chrome user cannot start a school visit because Apple Core Location reports `kCLErrorLocationUnknown`, while other users and networks work normally. The current UI only exposes a generic `POSITION_UNAVAILABLE` error, which is not enough to distinguish browser permission, OS location, network, visibility, accuracy, or timing failures.

## What changed

- Add opt-in structured browser-console diagnostics to the shared school-visit geolocation helper.
- Enable them by adding `?debugGps=1` to any Visit page URL.
- Log a per-attempt ID, elapsed time, browser/device context, secure-context state, page visibility/focus, cookie and online flags, network hints, Geolocation/Permissions API support, permission state, watch settings, reading counts and accuracy, browser errors, timeout/cancel/settle state, and cleanup.
- Keep normal behavior unchanged when the query parameter is absent.
- Document the diagnostic switch in the Visit context.

## Privacy

Diagnostics never log latitude, longitude, authentication data, email, cookies, or tokens. A focused test enforces that position logs contain only coordinate validity and accuracy.

## How to use

Open a staging Visit URL such as:

`/school/59528/visit/new?debugGps=1`

Then open Chrome DevTools Console and filter for `[GPS diagnostics]`.

## Checks

- `npm test -- src/lib/geolocation.test.ts` — 20 passed
- `npx eslint src/lib/geolocation.ts src/lib/geolocation.test.ts`
- Targeted strict TypeScript compile for `src/lib/geolocation.ts`
- `npm run fallow:audit` — no issues

Repository-wide `tsc --noEmit` remains blocked by existing unrelated test typing errors on `main`; no geolocation errors remain.
