### PR TITLE
chore(cms): identify a CMS test by id alone, drop curriculum/grade

### DIFF
--- a/src/app/api/cms/test-pdf/route.ts
+++ b/src/app/api/cms/test-pdf/route.ts
@@ -34,29 +34,22 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const testId = (searchParams.get("testId") || "").trim();
-  const curriculumId = (searchParams.get("curriculumId") || "").trim();
-  const gradeId = (searchParams.get("gradeId") || "").trim();
   const type = (searchParams.get("type") || "questions").trim();
   const download = (searchParams.get("download") || "").trim() === "1";
 
   if (!testId) {
     return NextResponse.json({ error: "testId is required" }, { status: 400 });
   }
-  if (!curriculumId || !gradeId) {
-    return NextResponse.json(
-      { error: "curriculumId and gradeId are required" },
-      { status: 400 }
-    );
-  }
   if (!PDF_TYPES.includes(type)) {
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });
   }
 
+  // A test is identified by its id alone. The CMS's PDF handler never read
+  // curriculum_id/grade_id, and nex-gen-cms#177 removed the last param reader on the
+  // single-test fetch it shares, so sending them only risked a stale/wrong pair.
   const cmsUrl =
     `${CMS_SERVICE_URL.replace(/\/$/, "")}/api/service/test-pdf` +
     `?id=${encodeURIComponent(testId)}` +
-    `&curriculum_id=${encodeURIComponent(curriculumId)}` +
-    `&grade_id=${encodeURIComponent(gradeId)}` +
     `&type=${encodeURIComponent(type)}`;
 
   let response: Response;

--- a/src/app/api/cms/test-pdf/route.ts
+++ b/src/app/api/cms/test-pdf/route.ts
@@ -44,9 +44,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });
   }
 
-  // A test is identified by its id alone. The CMS's PDF handler never read
-  // curriculum_id/grade_id, and nex-gen-cms#177 removed the last param reader on the
-  // single-test fetch it shares, so sending them only risked a stale/wrong pair.
+  // The CMS resolves a test by id alone (nex-gen-cms#177).
   const cmsUrl =
     `${CMS_SERVICE_URL.replace(/\/$/, "")}/api/service/test-pdf` +
     `?id=${encodeURIComponent(testId)}` +

--- a/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
@@ -226,7 +226,6 @@ describe("POST /api/quiz-sessions/[id]/regenerate", () => {
       const call = fetchCall("http://quiz-backend.local/quiz/quiz-abc123/from-cms");
       expect(call).toBeDefined();
       expect((call?.[1] as RequestInit)?.method).toBe("PUT");
-      // No curriculum_id/grade_id: the CMS resolves a test by id alone (nex-gen-cms#177).
       expect(JSON.parse(String((call?.[1] as RequestInit)?.body))).toEqual({
         test_id: 504,
         quiz_type: "assessment",
@@ -288,8 +287,7 @@ describe("POST /api/quiz-sessions/[id]/regenerate", () => {
     });
 
     it("regenerates from cms_test_id alone, without curriculum/grade", async () => {
-      // Sessions created after we stopped persisting cms_curriculum_id/cms_grade_id carry
-      // only the test id. Requiring the other two here would 422 every one of them.
+      // Sessions created after we stopped persisting curriculum/grade carry only the id.
       const { POST } = await loadRouteModule();
       mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
       mocks.mockQuery.mockResolvedValue([

--- a/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.test.ts
@@ -226,10 +226,9 @@ describe("POST /api/quiz-sessions/[id]/regenerate", () => {
       const call = fetchCall("http://quiz-backend.local/quiz/quiz-abc123/from-cms");
       expect(call).toBeDefined();
       expect((call?.[1] as RequestInit)?.method).toBe("PUT");
+      // No curriculum_id/grade_id: the CMS resolves a test by id alone (nex-gen-cms#177).
       expect(JSON.parse(String((call?.[1] as RequestInit)?.body))).toEqual({
         test_id: 504,
-        curriculum_id: 1,
-        grade_id: 7,
         quiz_type: "assessment",
         // Stored end_time is IST wall-clock; sent as a bare wall-clock so quiz-backend can
         // re-derive answer-visibility against the refreshed quiz duration.
@@ -288,13 +287,41 @@ describe("POST /api/quiz-sessions/[id]/regenerate", () => {
       expect(fetchCall("http://db-service.local/session/42")).toBeUndefined();
     });
 
-    it("returns 422 when the CMS identifiers are missing", async () => {
+    it("regenerates from cms_test_id alone, without curriculum/grade", async () => {
+      // Sessions created after we stopped persisting cms_curriculum_id/cms_grade_id carry
+      // only the test id. Requiring the other two here would 422 every one of them.
       const { POST } = await loadRouteModule();
       mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
       mocks.mockQuery.mockResolvedValue([
         cmsSessionRow({
           meta_data: { cms_source: "nex-gen-cms", cms_test_id: "504" },
         }),
+      ]);
+      mocks.mockFetch.mockImplementation((input: unknown) => {
+        if (String(input).includes("/quiz/")) {
+          return Promise.resolve(jsonResponse({ id: "quiz-abc123", warnings: [] }));
+        }
+        return Promise.resolve(jsonResponse({ id: 42 }));
+      });
+
+      const res = await POST(
+        new Request("http://localhost") as never,
+        routeParams({ id: "42" })
+      );
+
+      expect(res.status).toBe(200);
+      const call = fetchCall("http://quiz-backend.local/quiz/quiz-abc123/from-cms");
+      expect(call).toBeDefined();
+      expect(
+        JSON.parse(String((call?.[1] as RequestInit)?.body)).test_id
+      ).toBe(504);
+    });
+
+    it("returns 422 when cms_test_id is missing", async () => {
+      const { POST } = await loadRouteModule();
+      mocks.mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+      mocks.mockQuery.mockResolvedValue([
+        cmsSessionRow({ meta_data: { cms_source: "nex-gen-cms" } }),
       ]);
 
       const res = await POST(

--- a/src/app/api/quiz-sessions/[id]/regenerate/route.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.ts
@@ -170,9 +170,8 @@ async function regenerateFromCms(
   const quizId = currentSession.platform_id;
   const cmsTestId = metaString(metaData, "cms_test_id");
 
-  // The test id is the only identifier needed: the CMS resolves a test by id alone and
-  // nex-gen-cms#177 removed the last reader of curriculum_id/grade_id. Requiring them here
-  // would 422 every session created after we stopped persisting them.
+  // Test id only: requiring curriculum/grade would 422 every session created after we
+  // stopped persisting them (nex-gen-cms#177).
   if (!quizId || !cmsTestId) {
     console.error(
       `Session ${sessionId} is CMS-sourced but missing regenerate identifiers ` +

--- a/src/app/api/quiz-sessions/[id]/regenerate/route.ts
+++ b/src/app/api/quiz-sessions/[id]/regenerate/route.ts
@@ -169,14 +169,14 @@ async function regenerateFromCms(
 
   const quizId = currentSession.platform_id;
   const cmsTestId = metaString(metaData, "cms_test_id");
-  const curriculumId = metaString(metaData, "cms_curriculum_id");
-  const gradeId = metaString(metaData, "cms_grade_id");
 
-  if (!quizId || !cmsTestId || !curriculumId || !gradeId) {
+  // The test id is the only identifier needed: the CMS resolves a test by id alone and
+  // nex-gen-cms#177 removed the last reader of curriculum_id/grade_id. Requiring them here
+  // would 422 every session created after we stopped persisting them.
+  if (!quizId || !cmsTestId) {
     console.error(
       `Session ${sessionId} is CMS-sourced but missing regenerate identifiers ` +
-        `(platform_id=${quizId}, cms_test_id=${cmsTestId}, ` +
-        `cms_curriculum_id=${curriculumId}, cms_grade_id=${gradeId})`
+        `(platform_id=${quizId}, cms_test_id=${cmsTestId})`
     );
     return NextResponse.json(
       { error: "Session is missing the CMS identifiers needed to regenerate" },
@@ -196,8 +196,6 @@ async function regenerateFromCms(
       headers: { "Content-Type": "application/json", accept: "application/json" },
       body: JSON.stringify({
         test_id: Number(cmsTestId),
-        curriculum_id: Number(curriculumId),
-        grade_id: Number(gradeId),
         quiz_type: "assessment",
         ...(sessionEndTime ? { session_end_time: sessionEndTime } : {}),
       }),

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -216,9 +216,7 @@ export async function POST(request: NextRequest) {
   }
   const { group, authType } = resolved;
 
-  // resolveGradeId is kept as a VALIDATION step even though the id is no longer sent
-  // anywhere: a grade with no row is a bad request and should fail here rather than
-  // producing a session against a grade the CMS has never heard of.
+  // Kept for validation only — the id itself is no longer sent anywhere.
   const gradeId = await resolveGradeId(body.grade);
   if (!gradeId) {
     return NextResponse.json(
@@ -362,9 +360,8 @@ export async function POST(request: NextRequest) {
       cms_source: CMS_SOURCE,
       cms_test_id: String(body.cmsTestId),
       cms_source_id: String(body.cmsTestId),
-      // No cms_curriculum_id/cms_grade_id: the CMS resolves a test by id alone, so the PDF
-      // proxy and the regenerate path both need only cms_test_id (nex-gen-cms#177). Older
-      // sessions keep the keys they were created with; nothing reads them any more.
+      // No cms_curriculum_id/cms_grade_id: the PDF proxy and regenerate need only
+      // cms_test_id (nex-gen-cms#177). Older sessions keep theirs; nothing reads them.
       has_synced_to_bq: false,
       infinite_session: false,
       report_link: reportLink,

--- a/src/app/api/quiz-sessions/from-cms/route.ts
+++ b/src/app/api/quiz-sessions/from-cms/route.ts
@@ -9,7 +9,6 @@ import {
 import { istWallClockWindowEnd, utcToISTDate } from "@/lib/quiz-session-time";
 import {
   EXAM_TRACKS,
-  curriculumIdForExamTrack,
   resolveGradeId,
   streamForExamTrack,
 } from "@/lib/curriculum-options";
@@ -217,7 +216,9 @@ export async function POST(request: NextRequest) {
   }
   const { group, authType } = resolved;
 
-  const curriculumId = curriculumIdForExamTrack(body.examTrack);
+  // resolveGradeId is kept as a VALIDATION step even though the id is no longer sent
+  // anywhere: a grade with no row is a bad request and should fail here rather than
+  // producing a session against a grade the CMS has never heard of.
   const gradeId = await resolveGradeId(body.grade);
   if (!gradeId) {
     return NextResponse.json(
@@ -246,8 +247,6 @@ export async function POST(request: NextRequest) {
       headers: { "Content-Type": "application/json", accept: "application/json" },
       body: JSON.stringify({
         test_id: Number(body.cmsTestId),
-        curriculum_id: curriculumId,
-        grade_id: gradeId,
         quiz_type: "assessment",
         shuffle,
         show_scores: showScores,
@@ -363,9 +362,9 @@ export async function POST(request: NextRequest) {
       cms_source: CMS_SOURCE,
       cms_test_id: String(body.cmsTestId),
       cms_source_id: String(body.cmsTestId),
-      // Persist what the on-demand PDF proxy needs to re-fetch the test from the CMS.
-      cms_curriculum_id: String(curriculumId),
-      cms_grade_id: String(gradeId),
+      // No cms_curriculum_id/cms_grade_id: the CMS resolves a test by id alone, so the PDF
+      // proxy and the regenerate path both need only cms_test_id (nex-gen-cms#177). Older
+      // sessions keep the keys they were created with; nothing reads them any more.
       has_synced_to_bq: false,
       infinite_session: false,
       report_link: reportLink,

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -2813,14 +2813,12 @@ function CmsAwarePaperLinks({
   const cmsSource = getMetaString(meta, "cms_source");
   // Ids may be stored as numbers (older sessions) or strings — accept both.
   const cmsTestId = getMetaScalar(meta, "cms_test_id");
-  const curriculumId = getMetaScalar(meta, "cms_curriculum_id");
-  const gradeId = getMetaScalar(meta, "cms_grade_id");
 
-  if (cmsSource && cmsTestId && curriculumId && gradeId) {
-    const base =
-      `/api/cms/test-pdf?testId=${encodeURIComponent(cmsTestId)}` +
-      `&curriculumId=${encodeURIComponent(curriculumId)}` +
-      `&gradeId=${encodeURIComponent(gradeId)}`;
+  // Gated on the test id alone. Gating on cms_curriculum_id/cms_grade_id too would silently
+  // fall through to the legacy stored-URL branch — i.e. no PDF links at all — for every
+  // session created after we stopped persisting them (nex-gen-cms#177).
+  if (cmsSource && cmsTestId) {
+    const base = `/api/cms/test-pdf?testId=${encodeURIComponent(cmsTestId)}`;
     return (
       <PaperResourceLinks
         questionHref={`${base}&type=questions`}

--- a/src/components/quiz-sessions/QuizSessionsTab.tsx
+++ b/src/components/quiz-sessions/QuizSessionsTab.tsx
@@ -2814,9 +2814,8 @@ function CmsAwarePaperLinks({
   // Ids may be stored as numbers (older sessions) or strings — accept both.
   const cmsTestId = getMetaScalar(meta, "cms_test_id");
 
-  // Gated on the test id alone. Gating on cms_curriculum_id/cms_grade_id too would silently
-  // fall through to the legacy stored-URL branch — i.e. no PDF links at all — for every
-  // session created after we stopped persisting them (nex-gen-cms#177).
+  // Test id only: also gating on cms_curriculum_id/cms_grade_id would silently fall through
+  // to the legacy branch — no PDF links — for sessions created after we stopped storing them.
   if (cmsSource && cmsTestId) {
     const base = `/api/cms/test-pdf?testId=${encodeURIComponent(cmsTestId)}`;
     return (


### PR DESCRIPTION
## 🎯 Why

Follow-up to [nex-gen-cms#177](https://github.com/avantifellows/nex-gen-cms/pull/177), which removes the last reader of `curriculum_id`/`grade_id` on the CMS single-test fetch.

They were never inert. The CMS fed them into `Test.SetCurriculumGrade`, which appended the caller-supplied pair into the cached `Test` **through a pointer into the shared, process-wide service cache** — so one request's params leaked into `curriculum_grades` for every later reader until the cache expired. af_lms was the origin of those params, so this drops them end to end.

## 🔧 What changed

- **`from-cms`** — stops sending `curriculum_id`/`grade_id` to quiz-backend, and stops persisting `cms_curriculum_id`/`cms_grade_id` on the session `meta_data`. `resolveGradeId` is kept purely as a **validation** step (a grade with no row is still a 400) even though the id is no longer used.
- **`regenerate`** — requires only `cms_test_id`. It previously **422'd** when `cms_curriculum_id`/`cms_grade_id` were absent, which would have rejected every session created after we stopped persisting them. This is the change that has to land before the other repos stop sending them.
- **`test-pdf` proxy** — stops requiring and forwarding them. Verified on the CMS side: `/api/service/test-pdf` and `/download-pdf` are served by the *same* `DownloadPdf` handler (`cmd/main.go:167,178`), which never reads either param.
- **`QuizSessionsTab`** — gates the on-demand PDF links on `cms_test_id` alone.

  ⚠️ **This one is the subtle catch and the reason this PR is wider than just the regenerate guard.** The links were gated on all three ids (`if (cmsSource && cmsTestId && curriculumId && gradeId)`). Without this change, a session created after the cleanup would silently fall through to the legacy stored-URL branch and render **no PDF links at all** — no error, no log, just missing buttons. That would have been a genuine regression shipped by an otherwise "dead code removal" cleanup.

## 🔒 Backward compatibility

Sessions created earlier keep whatever keys they were created with; nothing reads them any more. A regenerate test deliberately retains a fixture carrying both keys to confirm older sessions still regenerate.

## 🔗 Related

- nex-gen-cms#177 (the CMS-side removal)
- avantifellows/quiz-backend#180
- avantifellows/etl-data-flow#126
- `quiz-creator`: no change needed — only validates a pasted CMS edit link, both already optional (`a49253e`).

**Merge order:** this PR goes **first**. Its regenerate guard is the only thing that hard-fails when the params stop being persisted, so quiz-backend#180 and etl-data-flow#126 should follow.

## ✅ Test plan

- [x] `npx vitest run` — **3184 passed**, 3 skipped (247 files)
- [x] `npx eslint` on all five changed files — clean
- [x] Regenerate tests reworked: a session with only `cms_test_id` now regenerates (200) and sends `{test_id, quiz_type, session_end_time}` with no curriculum/grade; the 422 case now covers a *missing `cms_test_id`* instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
