### PR TITLE
Gate combined-report generation on session end time; drop Regenerate

### DIFF
--- a/src/app/api/quiz-analytics/[udise]/combined-reports/route.test.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/route.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api-auth", () => ({
+  authorizeSchoolAccess: vi.fn(),
+}));
+vi.mock("@/lib/reporting-service", () => ({
+  submitCombinedReport: vi.fn(),
+  listCombinedReportJobs: vi.fn(),
+  ReportingServiceError: class extends Error {},
+}));
+vi.mock("@/lib/combined-report-eligibility", async (importOriginal) => {
+  // Keep the real evaluator + messages; only the DB lookup is stubbed.
+  const actual = await importOriginal<
+    typeof import("@/lib/combined-report-eligibility")
+  >();
+  return { ...actual, getSessionWindow: vi.fn() };
+});
+vi.mock("@/lib/school-students", () => ({
+  getSchoolRoster: vi.fn(),
+  filterActiveRosterStudents: vi.fn(),
+}));
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+import { authorizeSchoolAccess } from "@/lib/api-auth";
+import {
+  submitCombinedReport,
+  listCombinedReportJobs,
+} from "@/lib/reporting-service";
+import type { CombinedReportJob } from "@/lib/reporting-service";
+import { getSessionWindow } from "@/lib/combined-report-eligibility";
+import {
+  getSchoolRoster,
+  filterActiveRosterStudents,
+} from "@/lib/school-students";
+import { GET, POST } from "./route";
+import {
+  jsonRequest,
+  routeParams,
+} from "../../../__test-utils__/api-test-helpers";
+
+const mockAuth = vi.mocked(authorizeSchoolAccess);
+const mockList = vi.mocked(listCombinedReportJobs);
+const mockSubmit = vi.mocked(submitCombinedReport);
+const mockWindow = vi.mocked(getSessionWindow);
+const mockRoster = vi.mocked(getSchoolRoster);
+const mockFilter = vi.mocked(filterActiveRosterStudents);
+
+const SCHOOL = { id: "1", code: "34054", name: "JNV Palghar", region: "West" };
+const URL_BASE =
+  "http://localhost/api/quiz-analytics/27361106702/combined-reports";
+const SESSION = "EnableStudents_abc";
+
+const ENDED = { endTimeUtcIso: "2026-06-23T18:03:00.000Z", hasEnded: true };
+const OPEN = { endTimeUtcIso: "2026-12-31T18:03:00.000Z", hasEnded: false };
+
+/** Only `status` drives the gate; the rest is filler to satisfy the job type. */
+function job(status: CombinedReportJob["status"]): CombinedReportJob {
+  return {
+    job_id: `job-${status}`,
+    session_id: SESSION,
+    school_code: SCHOOL.code,
+    test_name: null,
+    status,
+    student_count: 1,
+    matched_count: 1,
+    missing_count: 0,
+    error: null,
+    download_url: null,
+    created_at: "2026-06-24T00:00:00.000Z",
+    updated_at: "2026-06-24T00:00:00.000Z",
+    retry_count: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockAuth.mockResolvedValue({ authorized: true, school: SCHOOL });
+  // Roster shapes are incidental to the gate; cast to keep the fixture small.
+  mockRoster.mockResolvedValue({
+    students: [{ user_id: 1, student_id: "S1", apaar_id: null }],
+  } as unknown as Awaited<ReturnType<typeof getSchoolRoster>>);
+  mockFilter.mockReturnValue([
+    { user_id: 1, student_id: "S1", apaar_id: null },
+  ] as unknown as ReturnType<typeof filterActiveRosterStudents>);
+});
+
+function postBody() {
+  return jsonRequest(URL_BASE, {
+    method: "POST",
+    body: { session_id: SESSION, grade: 12 },
+  });
+}
+
+describe("GET combined-reports", () => {
+  it("reports can_generate false with a reason while the session is open", async () => {
+    mockList.mockResolvedValue([]);
+    mockWindow.mockResolvedValue(OPEN);
+
+    const res = await GET(
+      new Request(`${URL_BASE}?session_id=${SESSION}`),
+      routeParams({ udise: "27361106702" }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.can_generate).toBe(false);
+    expect(body.blocked_reason).toBe("session_not_ended");
+    expect(body.session_end_time).toBe(OPEN.endTimeUtcIso);
+    expect(body.blocked_message).toMatch(/still open/i);
+  });
+
+  it("reports can_generate true once ended with no prior jobs", async () => {
+    mockList.mockResolvedValue([]);
+    mockWindow.mockResolvedValue(ENDED);
+
+    const res = await GET(
+      new Request(`${URL_BASE}?session_id=${SESSION}`),
+      routeParams({ udise: "27361106702" }),
+    );
+    const body = await res.json();
+    expect(body.can_generate).toBe(true);
+    expect(body.blocked_reason).toBeNull();
+  });
+
+  it("reports already_generated when a done job exists", async () => {
+    mockList.mockResolvedValue([job("done")]);
+    mockWindow.mockResolvedValue(ENDED);
+
+    const res = await GET(
+      new Request(`${URL_BASE}?session_id=${SESSION}`),
+      routeParams({ udise: "27361106702" }),
+    );
+    const body = await res.json();
+    expect(body.can_generate).toBe(false);
+    expect(body.blocked_reason).toBe("already_generated");
+  });
+});
+
+describe("POST combined-reports gating", () => {
+  it("409s and does not submit while the session is still open", async () => {
+    mockWindow.mockResolvedValue(OPEN);
+    mockList.mockResolvedValue([]);
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe("session_not_ended");
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("409s and does not submit when a report was already generated", async () => {
+    mockWindow.mockResolvedValue(ENDED);
+    mockList.mockResolvedValue([job("done")]);
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).reason).toBe("already_generated");
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("409s while a job is still in flight", async () => {
+    mockWindow.mockResolvedValue(ENDED);
+    mockList.mockResolvedValue([job("processing")]);
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).reason).toBe("job_in_progress");
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits once ended with no blocking job", async () => {
+    mockWindow.mockResolvedValue(ENDED);
+    mockList.mockResolvedValue([]);
+    mockSubmit.mockResolvedValue({ job_id: "j1", status: "queued" });
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(202);
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("still submits when previous jobs all errored", async () => {
+    mockWindow.mockResolvedValue(ENDED);
+    mockList.mockResolvedValue([job("errored")]);
+    mockSubmit.mockResolvedValue({ job_id: "j2", status: "queued" });
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(202);
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps auth ahead of the gate", async () => {
+    const { NextResponse } = await import("next/server");
+    mockAuth.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json({ error: "Access denied" }, { status: 403 }),
+    });
+
+    const res = await POST(postBody(), routeParams({ udise: "27361106702" }));
+    expect(res.status).toBe(403);
+    expect(mockWindow).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
@@ -11,6 +11,11 @@ import {
   listCombinedReportJobs,
   ReportingServiceError,
 } from "@/lib/reporting-service";
+import {
+  getSessionWindow,
+  evaluateGenerationEligibility,
+  BLOCKED_MESSAGE,
+} from "@/lib/combined-report-eligibility";
 
 // GET /api/quiz-analytics/[udise]/combined-reports?session_id=...
 // List the combined-report jobs for this school + test (the Performance-tab view).
@@ -29,7 +34,19 @@ export async function GET(
 
   try {
     const jobs = await listCombinedReportJobs(sessionId, auth.school.code);
-    return NextResponse.json({ jobs });
+    // The panel renders its button from this, so it needs the same verdict the
+    // POST route will apply — otherwise the button invites a click that 409s.
+    const window = await getSessionWindow(sessionId);
+    const eligibility = evaluateGenerationEligibility(window, jobs);
+    return NextResponse.json({
+      jobs,
+      session_end_time: window.endTimeUtcIso,
+      can_generate: eligibility.allowed,
+      blocked_reason: eligibility.reason ?? null,
+      blocked_message: eligibility.reason
+        ? BLOCKED_MESSAGE[eligibility.reason]
+        : null,
+    });
   } catch (error) {
     if (error instanceof ReportingServiceError) {
       console.error("Combined-report list error:", error.status, error.body);
@@ -72,6 +89,24 @@ export async function POST(
   }
 
   try {
+    // Gate before doing any work: the session must have closed, and this test
+    // must not already have a finished or in-flight report.
+    const [window, existingJobs] = await Promise.all([
+      getSessionWindow(body.session_id),
+      listCombinedReportJobs(body.session_id, auth.school.code),
+    ]);
+    const eligibility = evaluateGenerationEligibility(window, existingJobs);
+    if (!eligibility.allowed && eligibility.reason) {
+      return NextResponse.json(
+        {
+          error: BLOCKED_MESSAGE[eligibility.reason],
+          reason: eligibility.reason,
+          session_end_time: window.endTimeUtcIso,
+        },
+        { status: 409 },
+      );
+    }
+
     const { students: roster } = await getSchoolRoster(auth.school.id);
     // Narrow to the cohort the test belongs to (and drop dropouts), so the
     // combined report matches what the teacher sees for this test.

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -62,6 +62,12 @@ export default function CombinedReportPanel({
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Generation eligibility comes from the API rather than being recomputed here,
+  // so the button can never disagree with what POST will actually allow.
+  const [canGenerate, setCanGenerate] = useState(false);
+  const [blockedMessage, setBlockedMessage] = useState<string | null>(null);
+  const [blockedReason, setBlockedReason] = useState<string | null>(null);
+  const [sessionEndTime, setSessionEndTime] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const base = `/api/quiz-analytics/${schoolUdise}/combined-reports`;
@@ -75,6 +81,10 @@ export default function CombinedReportPanel({
       if (!res.ok) throw new Error("Failed to load reports");
       const data = await res.json();
       setJobs(data.jobs ?? []);
+      setCanGenerate(Boolean(data.can_generate));
+      setBlockedMessage(data.blocked_message ?? null);
+      setBlockedReason(data.blocked_reason ?? null);
+      setSessionEndTime(data.session_end_time ?? null);
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load reports");
@@ -157,16 +167,24 @@ export default function CombinedReportPanel({
         </div>
         <button
           onClick={generate}
-          disabled={submitting}
-          className="px-4 py-2 min-h-[44px] text-xs md:text-sm font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent shadow-sm transition-colors hover:opacity-90 disabled:opacity-50"
+          disabled={submitting || loading || !canGenerate}
+          title={blockedMessage ?? undefined}
+          className="px-4 py-2 min-h-[44px] text-xs md:text-sm font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent shadow-sm transition-colors hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {submitting
-            ? "Starting…"
-            : jobs.some((j) => j.status === "done")
-              ? "Regenerate"
-              : "Generate combined report"}
+          {submitting ? "Starting…" : "Generate combined report"}
         </button>
       </div>
+
+      {/* Not an error — the ordinary state of a test that is still open, or one
+          whose report has already been produced. */}
+      {!loading && blockedMessage && (
+        <div className="p-2 bg-bg-card border border-border text-text-muted rounded text-xs">
+          {blockedMessage}
+          {blockedReason === "session_not_ended" && sessionEndTime && (
+            <> Session ends {formatTime(sessionEndTime)}.</>
+          )}
+        </div>
+      )}
 
       {error && (
         <div className="p-2 bg-danger-bg border border-danger text-danger rounded text-xs">

--- a/src/lib/combined-report-eligibility.test.ts
+++ b/src/lib/combined-report-eligibility.test.ts
@@ -44,11 +44,31 @@ describe("getSessionWindow", () => {
     expect(after.hasEnded).toBe(true);
   });
 
-  it("handles the ISO-with-offset form without double-converting", async () => {
-    stubEndTime("2026-06-23T18:03:00Z");
-    const w = await getSessionWindow("S1", new Date("2026-06-23T18:04:00Z"));
-    expect(w.endTimeUtcIso).toBe("2026-06-23T18:03:00.000Z");
+  // Regression: a trailing `Z` on a session timestamp is NOT UTC. The API layer
+  // stamps one on while the value stays IST wall-clock, so branching on it (or
+  // trusting Date.parse) puts the gate 5h30m early. Real example from session
+  // 18259, which reads "2026-08-12T23:45:00Z" but means 23:45 IST == 18:15 UTC.
+  it("treats a bogus trailing Z as IST wall-clock, not UTC", async () => {
+    stubEndTime("2026-08-12T23:45:00Z");
+    const w = await getSessionWindow("S1", new Date("2026-08-12T18:20:00Z"));
+    expect(w.endTimeUtcIso).toBe("2026-08-12T18:15:00.000Z");
     expect(w.hasEnded).toBe(true);
+  });
+
+  it("does not let a bogus Z unblock generation while the test is still open", async () => {
+    stubEndTime("2026-08-12T23:45:00Z");
+    // 18:05Z is 23:35 IST — ten minutes before the window closes. Reading the Z
+    // as UTC would call this ended.
+    const w = await getSessionWindow("S1", new Date("2026-08-12T18:05:00Z"));
+    expect(w.hasEnded).toBe(false);
+  });
+
+  it("agrees across the space-separated and Z-suffixed forms of one instant", async () => {
+    stubEndTime("2026-08-12 23:45:00");
+    const bare = await getSessionWindow("S1", new Date("2026-08-12T18:20:00Z"));
+    stubEndTime("2026-08-12T23:45:00Z");
+    const zed = await getSessionWindow("S1", new Date("2026-08-12T18:20:00Z"));
+    expect(zed.endTimeUtcIso).toBe(bare.endTimeUtcIso);
   });
 
   it("fails open when the session row is absent", async () => {

--- a/src/lib/combined-report-eligibility.test.ts
+++ b/src/lib/combined-report-eligibility.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@/lib/db";
+import {
+  getSessionWindow,
+  evaluateGenerationEligibility,
+} from "./combined-report-eligibility";
+
+const mockQuery = vi.mocked(query);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+function stubEndTime(end_time: string | null | undefined) {
+  mockQuery.mockResolvedValue(
+    end_time === undefined ? [] : [{ end_time }],
+  );
+}
+
+describe("getSessionWindow", () => {
+  it("treats a stored end_time as IST wall-clock, not UTC", async () => {
+    // 2026-06-23 23:33 IST == 2026-06-23 18:03 UTC.
+    stubEndTime("2026-06-23 23:33:00");
+    const w = await getSessionWindow("S1", new Date("2026-06-23T18:04:00Z"));
+    expect(w.endTimeUtcIso).toBe("2026-06-23T18:03:00.000Z");
+    expect(w.hasEnded).toBe(true);
+  });
+
+  it("still blocks during the 5h30m window a UTC misreading would unblock", async () => {
+    // The bug this guards: parsed as UTC, end looks like 23:33Z and 19:00Z
+    // would read as 'before end' — but in IST terms 19:00Z is 00:30 IST, i.e.
+    // after the 23:33 IST close. Conversely a naive reading at 18:00Z would
+    // think the session already ended when it has 3 minutes left.
+    stubEndTime("2026-06-23 23:33:00");
+    const during = await getSessionWindow("S1", new Date("2026-06-23T18:00:00Z"));
+    expect(during.hasEnded).toBe(false);
+
+    const after = await getSessionWindow("S1", new Date("2026-06-23T18:03:00Z"));
+    expect(after.hasEnded).toBe(true);
+  });
+
+  it("handles the ISO-with-offset form without double-converting", async () => {
+    stubEndTime("2026-06-23T18:03:00Z");
+    const w = await getSessionWindow("S1", new Date("2026-06-23T18:04:00Z"));
+    expect(w.endTimeUtcIso).toBe("2026-06-23T18:03:00.000Z");
+    expect(w.hasEnded).toBe(true);
+  });
+
+  it("fails open when the session row is absent", async () => {
+    stubEndTime(undefined);
+    const w = await getSessionWindow("missing", new Date("2020-01-01T00:00:00Z"));
+    expect(w.hasEnded).toBe(true);
+    expect(w.endTimeUtcIso).toBeNull();
+  });
+
+  it("fails open when end_time is null or unparseable", async () => {
+    stubEndTime(null);
+    expect((await getSessionWindow("S1")).hasEnded).toBe(true);
+
+    stubEndTime("not-a-date");
+    const w = await getSessionWindow("S1");
+    expect(w.hasEnded).toBe(true);
+    expect(w.endTimeUtcIso).toBeNull();
+  });
+
+  it("is inclusive at the boundary instant", async () => {
+    stubEndTime("2026-06-23 23:33:00");
+    const w = await getSessionWindow("S1", new Date("2026-06-23T18:03:00.000Z"));
+    expect(w.hasEnded).toBe(true);
+  });
+});
+
+describe("evaluateGenerationEligibility", () => {
+  const ended = { endTimeUtcIso: "2026-06-23T18:03:00.000Z", hasEnded: true };
+  const open = { endTimeUtcIso: "2026-12-31T18:03:00.000Z", hasEnded: false };
+
+  it("blocks while the session is still open, even with no jobs", () => {
+    expect(evaluateGenerationEligibility(open, [])).toEqual({
+      allowed: false,
+      reason: "session_not_ended",
+    });
+  });
+
+  it("allows a first generation once the session has ended", () => {
+    expect(evaluateGenerationEligibility(ended, [])).toEqual({ allowed: true });
+  });
+
+  it.each(["queued", "started", "processing"])(
+    "blocks a duplicate while a %s job exists",
+    (status) => {
+      expect(evaluateGenerationEligibility(ended, [{ status }])).toEqual({
+        allowed: false,
+        reason: "job_in_progress",
+      });
+    },
+  );
+
+  it("blocks regeneration once a job is done", () => {
+    expect(
+      evaluateGenerationEligibility(ended, [{ status: "done" }]),
+    ).toEqual({ allowed: false, reason: "already_generated" });
+  });
+
+  it("still allows generation when every previous job errored", () => {
+    expect(
+      evaluateGenerationEligibility(ended, [
+        { status: "errored" },
+        { status: "errored" },
+      ]),
+    ).toEqual({ allowed: true });
+  });
+
+  it("prefers the session gate over job state when both would block", () => {
+    expect(
+      evaluateGenerationEligibility(open, [{ status: "done" }]),
+    ).toEqual({ allowed: false, reason: "session_not_ended" });
+  });
+});

--- a/src/lib/combined-report-eligibility.ts
+++ b/src/lib/combined-report-eligibility.ts
@@ -58,15 +58,21 @@ export async function getSessionWindow(
   const raw = rows[0]?.end_time ?? null;
   if (!raw) return { endTimeUtcIso: null, hasEnded: true };
 
-  // dbIstTimestampToUtcIso THROWS on a value it can't parse (it falls through to
-  // `new Date(x).toISOString()`), so a malformed timestamp must not be allowed to
-  // turn a report listing into a 502.
+  // Convert unconditionally — never branch on a trailing `Z`. Session timestamps
+  // are IST wall-clock even when something upstream has stamped a `Z` on them
+  // (the API layer does), so that `Z` does not mean UTC: session 18259's window
+  // end reads "2026-08-12T23:45:00Z" through the API but means 23:45 IST.
+  // Trusting it would put the gate 5h30m early. dbIstTimestampToUtcIso handles
+  // both the bare `YYYY-MM-DD HH:mm:ss` this query returns and the Z-suffixed
+  // form, so one unconditional call is correct for every shape — matching what
+  // the quiz-sessions routes do.
+  //
+  // It THROWS on a value it can't parse (falling through to
+  // `new Date(x).toISOString()`), so a malformed timestamp must not be allowed
+  // to turn a report listing into a 502.
   let endMs = NaN;
   try {
-    const utcIso = /[zZ]$|[+-]\d{2}:\d{2}$/.test(raw)
-      ? raw
-      : dbIstTimestampToUtcIso(raw);
-    endMs = Date.parse(utcIso);
+    endMs = Date.parse(dbIstTimestampToUtcIso(raw));
   } catch {
     endMs = NaN;
   }

--- a/src/lib/combined-report-eligibility.ts
+++ b/src/lib/combined-report-eligibility.ts
@@ -1,0 +1,116 @@
+import { query } from "@/lib/db";
+import { dbIstTimestampToUtcIso } from "@/lib/quiz-session-time";
+
+/**
+ * When a combined student report may be generated.
+ *
+ * Two rules, both enforced server-side (the UI mirrors them, but the route is
+ * the authority):
+ *  1. Not until the test's session window has closed — a report built mid-test
+ *     silently omits students who haven't submitted yet, and looks complete.
+ *  2. Once per test — a successful or in-flight job blocks another. Ops print
+ *     these, so two near-identical PDFs for one test is worse than none.
+ */
+
+export type GenerationBlockedReason =
+  | "session_not_ended"
+  | "job_in_progress"
+  | "already_generated";
+
+export interface SessionWindow {
+  /** Session end as a true instant, or null when we can't determine one. */
+  endTimeUtcIso: string | null;
+  /**
+   * False only when we positively know the window is still open. Unknown
+   * timing counts as ended — see getSessionWindow for why.
+   */
+  hasEnded: boolean;
+}
+
+interface SessionEndRow {
+  end_time: string | null;
+}
+
+/**
+ * Look up when a quiz session's window closes.
+ *
+ * `session.end_time` is `timestamp without time zone` holding **IST wall-clock**,
+ * so it must go through `dbIstTimestampToUtcIso`. Passing it to `new Date(...)`
+ * would read it as UTC and land 5h30m early — which would unblock generation
+ * while a test was still running, i.e. exactly the bug this gate exists to stop.
+ *
+ * Fails **open** (hasEnded: true) when there is no row or no end_time. The
+ * Performance tab lists tests from BigQuery, not Postgres, so a visible test is
+ * not guaranteed a `session` row — an absent one means a legacy session that
+ * ended long ago, and blocking those would break generation that works today.
+ * Recent sessions (the only ones that can still be open, and so the only ones
+ * this gate needs to catch) are always written to Postgres at creation.
+ */
+export async function getSessionWindow(
+  sessionId: string,
+  now: Date = new Date(),
+): Promise<SessionWindow> {
+  const rows = await query<SessionEndRow>(
+    `SELECT end_time::text AS end_time FROM session WHERE session_id = $1 LIMIT 1`,
+    [sessionId],
+  );
+
+  const raw = rows[0]?.end_time ?? null;
+  if (!raw) return { endTimeUtcIso: null, hasEnded: true };
+
+  // dbIstTimestampToUtcIso THROWS on a value it can't parse (it falls through to
+  // `new Date(x).toISOString()`), so a malformed timestamp must not be allowed to
+  // turn a report listing into a 502.
+  let endMs = NaN;
+  try {
+    const utcIso = /[zZ]$|[+-]\d{2}:\d{2}$/.test(raw)
+      ? raw
+      : dbIstTimestampToUtcIso(raw);
+    endMs = Date.parse(utcIso);
+  } catch {
+    endMs = NaN;
+  }
+  if (Number.isNaN(endMs)) return { endTimeUtcIso: null, hasEnded: true };
+
+  return {
+    endTimeUtcIso: new Date(endMs).toISOString(),
+    hasEnded: now.getTime() >= endMs,
+  };
+}
+
+/** Minimal shape of a reporting job needed to judge eligibility. */
+export interface JobLike {
+  status: string;
+}
+
+const ACTIVE_STATUSES = new Set(["queued", "started", "processing"]);
+
+/**
+ * Decide whether a new job may be submitted, given the session window and the
+ * jobs that already exist for this school + test.
+ *
+ * Errored-only history stays generatable: retry handles the usual recovery, but
+ * if a job failed for a reason retry can't fix (wrong roster at submit time),
+ * refusing outright would leave ops with no route to a report at all.
+ */
+export function evaluateGenerationEligibility(
+  window: SessionWindow,
+  jobs: JobLike[],
+): { allowed: boolean; reason?: GenerationBlockedReason } {
+  if (!window.hasEnded) return { allowed: false, reason: "session_not_ended" };
+  if (jobs.some((j) => ACTIVE_STATUSES.has(j.status))) {
+    return { allowed: false, reason: "job_in_progress" };
+  }
+  if (jobs.some((j) => j.status === "done")) {
+    return { allowed: false, reason: "already_generated" };
+  }
+  return { allowed: true };
+}
+
+export const BLOCKED_MESSAGE: Record<GenerationBlockedReason, string> = {
+  session_not_ended:
+    "This test is still open. The combined report can be generated once the session end time has passed.",
+  job_in_progress: "A combined report for this test is already being generated.",
+  already_generated:
+    "A combined report has already been generated for this test.",
+};


### PR DESCRIPTION
Ops print the combined student reports, which makes two current behaviours a problem:

1. **A report can be generated while the test is still open.** It silently omits students who haven't submitted yet, and the PDF looks complete.
2. **The button offered "Regenerate"** once a report existed, so one test could yield several near-identical PDFs.

## What changes

Generation now requires the session window to have **closed**, and is allowed **once per test**. Both rules live in `src/lib/combined-report-eligibility.ts`:

- `POST` enforces them — **409** with a machine-readable `reason` (`session_not_ended` / `job_in_progress` / `already_generated`).
- `GET` returns the *same* verdict (`can_generate`, `blocked_reason`, `blocked_message`, `session_end_time`), so the panel mirrors the server instead of recomputing the rules. The button can't invite a click the API would reject.
- The **"Regenerate" label is gone**. The button is disabled with a plain-language explanation, and for a still-open test it shows when the session ends.

**Errored-only history stays generatable.** Retry covers the usual recovery, but if a job failed for a reason retry can't fix (e.g. wrong roster at submit time), refusing outright would leave ops no route to a report at all.

## Two subtleties

**Timezone.** `session.end_time` is `timestamp without time zone` holding **IST wall-clock**, so it goes through the existing `dbIstTimestampToUtcIso`. `new Date(...)` would read it as UTC and land **5h30m early** — unblocking generation mid-test, i.e. exactly the bug this closes. Covered by boundary tests.

**The gate fails _open_ when timing is unknown.** The Performance tab lists tests from BigQuery, not Postgres, so a visible test isn't guaranteed a `session` row. An absent row means a legacy session that ended long ago; blocking those would break generation that works today. Recent sessions — the only ones that can still be open, and so the only ones this gate must catch — are always written to Postgres at creation. This also guards `dbIstTimestampToUtcIso` **throwing** on an unparseable value, which would otherwise turn the report listing into a 502.

## Verification

- **23 new tests** (14 eligibility incl. IST boundary + fail-open paths, 9 route incl. "does not submit" assertions and auth-before-gate).
- `tsc`: no errors in the changed files.
- `eslint` clean on the changed files.
- Full unit suite: the 7 pre-existing failures (visits / academic-mentorship / quiz-sessions / Toast) are untouched by this change and reference none of these modules.
- The `session_id` lookup is served by the existing **unique** btree index, so the added query is an index scan even on the 4s poll.

## Notes

- **af_lms-only.** The reporting service is service-key gated with af_lms as its only caller, and reporting has no Postgres access to know session timing, so the LMS route is the right enforcement point.
- Not yet exercised through the UI against a live open test — the rules are covered by unit tests, but a click-through on a currently-open session is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)