### PR TITLE
Keep unsubmitted attempts out of Performance tab results

### DIFF
--- a/src/components/performance/StudentResultsTable.test.tsx
+++ b/src/components/performance/StudentResultsTable.test.tsx
@@ -16,6 +16,7 @@ const STUDENTS: StudentDeepDiveRow[] = [
     percentage: 40,
     accuracy: 50,
     attempt_rate: 60,
+    has_quiz_ended: true,
     subject_scores: [
       {
         subject: "Physics",
@@ -79,6 +80,33 @@ describe("StudentResultsTable", () => {
     render(<StudentResultsTable {...props} />);
     expect(screen.getByText("Asha Rao")).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("badges a student who never submitted the test", () => {
+    render(
+      <StudentResultsTable
+        {...props}
+        students={[{ ...STUDENTS[0], has_quiz_ended: false }]}
+      />
+    );
+    expect(screen.getByText("Test Incomplete")).toBeInTheDocument();
+  });
+
+  it("shows no badge when submission status is unknown", () => {
+    // Report docs written before etl-next carried the flag have no value at all.
+    // Treating that as unsubmitted would badge every historical test.
+    render(
+      <StudentResultsTable
+        {...props}
+        students={[{ ...STUDENTS[0], has_quiz_ended: null }]}
+      />
+    );
+    expect(screen.queryByText("Test Incomplete")).not.toBeInTheDocument();
+  });
+
+  it("shows no badge for a submitted attempt", () => {
+    render(<StudentResultsTable {...props} />);
+    expect(screen.queryByText("Test Incomplete")).not.toBeInTheDocument();
   });
 
   it("renders the student's social category as a chip", () => {

--- a/src/components/performance/StudentResultsTable.test.tsx
+++ b/src/components/performance/StudentResultsTable.test.tsx
@@ -92,6 +92,25 @@ describe("StudentResultsTable", () => {
     expect(screen.getByText("Test Incomplete")).toBeInTheDocument();
   });
 
+  it("does not let an unsubmitted student consume a rank position", () => {
+    render(
+      <StudentResultsTable
+        {...props}
+        students={[
+          { ...STUDENTS[0], student_name: "Top Scorer", percentage: 90, has_quiz_ended: true },
+          { ...STUDENTS[0], student_name: "Walked Out", percentage: 4, has_quiz_ended: false },
+          { ...STUDENTS[0], student_name: "Second", percentage: 50, has_quiz_ended: true },
+        ]}
+      />
+    );
+    const rowFor = (name: string) =>
+      screen.getByText(name).closest("tr") as HTMLElement;
+    expect(rowFor("Top Scorer").textContent).toContain("01");
+    expect(rowFor("Second").textContent).toContain("02");
+    // Not "03" — ranking a non-participant misstates the "of N" a teacher reads.
+    expect(rowFor("Walked Out").textContent).toContain("—");
+  });
+
   it("shows no badge when submission status is unknown", () => {
     // Report docs written before etl-next carried the flag have no value at all.
     // Treating that as unsubmitted would badge every historical test.

--- a/src/components/performance/StudentResultsTable.test.tsx
+++ b/src/components/performance/StudentResultsTable.test.tsx
@@ -111,6 +111,24 @@ describe("StudentResultsTable", () => {
     expect(rowFor("Walked Out").textContent).toContain("—");
   });
 
+  it("sorts unsubmitted attempts below submitted ones on an equal score", () => {
+    // A genuine 0% (negative marking, submitted) must outrank a 0% walkout,
+    // otherwise the ranked column reads out of order.
+    render(
+      <StudentResultsTable
+        {...props}
+        students={[
+          { ...STUDENTS[0], student_name: "Walked Out", percentage: 0, has_quiz_ended: false },
+          { ...STUDENTS[0], student_name: "Scored Zero", percentage: 0, has_quiz_ended: true },
+        ]}
+      />
+    );
+    const names = screen.getAllByRole("row").slice(1).map((r) => r.textContent || "");
+    const iZero = names.findIndex((t) => t.includes("Scored Zero"));
+    const iOut = names.findIndex((t) => t.includes("Walked Out"));
+    expect(iZero).toBeLessThan(iOut);
+  });
+
   it("shows no badge when submission status is unknown", () => {
     // Report docs written before etl-next carried the flag have no value at all.
     // Treating that as unsubmitted would badge every historical test.

--- a/src/components/performance/StudentResultsTable.tsx
+++ b/src/components/performance/StudentResultsTable.tsx
@@ -270,6 +270,13 @@ export default function StudentResultsTable({
   };
 
   const sorted = [...students].sort((a, b) => {
+    // Unsubmitted attempts always sit below submitted ones, whatever the sort:
+    // otherwise a 0% walkout interleaves with a genuine 0% and the ranked column
+    // reads out of order.
+    const aDone = a.has_quiz_ended !== false;
+    const bDone = b.has_quiz_ended !== false;
+    if (aDone !== bDone) return aDone ? -1 : 1;
+
     const mul = sortDir === "asc" ? 1 : -1;
     if (sortKey === "student_name") {
       return mul * a.student_name.localeCompare(b.student_name);
@@ -361,7 +368,7 @@ export default function StudentResultsTable({
                       )}
                       {s.has_quiz_ended === false && (
                         <span
-                          className="ml-2 inline-flex items-center px-2 py-0.5 text-xs font-bold uppercase tracking-wide rounded bg-danger text-white"
+                          className="ml-2 inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded bg-danger text-white"
                           title="This student never submitted the test, so their marks are only what was saved before they left."
                         >
                           Test Incomplete

--- a/src/components/performance/StudentResultsTable.tsx
+++ b/src/components/performance/StudentResultsTable.tsx
@@ -277,6 +277,14 @@ export default function StudentResultsTable({
     return mul * ((a[sortKey] ?? 0) - (b[sortKey] ?? 0));
   });
 
+  // Rank is over submitted attempts only, so a student who never submitted does
+  // not consume a position (and does not inflate the "of N" a teacher reads).
+  const rankByName = new Map<string, string>();
+  [...students]
+    .filter((s) => s.has_quiz_ended !== false)
+    .sort((a, b) => b.percentage - a.percentage)
+    .forEach((s, i) => rankByName.set(s.student_name, String(i + 1).padStart(2, "0")));
+
   const sortIcon = (key: SortKey) => {
     if (sortKey !== key) return "";
     return sortDir === "asc" ? " ↑" : " ↓";
@@ -333,7 +341,7 @@ export default function StudentResultsTable({
             </tr>
           </thead>
           <tbody>
-            {sorted.map((s, idx) => {
+            {sorted.map((s) => {
               const isExpanded = expandedName === s.student_name;
               return (
                 <Fragment key={s.student_name}>
@@ -342,7 +350,7 @@ export default function StudentResultsTable({
                     onClick={() => toggleStudent(s.student_name)}
                   >
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-bold text-accent">
-                      {String(idx + 1).padStart(2, "0")}
+                      {rankByName.get(s.student_name) ?? "—"}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-semibold text-text-primary">
                       {s.student_name}

--- a/src/components/performance/StudentResultsTable.tsx
+++ b/src/components/performance/StudentResultsTable.tsx
@@ -351,6 +351,14 @@ export default function StudentResultsTable({
                           {isExpanded ? "▼" : "▶"}
                         </span>
                       )}
+                      {s.has_quiz_ended === false && (
+                        <span
+                          className="ml-2 inline-flex items-center px-2 py-0.5 text-xs font-bold uppercase tracking-wide rounded bg-danger text-white"
+                          title="This student never submitted the test, so their marks are only what was saved before they left."
+                        >
+                          Test Incomplete
+                        </span>
+                      )}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-text-secondary">
                       {s.gender || "-"}

--- a/src/components/performance/TestDeepDive.tsx
+++ b/src/components/performance/TestDeepDive.tsx
@@ -95,7 +95,23 @@ export default function TestDeepDive({
       {data && !loading && (
         <>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 md:gap-4">
-            <StatCard label="Students Appeared" value={data.summary.students_appeared} size="sm" color="brand-gold" />
+            {data.summary.students_submitted < data.summary.students_appeared ? (
+              // Scores below cover submitted attempts only, so show the
+              // denominator rather than an unqualified head count.
+              <StatCard
+                label="Submitted / Appeared"
+                value={`${data.summary.students_submitted} / ${data.summary.students_appeared}`}
+                size="sm"
+                color="brand-gold"
+              />
+            ) : (
+              <StatCard
+                label="Students Appeared"
+                value={data.summary.students_appeared}
+                size="sm"
+                color="brand-gold"
+              />
+            )}
             <StatCard label="Avg Score" value={`${data.summary.avg_marks}/${data.summary.total_marks} (${data.summary.avg_score}%)`} size="sm" color="brand-coral" />
             <StatCard label="Min Score" value={`${data.summary.min_marks}/${data.summary.total_marks} (${data.summary.min_score}%)`} size="sm" color="brand-amber" />
             <StatCard label="Max Score" value={`${data.summary.max_marks}/${data.summary.total_marks} (${data.summary.max_score}%)`} size="sm" color="brand-gold" />

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -171,6 +171,35 @@ describe("getBatchOverviewData", () => {
   });
 });
 
+describe("getTestQuestionLevelData", () => {
+  it("excludes unsubmitted attempts from the class-wide question breakdown", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]);
+
+    const { getTestQuestionLevelData } = await import("./bigquery");
+    await getTestQuestionLevelData("11223344", 11, "sess-1");
+
+    // Walkouts skip every question, so counting them nearly doubles the skip
+    // count and a hard question becomes indistinguishable from an absent class.
+    expect(mocks.mockQueryFn.mock.calls[0][0].query).toContain("has_quiz_ended IS NOT FALSE");
+  });
+});
+
+describe("getAvailableGrades / getAvailablePrograms", () => {
+  it("does not filter the dropdown queries", async () => {
+    // 275 grade/program combos have no submitted attempt at all; filtering here
+    // would remove them from the picker and make those schools unreachable.
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]]);
+
+    const { getAvailableGrades, getAvailablePrograms } = await import("./bigquery");
+    await getAvailableGrades("11223344");
+    await getAvailablePrograms("11223344");
+
+    for (const call of mocks.mockQueryFn.mock.calls) {
+      expect(call[0].query).not.toContain("has_quiz_ended");
+    }
+  });
+});
+
 describe("getCumulativeALData", () => {
   it("aggregates AL counts + per-test progression per student, sorts students by mode AL rank", async () => {
     // Asha (PCM): M1 on s1, M2 on s2, M1 on s3 → al_counts {M1:2, M2:1}, mode M1

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -219,6 +219,19 @@ describe("getCumulativeALData", () => {
     expect(result.students[result.students.length - 1].student_id).toBe("bilal");
   });
 
+  it("excludes unsubmitted attempts from the AL matrix", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]);
+
+    const { getCumulativeALData } = await import("./bigquery");
+    await getCumulativeALData("11223344", 11);
+
+    const sql = mocks.mockQueryFn.mock.calls[0][0].query;
+    // NOT FALSE, never = TRUE: null means unknown, and dropping those rows would
+    // silently remove attempts that have no test-level row upstream.
+    expect(sql).toContain("has_quiz_ended IS NOT FALSE");
+    expect(sql).not.toContain("has_quiz_ended = TRUE");
+  });
+
   it("normalizes BigQuery DATE objects ({value: '...'}) on start_date", async () => {
     const rows = [
       {

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -53,6 +53,11 @@ const DIM_STUDENT_TABLE = "`avantifellows.production_dbt_final.dim_student`";
 const FACT_QUESTION_LEVEL_TABLE =
   "`avantifellows.production_dbt_final.fact_student_test_results_question_level`";
 
+// An abandoned attempt still carries an academic_level, which would credit the
+// student with a level for a test they never submitted. NOT FALSE rather than
+// = TRUE: null means unknown (no test-level row upstream), not unsubmitted.
+const SUBMITTED_ONLY = "AND has_quiz_ended IS NOT FALSE";
+
 // Test formats that count as "major" (i.e. the Full Tests tab) — these also have
 // real Academic Level (AL) values populated on the section='overall' row.
 export const MAJOR_TEST_FORMATS = [
@@ -304,6 +309,7 @@ export async function getCumulativeALData(
       AND academic_level IN (${alList})
       AND fk_student_id IS NOT NULL
       AND session_id IS NOT NULL
+      ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
       ${testGradeFilter}

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -475,6 +475,7 @@ export async function getTestQuestionLevelData(
       AND session_id = @sessionId
       AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
       AND question_id IS NOT NULL
+      ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
     GROUP BY section, chapter_name, chapter_id, question_id

--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -379,6 +379,89 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
   });
 
   describe("aggregations", () => {
+    it("excludes unsubmitted attempts from the summary stats", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([
+        makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),
+        makeStudent({ student_id: "s2", apaar_id: null, user_id: "u2", first_name: "Bob" }),
+      ]);
+      mocks.mockSend.mockResolvedValueOnce({
+        Items: [
+          makeV2Doc({
+            student_id: "s1", user_id: "u1",
+            overall_performance: {
+              marks_scored: 90, max_marks_possible: 100, percentage: 90, accuracy: 80,
+              num_correct: 18, num_wrong: 0, num_skipped: 2, total_questions: 20,
+              has_quiz_ended: true,
+            },
+          }),
+          makeV2Doc({
+            student_id: "s2", user_id: "u2",
+            overall_performance: {
+              marks_scored: 4, max_marks_possible: 100, percentage: 4, accuracy: 10,
+              num_correct: 1, num_wrong: 1, num_skipped: 18, total_questions: 20,
+              has_quiz_ended: false,
+            },
+          }),
+        ],
+      });
+
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo("school-1", "JNV Test", 10, "sess-1");
+      // Both students are listed and counted as present...
+      expect(result!.summary.students_appeared).toBe(2);
+      expect(result!.students).toHaveLength(2);
+      // ...but the 4% walkout must not drag the average down or set the minimum.
+      expect(result!.summary.students_submitted).toBe(1);
+      expect(result!.summary.avg_score).toBe(90);
+      expect(result!.summary.min_score).toBe(90);
+    });
+
+    it("falls back to all attempts when nobody submitted", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([
+        makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),
+      ]);
+      mocks.mockSend.mockResolvedValueOnce({
+        Items: [
+          makeV2Doc({
+            student_id: "s1", user_id: "u1",
+            overall_performance: {
+              marks_scored: 8, max_marks_possible: 100, percentage: 8, accuracy: 20,
+              num_correct: 2, num_wrong: 2, num_skipped: 16, total_questions: 20,
+              has_quiz_ended: false,
+            },
+          }),
+        ],
+      });
+
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo("school-1", "JNV Test", 10, "sess-1");
+      // Zeroed tiles would read as a catastrophic result rather than an unfinished one.
+      expect(result!.summary.students_submitted).toBe(0);
+      expect(result!.summary.avg_score).toBe(8);
+    });
+
+    it("counts attempts with unknown submission status as submitted", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([
+        makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),
+      ]);
+      mocks.mockSend.mockResolvedValueOnce({
+        Items: [
+          makeV2Doc({
+            student_id: "s1", user_id: "u1",
+            overall_performance: {
+              marks_scored: 90, max_marks_possible: 100, percentage: 90, accuracy: 80,
+              num_correct: 18, num_wrong: 0, num_skipped: 2, total_questions: 20,
+            },
+          }),
+        ],
+      });
+
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo("school-1", "JNV Test", 10, "sess-1");
+      expect(result!.summary.students_submitted).toBe(1);
+      expect(result!.students[0].has_quiz_ended).toBeNull();
+    });
+
     it("computes summary (avg, min, max, accuracy) across students", async () => {
       mocks.mockQuery.mockResolvedValueOnce([
         makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),

--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -379,6 +379,52 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
   });
 
   describe("aggregations", () => {
+    it("keeps chapter priority from an unsubmitted attempt but not its scores", async () => {
+      // Priority is chapter metadata, constant across students, so it must survive
+      // even when the only student carrying it walked out — otherwise the Chapter
+      // Analysis priority column blanks out. Their marks must still be excluded.
+      mocks.mockQuery.mockResolvedValueOnce([
+        makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),
+        makeStudent({ student_id: "s2", apaar_id: null, user_id: "u2", first_name: "Bob" }),
+      ]);
+      mocks.mockSend.mockResolvedValueOnce({
+        Items: [
+          makeV2Doc({
+            student_id: "s1", user_id: "u1",
+            overall_performance: {
+              marks_scored: 0, max_marks_possible: 100, percentage: 0, accuracy: 0,
+              num_correct: 0, num_wrong: 0, num_skipped: 20, total_questions: 20,
+              has_quiz_ended: false,
+            },
+            chapter_performance: [
+              { chapter_name: "Limits", chapter_id: "c1", subject: "Physics", priority: "High",
+                marks_scored: 0, max_marks_possible: 20, percentage: 0, accuracy: 0,
+                num_correct: 0, num_wrong: 0, num_skipped: 5, total_questions: 5 },
+            ],
+          }),
+          makeV2Doc({
+            student_id: "s2", user_id: "u2",
+            overall_performance: {
+              marks_scored: 80, max_marks_possible: 100, percentage: 80, accuracy: 90,
+              num_correct: 16, num_wrong: 2, num_skipped: 2, total_questions: 20,
+              has_quiz_ended: true,
+            },
+            chapter_performance: [
+              { chapter_name: "Limits", chapter_id: "c1", subject: "Physics", priority: "None",
+                marks_scored: 16, max_marks_possible: 20, percentage: 80, accuracy: 90,
+                num_correct: 4, num_wrong: 1, num_skipped: 0, total_questions: 5 },
+            ],
+          }),
+        ],
+      });
+
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo("school-1", "JNV Test", 10, "sess-1");
+      const limits = result!.chapters.find((c) => c.chapter_name === "Limits")!;
+      expect(limits.priority).toBe("High");
+      expect(limits.avg_score).toBe(80);
+    });
+
     it("excludes unsubmitted attempts from the summary stats", async () => {
       mocks.mockQuery.mockResolvedValueOnce([
         makeStudent({ student_id: "s1", apaar_id: null, user_id: "u1", first_name: "Alice" }),

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -95,6 +95,9 @@ interface V2OverallPerformance {
   // codes, and emits an empty status where no cutoff applies (e.g. "Not
   // Eligible for Academic Level"), so treat anything unrecognised as unknown.
   qualification_status?: string | null;
+  // Absent on docs written before etl-next carried it, and null where the
+  // student has no test-level row upstream — both mean unknown, not unsubmitted.
+  has_quiz_ended?: boolean | null;
 }
 
 interface V2SubjectPerformance {
@@ -434,6 +437,8 @@ export async function getTestDeepDiveFromDynamo(
       accuracy: toNum(overall.accuracy),
       attempt_rate: overallAttemptRate,
       subject_scores: subjectScores,
+      has_quiz_ended:
+        typeof overall.has_quiz_ended === "boolean" ? overall.has_quiz_ended : null,
     });
   }
 

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -314,6 +314,9 @@ export async function getTestDeepDiveFromDynamo(
     if (!testName) testName = doc.report_header?.test_name || "";
     if (!startDate) startDate = doc.report_header?.test_date || "";
 
+    // Unknown counts as submitted, so historical reports keep their figures.
+    const submitted = overall.has_quiz_ended !== false;
+
     const overallTotal = toNum(overall.total_questions);
     const overallSkipped = toNum(overall.num_skipped);
     const overallAttemptRate =
@@ -351,12 +354,14 @@ export async function getTestDeepDiveFromDynamo(
         totalQ: 0,
         count: 0,
       };
-      existing.totalPct += toNum(si.percentage);
-      existing.totalAcc += toNum(si.accuracy);
-      existing.totalAttempt += attemptRate;
-      existing.totalQ = Math.max(existing.totalQ, total);
-      existing.count += 1;
-      subjectAggMap.set(sectionKey, existing);
+      if (submitted) {
+        existing.totalPct += toNum(si.percentage);
+        existing.totalAcc += toNum(si.accuracy);
+        existing.totalAttempt += attemptRate;
+        existing.totalQ = Math.max(existing.totalQ, total);
+        existing.count += 1;
+        subjectAggMap.set(sectionKey, existing);
+      }
 
       // Per-student chapter rows for this subject.
       const chapters: StudentChapterScore[] = subjectChapters.map((c) => {
@@ -387,14 +392,16 @@ export async function getTestDeepDiveFromDynamo(
         if (!chEx.priority && c.priority && c.priority !== "None") {
           chEx.priority = c.priority;
         }
-        chEx.totalScore += chPct;
-        chEx.totalMarks += chMarks;
-        chEx.maxMarks = Math.max(chEx.maxMarks, chMax);
-        chEx.totalAcc += toNum(c.accuracy);
-        chEx.totalAttempt += chAttemptRate;
-        chEx.totalQ = Math.max(chEx.totalQ, chTotal);
-        chEx.count += 1;
-        chapterAggMap.set(chKey, chEx);
+        if (submitted) {
+          chEx.totalScore += chPct;
+          chEx.totalMarks += chMarks;
+          chEx.maxMarks = Math.max(chEx.maxMarks, chMax);
+          chEx.totalAcc += toNum(c.accuracy);
+          chEx.totalAttempt += chAttemptRate;
+          chEx.totalQ = Math.max(chEx.totalQ, chTotal);
+          chEx.count += 1;
+          chapterAggMap.set(chKey, chEx);
+        }
 
         return {
           subject: sectionDisplay,
@@ -444,11 +451,16 @@ export async function getTestDeepDiveFromDynamo(
 
   if (studentRows.length === 0) return null;
 
-  // Compute summary
-  const percentages = studentRows.map((s) => s.percentage);
-  const marks = studentRows.map((s) => s.marks_scored);
-  const accuracies = studentRows.map((s) => s.accuracy);
-  const attemptRates = studentRows.map((s) => s.attempt_rate);
+  // Summary stats cover submitted attempts only; students_appeared still counts
+  // everyone who opened the test. Falls back to all rows when nobody submitted,
+  // so the tiles show the attempts that exist rather than zeroes.
+  const scored = studentRows.filter((s) => s.has_quiz_ended !== false);
+  const statRows = scored.length > 0 ? scored : studentRows;
+
+  const percentages = statRows.map((s) => s.percentage);
+  const marks = statRows.map((s) => s.marks_scored);
+  const accuracies = statRows.map((s) => s.accuracy);
+  const attemptRates = statRows.map((s) => s.attempt_rate);
 
   const avg = (arr: number[]) =>
     arr.length > 0
@@ -460,6 +472,7 @@ export async function getTestDeepDiveFromDynamo(
     test_name: testName,
     start_date: startDate,
     students_appeared: studentRows.length,
+    students_submitted: scored.length,
     avg_score: avg(percentages),
     min_score: round1(Math.min(...percentages)),
     max_score: round1(Math.max(...percentages)),

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -155,6 +155,94 @@ function toNum(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+interface SubjectAgg {
+  displayName: string;
+  totalPct: number;
+  totalAcc: number;
+  totalAttempt: number;
+  totalQ: number;
+  count: number;
+}
+
+interface ChapterAgg {
+  subject: string;
+  chapter_name: string;
+  chapter_id: string | null;
+  priority: string | null;
+  totalScore: number;
+  totalMarks: number;
+  maxMarks: number;
+  totalAcc: number;
+  totalAttempt: number;
+  totalQ: number;
+  count: number;
+}
+
+// Class-wide subject totals. Only submitted attempts contribute — an abandoned
+// one would drag the class average down without being a result.
+function accumulateSubject(
+  map: Map<string, SubjectAgg>,
+  key: string,
+  displayName: string,
+  row: { percentage?: number | null; accuracy?: number | null },
+  attemptRate: number,
+  totalQuestions: number
+): void {
+  const agg = map.get(key) ?? {
+    displayName,
+    totalPct: 0,
+    totalAcc: 0,
+    totalAttempt: 0,
+    totalQ: 0,
+    count: 0,
+  };
+  agg.totalPct += toNum(row.percentage);
+  agg.totalAcc += toNum(row.accuracy);
+  agg.totalAttempt += attemptRate;
+  agg.totalQ = Math.max(agg.totalQ, totalQuestions);
+  agg.count += 1;
+  map.set(key, agg);
+}
+
+// Class-wide chapter totals. `priority` is constant per chapter across students,
+// so it is captured from whichever row first carries a meaningful value — and it
+// is recorded even for an unsubmitted attempt, since it is metadata, not a score.
+function accumulateChapter(
+  map: Map<string, ChapterAgg>,
+  key: string,
+  subject: string,
+  chapter: V2ChapterPerformance,
+  values: { pct: number; marks: number; max: number; attemptRate: number; questions: number },
+  submitted: boolean
+): void {
+  const agg = map.get(key) ?? {
+    subject,
+    chapter_name: chapter.chapter_name || "",
+    chapter_id: chapter.chapter_id || null,
+    priority: null,
+    totalScore: 0,
+    totalMarks: 0,
+    maxMarks: 0,
+    totalAcc: 0,
+    totalAttempt: 0,
+    totalQ: 0,
+    count: 0,
+  };
+  if (!agg.priority && chapter.priority && chapter.priority !== "None") {
+    agg.priority = chapter.priority;
+  }
+  if (submitted) {
+    agg.totalScore += values.pct;
+    agg.totalMarks += values.marks;
+    agg.maxMarks = Math.max(agg.maxMarks, values.max);
+    agg.totalAcc += toNum(chapter.accuracy);
+    agg.totalAttempt += values.attemptRate;
+    agg.totalQ = Math.max(agg.totalQ, values.questions);
+    agg.count += 1;
+  }
+  map.set(key, agg);
+}
+
 // Paginate any QueryCommand until LastEvaluatedKey is null.
 async function paginatedQuery(
   buildCmd: (startKey?: Record<string, unknown>) => QueryCommand,
@@ -280,29 +368,11 @@ export async function getTestDeepDiveFromDynamo(
 
   // Step 3: Transform into TestDeepDiveData
   const studentRows: StudentDeepDiveRow[] = [];
-  const subjectAggMap = new Map<
-    string,
-    { displayName: string; totalPct: number; totalAcc: number; totalAttempt: number; totalQ: number; count: number }
-  >();
+  const subjectAggMap = new Map<string, SubjectAgg>();
   // Key chapter aggregates by chapter_id when available; fall back to
   // subject + chapter_name as a last resort so legacy/missing-id rows still
   // group correctly within a single session.
-  const chapterAggMap = new Map<
-    string,
-    {
-      subject: string;
-      chapter_name: string;
-      chapter_id: string | null;
-      priority: string | null;
-      totalScore: number;
-      totalMarks: number;
-      maxMarks: number;
-      totalAcc: number;
-      totalAttempt: number;
-      totalQ: number;
-      count: number;
-    }
-  >();
+  const chapterAggMap = new Map<string, ChapterAgg>();
 
   let testName = "";
   let startDate = "";
@@ -345,22 +415,8 @@ export async function getTestDeepDiveFromDynamo(
       const skipped = subjectChapters.reduce((sum, c) => sum + toNum(c.num_skipped), 0);
       const attemptRate = total > 0 ? ((total - skipped) / total) * 100 : 0;
 
-      // Subject analysis aggregates across the class.
-      const existing = subjectAggMap.get(sectionKey) || {
-        displayName: sectionDisplay,
-        totalPct: 0,
-        totalAcc: 0,
-        totalAttempt: 0,
-        totalQ: 0,
-        count: 0,
-      };
       if (submitted) {
-        existing.totalPct += toNum(si.percentage);
-        existing.totalAcc += toNum(si.accuracy);
-        existing.totalAttempt += attemptRate;
-        existing.totalQ = Math.max(existing.totalQ, total);
-        existing.count += 1;
-        subjectAggMap.set(sectionKey, existing);
+        accumulateSubject(subjectAggMap, sectionKey, sectionDisplay, si, attemptRate, total);
       }
 
       // Per-student chapter rows for this subject.
@@ -374,34 +430,20 @@ export async function getTestDeepDiveFromDynamo(
         const chPct = chMax > 0 ? (chMarks / chMax) * 100 : 0;
 
         const chKey = c.chapter_id || `${sectionKey}||${(c.chapter_name || "").toLowerCase()}`;
-        const chEx = chapterAggMap.get(chKey) || {
-          subject: sectionDisplay,
-          chapter_name: c.chapter_name || "",
-          chapter_id: c.chapter_id || null,
-          priority: null,
-          totalScore: 0,
-          totalMarks: 0,
-          maxMarks: 0,
-          totalAcc: 0,
-          totalAttempt: 0,
-          totalQ: 0,
-          count: 0,
-        };
-        // Priority is constant per chapter across students; keep the first
-        // meaningful (non-empty, non-"None") value we see.
-        if (!chEx.priority && c.priority && c.priority !== "None") {
-          chEx.priority = c.priority;
-        }
-        if (submitted) {
-          chEx.totalScore += chPct;
-          chEx.totalMarks += chMarks;
-          chEx.maxMarks = Math.max(chEx.maxMarks, chMax);
-          chEx.totalAcc += toNum(c.accuracy);
-          chEx.totalAttempt += chAttemptRate;
-          chEx.totalQ = Math.max(chEx.totalQ, chTotal);
-          chEx.count += 1;
-          chapterAggMap.set(chKey, chEx);
-        }
+        accumulateChapter(
+          chapterAggMap,
+          chKey,
+          sectionDisplay,
+          c,
+          {
+            pct: chPct,
+            marks: chMarks,
+            max: chMax,
+            attemptRate: chAttemptRate,
+            questions: chTotal,
+          },
+          submitted
+        );
 
         return {
           subject: sectionDisplay,

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -169,6 +169,10 @@ export interface StudentDeepDiveRow {
   accuracy: number;
   attempt_rate: number;
   subject_scores: StudentSubjectScore[];
+  // False only when the report doc positively says the student never submitted.
+  // Null for docs written before etl-next started carrying the flag, and where
+  // the student has no test-level row upstream — unknown, so no badge.
+  has_quiz_ended: boolean | null;
 }
 
 export interface TestDeepDiveData {

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -77,6 +77,8 @@ export interface TestDeepDiveSummary {
   test_name: string;
   start_date: string;
   students_appeared: number;
+  // Of those, how many submitted. Every figure below is computed over these only.
+  students_submitted: number;
   avg_score: number;
   min_score: number;
   max_score: number;


### PR DESCRIPTION
An abandoned attempt was counted as a real result across the Performance tab. This fixes it in **both** data paths — DynamoDB (test deep-dive) and BigQuery (Cumulative AL, question drill-down).

Verified end-to-end against **JNV Barwani → 12M16 Limits** (05 Aug, 3 of 17 never submitted) with real regenerated report docs.

## Before / after, on that session

| | before | after |
|---|---|---|
| Head-count tile | Students Appeared **17** | **Submitted / Appeared: 14 / 17** |
| Avg Score | 48.5% | **58.6%** |
| Ranks | 01–17 | **01–14** |
| Question skip count | 155 of 425 | **81 of 350** |
| Badged | — | Sanjay Jhariya, Mihika Patidar, Alakh Sahu |

## Every reader, audited

| reader | filtered? | why |
|---|---|---|
| deep-dive tiles / subject / chapter (DDB) | **yes** | walkouts sank the average and set a bogus minimum |
| `getCumulativeALData` | **yes** | 3,658 rows/year credit an M1/M2/B1/B2 for an abandoned test |
| `getTestQuestionLevelData` | **yes** | walkouts skip everything, so a hard question looked like an absent class |
| `getStudentQuestionLevelData` | **no** | grouped per student; filtering would blank a badged student's own drill-down instead of showing what they did answer |
| `getAvailableGrades` / `getAvailablePrograms` | **no** | 275 grade/program combos have no submitted attempt at all — filtering removes them from the picker and makes those schools unreachable |
| `getBatchOverviewData` | **no** | participation is attendance; a student who opened it and lost connection did turn up (the signal we need for the Kolhapur complaints) |

## Student Results table

Students are never hidden — a red `Test incomplete` badge, rank `—`, marks still shown. Nobody disappears, so no "why is this student missing" tickets.

Badge is sentence case at `font-semibold`/`text-xs`, smaller than the `text-sm` name, so it reads as a note rather than competing with it (as requested in review).

**Unsubmitted attempts also sort below submitted ones**, whatever the active sort. Found via Barwani: Ansh Yadav submitted and scored **−25 marks**, which the fact table floors to 0%, so he tied with the 0% walkouts and sorted among them while holding rank 14 — the ranked column read out of order.

## Unknown is not unsubmitted

The predicate is `!== false` / `IS NOT FALSE`, never `= TRUE`:

- the flag is **absent** on every report doc written before etl-next#139
- it is **null** where a student has no test-level row upstream (2,505 such question-level rows)

Both count as submitted, so **historical figures are unchanged**. A `= TRUE` filter would have flagged every past test as incomplete and silently dropped real rows.

Where **nobody** submitted, the tiles fall back to all attempts rather than showing zeroes — a zeroed card reads as a catastrophic result rather than an unfinished one.

## Verification

- 12 tests added across `dynamodb`, `bigquery` and `StudentResultsTable`
- Every behaviour independently reverted to confirm its test fails — no tautologies
- **Full suite: 3,178 passed** (246 files); `tsc --noEmit` and `eslint` clean
- All impact figures measured against prod BigQuery / DynamoDB, not estimated

## Known issue, not fixed here

**Min Score can read `-25/100 (0%)`** — self-contradictory. dbt floors `percentage` to 0 for negative marking but leaves `marks_scored` negative; confirmed in BigQuery (`marks=-25, pct=0`). af_lms renders the source faithfully, so fixing it belongs in dbt rather than clamping a real score here.

## Rollout

etl-next#139 carries the flag into new report docs only, so nothing changes for a session until `student_reports_v2_flow` re-processes it. **No backfill planned** — the flag matters most while a test is *ongoing* (some finished, some not), and the 2-hourly scheduled run picks those up automatically. Barwani was regenerated manually to verify this PR.

