### PR TITLE
Add CET to the quiz-session exam track picker

### DIFF
--- a/src/app/curriculum-summary/config/CurriculumConfigTable.tsx
+++ b/src/app/curriculum-summary/config/CurriculumConfigTable.tsx
@@ -1182,6 +1182,7 @@ function formatExamTrack(track: ExamTrack): string {
     jee_main: "JEE Main",
     jee_advanced: "JEE Advanced",
     neet: "NEET",
+    cet: "CET",
   };
   return labels[track];
 }

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -94,6 +94,7 @@ const EXAM_TRACK_OPTIONS: { value: ExamTrack; label: string }[] = [
   { value: "jee_main", label: "JEE Main" },
   { value: "jee_advanced", label: "JEE Advanced" },
   { value: "neet", label: "NEET" },
+  { value: "cet", label: "CET" },
 ];
 const CMS_SUBJECT_OPTIONS = ["Physics", "Chemistry", "Maths", "Biology"];
 

--- a/src/lib/curriculum-config.ts
+++ b/src/lib/curriculum-config.ts
@@ -293,11 +293,12 @@ interface RemoveMutationRow extends CurriculumConfigQueryRow {
   failure_reason: "stale" | "missing" | "already_out_of_syllabus" | null;
 }
 
-const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
+const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet", "cet"];
 const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
   jee_main: 1,
   jee_advanced: 9,
   neet: 2,
+  cet: 10,
 };
 const SYLLABUS_STATUSES: CurriculumConfigSyllabusStatus[] = [
   "in_syllabus",

--- a/src/lib/curriculum-options.test.ts
+++ b/src/lib/curriculum-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  EXAM_TRACKS,
+  curriculumIdForExamTrack,
+  isExamTrack,
+  streamForExamTrack,
+} from "./curriculum-options";
+
+describe("exam tracks", () => {
+  it("maps each track to its CMS curriculum id", () => {
+    // db-service /api/curriculum: JEE Mains=1, NEET=2, JEE Advanced=9, CET=10.
+    expect(curriculumIdForExamTrack("jee_main")).toBe(1);
+    expect(curriculumIdForExamTrack("neet")).toBe(2);
+    expect(curriculumIdForExamTrack("jee_advanced")).toBe(9);
+    expect(curriculumIdForExamTrack("cet")).toBe(10);
+  });
+
+  it("accepts cet as an exam track", () => {
+    expect(isExamTrack("cet")).toBe(true);
+    expect(EXAM_TRACKS).toContain("cet");
+  });
+
+  it("rejects an unknown track", () => {
+    expect(isExamTrack("cuet")).toBe(false);
+    expect(isExamTrack("")).toBe(false);
+  });
+
+  it("leaves cet unbound to a stream", () => {
+    // CET papers are PCM/PCB/PCMB, so they serve engineering and medical batches
+    // alike. An empty stream skips the stream-match guard in the from-cms route;
+    // returning "engineering" would reject every valid medical pairing.
+    expect(streamForExamTrack("cet")).toBe("");
+    expect(streamForExamTrack("jee_main")).toBe("engineering");
+    expect(streamForExamTrack("jee_advanced")).toBe("engineering");
+    expect(streamForExamTrack("neet")).toBe("medical");
+  });
+});

--- a/src/lib/curriculum-options.ts
+++ b/src/lib/curriculum-options.ts
@@ -16,7 +16,7 @@ import type {
   Topic,
 } from "@/types/curriculum";
 
-export const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet"];
+export const EXAM_TRACKS: ExamTrack[] = ["jee_main", "jee_advanced", "neet", "cet"];
 // Curriculum applies to every physical-centre program (all non-NVS programs),
 // not just JNV CoE/Nodal — otherwise a Punjab/EMRS/RGNV teacher's programs
 // intersect to empty and their curriculum tab loads blank.
@@ -26,6 +26,7 @@ const EXAM_TRACK_CURRICULUM_IDS: Record<ExamTrack, number> = {
   jee_main: 1,
   jee_advanced: 9,
   neet: 2,
+  cet: 10,
 };
 interface SchoolScopeRow {
   code: string;
@@ -128,10 +129,13 @@ export function curriculumIdForExamTrack(examTrack: ExamTrack): number {
 // The batch stream (as produced by parseBatchStream: "engineering" | "medical") each exam
 // track targets. Used to reject mismatched pairings (e.g. a NEET test on an engineering
 // batch), which would otherwise put a wrong-subject test live for those students.
+// CET papers are PCM/PCB/PCMB, so the track spans both streams. Empty string
+// skips the stream-match guard rather than rejecting half the valid pairings.
 const EXAM_TRACK_STREAMS: Record<ExamTrack, string> = {
   jee_main: "engineering",
   jee_advanced: "engineering",
   neet: "medical",
+  cet: "",
 };
 
 export function streamForExamTrack(examTrack: ExamTrack): string {

--- a/src/types/curriculum.ts
+++ b/src/types/curriculum.ts
@@ -53,7 +53,7 @@ export interface ChapterProgress {
 
 export type SubjectName = "Physics" | "Chemistry" | "Maths" | "Biology";
 export type GradeNumber = 11 | 12;
-export type ExamTrack = "jee_main" | "jee_advanced" | "neet";
+export type ExamTrack = "jee_main" | "jee_advanced" | "neet" | "cet";
 
 export interface CurriculumProgramOption {
   id: number;


### PR DESCRIPTION
Closes #276 — adds **CET** to the exam track picker when sourcing a quiz session from the new CMS.

## Verified against the live CMS first

The claim in the issue checks out. `db-service /api/curriculum` gives CET **id 10**, and the CMS returns real papers:

| grade | major tests | sample |
|---|---|---|
| 11 (`grade_id=3`) | 6 | `JNV-G11-MT-01-PCMB (CET-AIAT 02)` |
| 12 (`grade_id=4`) | 6 | `JNV-G12-MT-01-PCM (CET-AIAT 02)` |

Confirmed end to end through the same call `/api/cms/tests` makes — `exam_track=cet` → `curriculum-dropdown=10` → HTTP 200, 6 tests.

**CET has no chapter tests yet** (0 for both grades), so that subtype legitimately returns an empty list. Worth knowing before someone reports it as a bug.

## The one judgement call: stream matching

`streamForExamTrack` returns `""` for CET, unlike the other tracks.

CET papers are **PCM / PCB / PCMB**, so the track serves engineering and medical batches alike. The `from-cms` route guards with `if (expectedStream && body.stream !== expectedStream)` — an empty value skips the check. Naming either stream would reject every valid pairing for the other (e.g. `cet: "engineering"` would block the PCB paper on a medical batch).

## Scope

`ExamTrack` is shared with the curriculum-summary feature, so extending the type surfaced four exhaustive `Record<ExamTrack, …>` maps — TypeScript found them all, and each is filled.

Curriculum-summary keeps its own three-track lists (`curriculum-summary.ts`, `configs/impact`, `configs/chapter-options`). That's deliberate: the feature is chapter-test scoped and CET has no chapters to track. Adding it there would put an always-empty option in front of users.

## Verification

- 4 new tests in `curriculum-options.test.ts` (new file) covering the id mapping, `isExamTrack`, and CET's empty stream
- Full suite **3,171 passed** (247 files); `tsc --noEmit` and `eslint` clean
- Curriculum ids cross-checked against prod `db-service`, not assumed

