### PR TITLE
Exclude unsubmitted attempts from the Cumulative AL matrix

### DIFF
--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -157,16 +157,17 @@ describe("getBatchOverviewData", () => {
     await expect(getBatchOverviewData("11223344", 10)).rejects.toThrow("BQ error");
   });
 
-  it("counts only submitted attempts in the test list", async () => {
+  // Participation is attendance, not a result: a student who opened the test and
+  // never submitted still turned up, and that is the signal we need for
+  // connectivity complaints. Only scored figures exclude them.
+  it("keeps unsubmitted attempts in the participation count", async () => {
     mocks.mockQueryFn.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]]);
 
     const { getBatchOverviewData } = await import("./bigquery");
     await getBatchOverviewData("11223344", 10);
 
-    const [testListCall, enrolledCall] = mocks.mockQueryFn.mock.calls;
-    expect(testListCall[0].query).toContain("has_quiz_ended IS TRUE");
-    // The enrolment count comes from dim_student, which has no such column.
-    expect(enrolledCall[0].query).not.toContain("has_quiz_ended");
+    const [testListCall] = mocks.mockQueryFn.mock.calls;
+    expect(testListCall[0].query).not.toContain("has_quiz_ended");
   });
 
   it("returns null totalEnrolled when no enrollment rows", async () => {

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -157,6 +157,18 @@ describe("getBatchOverviewData", () => {
     await expect(getBatchOverviewData("11223344", 10)).rejects.toThrow("BQ error");
   });
 
+  it("counts only submitted attempts in the test list", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]]);
+
+    const { getBatchOverviewData } = await import("./bigquery");
+    await getBatchOverviewData("11223344", 10);
+
+    const [testListCall, enrolledCall] = mocks.mockQueryFn.mock.calls;
+    expect(testListCall[0].query).toContain("has_quiz_ended IS TRUE");
+    // The enrolment count comes from dim_student, which has no such column.
+    expect(enrolledCall[0].query).not.toContain("has_quiz_ended");
+  });
+
   it("returns null totalEnrolled when no enrollment rows", async () => {
     mocks.mockQueryFn
       .mockResolvedValueOnce([[]])
@@ -217,6 +229,15 @@ describe("getCumulativeALData", () => {
     // Mode AL rank ordering: B1, M1 are tier 3 (tie) → tie broken by total tests desc
     // asha (3 tests) and chen (3 tests) before bilal (2 tests)
     expect(result.students[result.students.length - 1].student_id).toBe("bilal");
+  });
+
+  it("counts only submitted attempts", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]);
+
+    const { getCumulativeALData } = await import("./bigquery");
+    await getCumulativeALData("11223344", 11);
+
+    expect(mocks.mockQueryFn.mock.calls[0][0].query).toContain("has_quiz_ended IS TRUE");
   });
 
   it("normalizes BigQuery DATE objects ({value: '...'}) on start_date", async () => {

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -52,6 +52,12 @@ const DIM_STUDENT_TABLE = "`avantifellows.production_dbt_final.dim_student`";
 const FACT_QUESTION_LEVEL_TABLE =
   "`avantifellows.production_dbt_final.fact_student_test_results_question_level`";
 
+// Opening a test without submitting still writes fact rows, at near-zero marks,
+// which drags class averages down and lists non-participants as low scorers. The
+// quiz ETL already excludes these from its own aggregates
+// (filter_test_level_df_for_aggregation). Only the overall fact carries the flag.
+const SUBMITTED_ONLY = "AND has_quiz_ended IS TRUE";
+
 // Test formats that count as "major" (i.e. the Full Tests tab) — these also have
 // real Academic Level (AL) values populated on the section='overall' row.
 export const MAJOR_TEST_FORMATS = [
@@ -179,6 +185,7 @@ export async function getBatchOverviewData(
       AND student_grade = @grade
       AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
       AND session_id IS NOT NULL
+      ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
     GROUP BY session_id, test_name
@@ -315,6 +322,7 @@ export async function getCumulativeALData(
       AND academic_level IN (${alList})
       AND fk_student_id IS NOT NULL
       AND session_id IS NOT NULL
+      ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
       ${testGradeFilter}

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -52,10 +52,11 @@ const DIM_STUDENT_TABLE = "`avantifellows.production_dbt_final.dim_student`";
 const FACT_QUESTION_LEVEL_TABLE =
   "`avantifellows.production_dbt_final.fact_student_test_results_question_level`";
 
-// Opening a test without submitting still writes fact rows, at near-zero marks,
-// which drags class averages down and lists non-participants as low scorers. The
-// quiz ETL already excludes these from its own aggregates
-// (filter_test_level_df_for_aggregation). Only the overall fact carries the flag.
+// Opening a test without submitting still writes fact rows, at near-zero marks.
+// Those rows are real attendance, so participation counts keep them; but they are
+// not results, so anything scored reads submitted attempts only. The quiz ETL
+// draws the same line in filter_test_level_df_for_aggregation. Only the overall
+// fact carries the flag — the question- and chapter-level facts do not.
 const SUBMITTED_ONLY = "AND has_quiz_ended IS TRUE";
 
 // Test formats that count as "major" (i.e. the Full Tests tab) — these also have
@@ -185,7 +186,6 @@ export async function getBatchOverviewData(
       AND student_grade = @grade
       AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
       AND session_id IS NOT NULL
-      ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
     GROUP BY session_id, test_name


### PR DESCRIPTION
Unsubmitted attempts are being counted as results in the Cumulative AL matrix. This is a narrow fix for the one place af_lms can currently fix it.

## The problem

A student who opens a test but never submits still gets a row in `fact_student_test_results_overall`. Those rows carry an `academic_level`, so the Cumulative AL progression matrix treats them as attempts.

Rows the Cumulative AL query currently picks up:

| | unsubmitted | submitted |
|---|---|---|
| M1 / M2 / B1 / B2 (a real AL) | **3,658** | 108,837 |
| Not Qualified / Not Eligible | 45,654 | 203,689 |
| **total** | **49,312** | 312,526 |

So 3,658 cells credit a student with an actual academic level on a test they abandoned, and ~45k more show "Not Qualified" for students who never attempted — which reads to a teacher as *failed* rather than *absent*.

## What changes

One filter, on `getCumulativeALData` only: `AND has_quiz_ended IS TRUE`. This also corrects each student's `mode_al` and `total_major_tests`, which were computed over those rows.

This matches the quiz ETL, which already excludes unsubmitted attempts from its own aggregates (`filter_test_level_df_for_aggregation` in etl-data-flow) — so the LMS stops disagreeing with the pipeline.

## Deliberately NOT filtered: participation

The test list / trend chart keeps counting everyone who opened a test. Participation is **attendance, not a result** — a student who opened and got disconnected did turn up, and that is exactly the signal we need for the connectivity complaints (e.g. Kolhapur, where students were dropping repeatedly mid-test).

An earlier revision of this PR did filter it. That was wrong: it made "Students Appeared" read 14 instead of 17 on JNV Barwani, and made 19 tests since July disappear from the list entirely — all of them the "everyone opened it, nobody finished" case, which is precisely what ops needs to see. Reverted.

## Scope — what this does NOT fix

Worth being explicit, because it is most of the Performance tab. **The entire test deep-dive page is served from DynamoDB `student_quiz_reports_v2`**, in one `test-deep-dive` call:

- the six summary tiles (Students Appeared, Avg / Min / Max Score, Avg Accuracy, Avg Attempt Rate)
- Subject Analysis
- Chapter Analysis
- Student Results table

Those documents have **no `has_quiz_ended` field** — `student_reports_v2_flow.py` never selects it (absent from `OVERALL_COLS`; the string appears nowhere in the file). So af_lms cannot filter any of it today, and an unsubmitted attempt still shows in Student Results as a low scorer.

The per-question drill-downs (chapter → questions, student → questions) read `fact_..._question_level`, which has no such column either.

**Unblocking the deep-dive page needs one line upstream:** add `has_quiz_ended` to `OVERALL_COLS` in `student_reports_v2_flow.py` so it lands in the report doc. I'd rather carry the flag through and let the display decide (ideally labelling these "opened, not submitted") than filter them out in the flow — same reasoning as the ETL keeping them in `test_responses`. Note it would only affect newly-written docs; existing sessions need a re-run.

## Verification

- Figures above measured against prod BigQuery, not estimated.
- 26 tests in `bigquery.test.ts` pass, including a new one asserting the participation query does **not** filter.
- All 8 quiz-analytics suites pass (81 tests).
- `tsc --noEmit` and `eslint` clean on the changed files.

Not clicked through in the UI. On a healthy session there is nothing to see — e.g. JNV Medak / NVS-04 G11 NEET has all 4 students submitted, so that page is unchanged. A school with unsubmitted attempts in a major test is the one worth eyeballing.
