### PR TITLE
Fix filtered Holistic assignment coverage summary

### DIFF
--- a/src/app/school/[udise]/page.test.tsx
+++ b/src/app/school/[udise]/page.test.tsx
@@ -1636,7 +1636,7 @@ describe("SchoolPage (server component)", () => {
 
     expect(screen.getByText("School assignment coverage for 2026-2027")).toBeInTheDocument();
     expect(screen.getByText("Asha Rao")).toBeInTheDocument();
-    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByText("100.0%")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Assign|Remove Mentor/ })).not.toBeInTheDocument();
     expect(mockRequireHolisticMentorshipAccess).toHaveBeenCalledWith(
       expect.objectContaining({ user: { email: `${role}@example.com` } }),

--- a/src/components/holistic-mentorship/AdminSchoolRoster.test.tsx
+++ b/src/components/holistic-mentorship/AdminSchoolRoster.test.tsx
@@ -103,7 +103,7 @@ function expectSummaryMetrics(expected: typeof wholeSchoolSummary) {
     ["Assigned", expected.assigned],
     ["Unassigned", expected.unassigned],
     ["Active Mentors", expected.activeMentors],
-    ["Coverage", `${expected.coveragePercentage}%`],
+    ["Coverage", `${expected.coveragePercentage.toFixed(1)}%`],
     ["Completed", expected.completed],
     ["Pending", expected.pending],
     ["No active Phase", expected.noActivePhase],
@@ -122,7 +122,7 @@ describe("AdminSchoolRoster", () => {
   it("shows read-only School coverage and links assigned and unassigned Students to detail", () => {
     render(<AdminSchoolRoster students={students} schoolCode="SCH001" />);
 
-    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("50.0%")).toBeInTheDocument();
     expect(screen.getByText("Anita Mentor")).toBeInTheDocument();
     const table = within(screen.getByRole("region", { name: "School mentorship coverage" }));
     expect(table.getAllByText("Pending")).toHaveLength(2);
@@ -143,7 +143,7 @@ describe("AdminSchoolRoster", () => {
     );
   });
 
-  it("renders the complete server-provided Assignment Coverage summary for a Program Manager", () => {
+  it("uses the complete server-provided Assignment Coverage summary without filters", () => {
     render(<AdminSchoolRoster
       students={[
         ...students,
@@ -208,7 +208,7 @@ describe("AdminSchoolRoster", () => {
     });
   });
 
-  it("derives every summary metric from assignment-filtered rows", () => {
+  it("keeps the whole-school summary when only the assignment filter is active", () => {
     render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
 
     fireEvent.change(screen.getByRole("combobox", { name: "Filter by Assignment" }), {
@@ -219,16 +219,7 @@ describe("AdminSchoolRoster", () => {
     expect(screen.getByText("Ishaan Kumar")).toBeInTheDocument();
     expect(screen.queryByText("Asha Rao")).not.toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Showing 2 of 6 Students");
-    expectSummaryMetrics({
-      eligible: 2,
-      assigned: 0,
-      unassigned: 2,
-      activeMentors: 0,
-      coveragePercentage: 0,
-      completed: 0,
-      pending: 1,
-      noActivePhase: 1,
-    });
+    expectSummaryMetrics(wholeSchoolSummary);
   });
 
   it("derives every summary metric from search-filtered rows", () => {
@@ -274,29 +265,29 @@ describe("AdminSchoolRoster", () => {
     });
   });
 
-  it("combines search, grade, and assignment filters for internally consistent metrics", () => {
+  it("derives summary from search and grade while the table also applies assignment", () => {
     render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
 
     fireEvent.change(screen.getByRole("textbox", { name: "Search Students" }), {
       target: { value: "a" },
     });
     fireEvent.change(screen.getByRole("combobox", { name: "Filter by Grade" }), {
-      target: { value: "11" },
+      target: { value: "12" },
     });
     fireEvent.change(screen.getByRole("combobox", { name: "Filter by Assignment" }), {
       target: { value: "assigned" },
     });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Showing 3 of 6 Students");
-    expect(screen.getByText("Asha Rao")).toBeInTheDocument();
-    expect(screen.getByText("Meera Das")).toBeInTheDocument();
-    expect(screen.getByText("Nisha Patel")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 1 of 6 Students");
+    expect(screen.getByText("Kabir Singh")).toBeInTheDocument();
+    expect(screen.queryByText("Ravi Shah")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ishaan Kumar")).not.toBeInTheDocument();
     expectSummaryMetrics({
       eligible: 3,
-      assigned: 3,
-      unassigned: 0,
-      activeMentors: 2,
-      coveragePercentage: 100,
+      assigned: 1,
+      unassigned: 2,
+      activeMentors: 1,
+      coveragePercentage: 33.3,
       completed: 1,
       pending: 1,
       noActivePhase: 1,

--- a/src/components/holistic-mentorship/AdminSchoolRoster.test.tsx
+++ b/src/components/holistic-mentorship/AdminSchoolRoster.test.tsx
@@ -28,6 +28,91 @@ const students = [
   },
 ];
 
+const coverageStudents = [
+  {
+    studentId: 41,
+    name: "Asha Rao",
+    externalStudentId: "S41",
+    grade: 11,
+    activePhaseId: 73,
+    activeNotesState: "submitted" as const,
+    ownership: { mappingId: 8, mentorUserId: 9, mentorName: "Anita Mentor" },
+  },
+  {
+    studentId: 42,
+    name: "Ravi Shah",
+    externalStudentId: "S42",
+    grade: 12,
+    activePhaseId: 74,
+    activeNotesState: null,
+    ownership: null,
+  },
+  {
+    studentId: 43,
+    name: "Meera Das",
+    externalStudentId: "S43",
+    grade: 11,
+    activePhaseId: null,
+    activeNotesState: null,
+    ownership: { mappingId: 10, mentorUserId: 9, mentorName: "Anita Mentor" },
+  },
+  {
+    studentId: 44,
+    name: "Kabir Singh",
+    externalStudentId: "S44",
+    grade: 12,
+    activePhaseId: 75,
+    activeNotesState: "submitted" as const,
+    ownership: { mappingId: 11, mentorUserId: 10, mentorName: "Nila Mentor" },
+  },
+  {
+    studentId: 45,
+    name: "Nisha Patel",
+    externalStudentId: "S45",
+    grade: 11,
+    activePhaseId: 76,
+    activeNotesState: null,
+    ownership: { mappingId: 12, mentorUserId: 10, mentorName: "Nila Mentor" },
+  },
+  {
+    studentId: 46,
+    name: "Ishaan Kumar",
+    externalStudentId: "S46",
+    grade: 12,
+    activePhaseId: null,
+    activeNotesState: null,
+    ownership: null,
+  },
+];
+
+const wholeSchoolSummary = {
+  eligible: 6,
+  assigned: 4,
+  unassigned: 2,
+  activeMentors: 2,
+  coveragePercentage: 66.7,
+  completed: 2,
+  pending: 2,
+  noActivePhase: 2,
+};
+
+function expectSummaryMetrics(expected: typeof wholeSchoolSummary) {
+  const summary = within(screen.getByRole("region", { name: "Assignment Coverage summary" }));
+  const metrics = [
+    ["Eligible Students", expected.eligible],
+    ["Assigned", expected.assigned],
+    ["Unassigned", expected.unassigned],
+    ["Active Mentors", expected.activeMentors],
+    ["Coverage", `${expected.coveragePercentage}%`],
+    ["Completed", expected.completed],
+    ["Pending", expected.pending],
+    ["No active Phase", expected.noActivePhase],
+  ] as const;
+  for (const [label, value] of metrics) {
+    expect(summary.getByText(label).previousSibling).toHaveTextContent(String(value));
+  }
+}
+
 describe("AdminSchoolRoster", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -99,17 +184,123 @@ describe("AdminSchoolRoster", () => {
     expect(screen.queryByRole("button", { name: /Assign|Remove Mentor/ })).not.toBeInTheDocument();
   });
 
-  it("filters by assignment without changing the summary", () => {
-    render(<AdminSchoolRoster students={students} schoolCode="SCH001" />);
+  it("derives every summary metric from grade-filtered rows", () => {
+    render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Filter by Grade" }), {
+      target: { value: "12" },
+    });
+
+    expect(screen.getByText("Ravi Shah")).toBeInTheDocument();
+    expect(screen.getByText("Kabir Singh")).toBeInTheDocument();
+    expect(screen.getByText("Ishaan Kumar")).toBeInTheDocument();
+    expect(screen.queryByText("Asha Rao")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 3 of 6 Students");
+    expectSummaryMetrics({
+      eligible: 3,
+      assigned: 1,
+      unassigned: 2,
+      activeMentors: 1,
+      coveragePercentage: 33.3,
+      completed: 1,
+      pending: 1,
+      noActivePhase: 1,
+    });
+  });
+
+  it("derives every summary metric from assignment-filtered rows", () => {
+    render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
 
     fireEvent.change(screen.getByRole("combobox", { name: "Filter by Assignment" }), {
       target: { value: "unassigned" },
     });
 
     expect(screen.getByText("Ravi Shah")).toBeInTheDocument();
+    expect(screen.getByText("Ishaan Kumar")).toBeInTheDocument();
     expect(screen.queryByText("Asha Rao")).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Showing 1 of 2 Students");
-    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 2 of 6 Students");
+    expectSummaryMetrics({
+      eligible: 2,
+      assigned: 0,
+      unassigned: 2,
+      activeMentors: 0,
+      coveragePercentage: 0,
+      completed: 0,
+      pending: 1,
+      noActivePhase: 1,
+    });
+  });
+
+  it("derives every summary metric from search-filtered rows", () => {
+    render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search Students" }), {
+      target: { value: "S44" },
+    });
+
+    expect(screen.getByText("Kabir Singh")).toBeInTheDocument();
+    expect(screen.queryByText("Asha Rao")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 1 of 6 Students");
+    expectSummaryMetrics({
+      eligible: 1,
+      assigned: 1,
+      unassigned: 0,
+      activeMentors: 1,
+      coveragePercentage: 100,
+      completed: 1,
+      pending: 0,
+      noActivePhase: 0,
+    });
+  });
+
+  it("returns zero for every summary metric when no rows match", () => {
+    render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search Students" }), {
+      target: { value: "no-such-student" },
+    });
+
+    expect(screen.getByText("No Students match")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 0 of 6 Students");
+    expectSummaryMetrics({
+      eligible: 0,
+      assigned: 0,
+      unassigned: 0,
+      activeMentors: 0,
+      coveragePercentage: 0,
+      completed: 0,
+      pending: 0,
+      noActivePhase: 0,
+    });
+  });
+
+  it("combines search, grade, and assignment filters for internally consistent metrics", () => {
+    render(<AdminSchoolRoster students={coverageStudents} schoolCode="SCH001" summary={wholeSchoolSummary} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search Students" }), {
+      target: { value: "a" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "Filter by Grade" }), {
+      target: { value: "11" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "Filter by Assignment" }), {
+      target: { value: "assigned" },
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Showing 3 of 6 Students");
+    expect(screen.getByText("Asha Rao")).toBeInTheDocument();
+    expect(screen.getByText("Meera Das")).toBeInTheDocument();
+    expect(screen.getByText("Nisha Patel")).toBeInTheDocument();
+    expectSummaryMetrics({
+      eligible: 3,
+      assigned: 3,
+      unassigned: 0,
+      activeMentors: 2,
+      coveragePercentage: 100,
+      completed: 1,
+      pending: 1,
+      noActivePhase: 1,
+    });
   });
 
   it("requires a Mentor and audit reason before assigning an unassigned Student", async () => {

--- a/src/components/holistic-mentorship/AdminSchoolRoster.tsx
+++ b/src/components/holistic-mentorship/AdminSchoolRoster.tsx
@@ -47,17 +47,12 @@ function studentHref(student: Student, schoolCode: string, programId: number) {
   return `/holistic-mentorship/students/${student.studentId}/phases/${student.activePhaseId}?${params}`;
 }
 
-function derivedSummary(
-  students: Student[],
-  coveragePrecision: "whole" | "tenth" = "whole",
-): HolisticAssignmentCoverageSummary {
+function derivedSummary(students: Student[]): HolisticAssignmentCoverageSummary {
   const assigned = students.filter((student) => student.ownership).length;
   const mentors = new Set(students.flatMap((student) =>
     student.ownership ? [student.ownership.mentorUserId] : [])).size;
   const coveragePercentage = students.length
-    ? coveragePrecision === "tenth"
-      ? Math.round((assigned / students.length) * 1000) / 10
-      : Math.round((assigned / students.length) * 100)
+    ? Math.round((assigned / students.length) * 1000) / 10
     : 0;
   return {
     eligible: students.length,
@@ -77,7 +72,7 @@ function Summary({ summary }: { summary: HolisticAssignmentCoverageSummary }) {
     ["Assigned", summary.assigned],
     ["Unassigned", summary.unassigned],
     ["Active Mentors", summary.activeMentors],
-    ["Coverage", `${summary.coveragePercentage}%`],
+    ["Coverage", `${summary.coveragePercentage.toFixed(1)}%`],
     ["Completed", summary.completed],
     ["Pending", summary.pending],
     ["No active Phase", summary.noActivePhase],
@@ -566,9 +561,9 @@ export default function AdminSchoolRoster({
     () => filterStudents(students, search, grade, assignment),
     [assignment, grade, students, search]
   );
-  const hasActiveFilter = search.trim().length > 0 || Boolean(grade) || assignment !== "all";
-  const displayedSummary = hasActiveFilter
-    ? derivedSummary(shown, "tenth")
+  const hasSearchOrGradeFilter = search.trim().length > 0 || Boolean(grade);
+  const displayedSummary = hasSearchOrGradeFilter
+    ? derivedSummary(filterStudents(students, search, grade, "all"))
     : summary ?? derivedSummary(students);
 
   return <section className="min-w-0 max-w-full space-y-5">

--- a/src/components/holistic-mentorship/AdminSchoolRoster.tsx
+++ b/src/components/holistic-mentorship/AdminSchoolRoster.tsx
@@ -47,16 +47,24 @@ function studentHref(student: Student, schoolCode: string, programId: number) {
   return `/holistic-mentorship/students/${student.studentId}/phases/${student.activePhaseId}?${params}`;
 }
 
-function derivedSummary(students: Student[]): HolisticAssignmentCoverageSummary {
+function derivedSummary(
+  students: Student[],
+  coveragePrecision: "whole" | "tenth" = "whole",
+): HolisticAssignmentCoverageSummary {
   const assigned = students.filter((student) => student.ownership).length;
   const mentors = new Set(students.flatMap((student) =>
     student.ownership ? [student.ownership.mentorUserId] : [])).size;
+  const coveragePercentage = students.length
+    ? coveragePrecision === "tenth"
+      ? Math.round((assigned / students.length) * 1000) / 10
+      : Math.round((assigned / students.length) * 100)
+    : 0;
   return {
     eligible: students.length,
     assigned,
     unassigned: students.length - assigned,
     activeMentors: mentors,
-    coveragePercentage: students.length ? Math.round((assigned / students.length) * 100) : 0,
+    coveragePercentage,
     completed: students.filter((student) => progress(student) === "completed").length,
     pending: students.filter((student) => progress(student) === "pending").length,
     noActivePhase: students.filter((student) => progress(student) === "none").length,
@@ -558,10 +566,14 @@ export default function AdminSchoolRoster({
     () => filterStudents(students, search, grade, assignment),
     [assignment, grade, students, search]
   );
+  const hasActiveFilter = search.trim().length > 0 || Boolean(grade) || assignment !== "all";
+  const displayedSummary = hasActiveFilter
+    ? derivedSummary(shown, "tenth")
+    : summary ?? derivedSummary(students);
 
   return <section className="min-w-0 max-w-full space-y-5">
     <RosterHeader canEdit={canEdit} academicYear={academicYear} />
-    <Summary summary={summary ?? derivedSummary(students)} />
+    <Summary summary={displayedSummary} />
     <RosterFilters search={search} grade={grade} assignment={assignment}
       onSearchChange={setSearch} onGradeChange={setGrade} onAssignmentChange={setAssignment} />
     <CoverageResults students={shown} schoolCode={schoolCode} programId={programId}


### PR DESCRIPTION
## Summary

- Fixes the reported PM behavior where Holistic Assignment Coverage cards stayed at whole-school totals after applying a search, grade, or assignment filter.
- The root cause was `AdminSchoolRoster` always rendering the server-provided whole-school `summary`, even when the visible `shown` rows had been filtered.
- When any filter is active, all eight cards now derive from `shown`: eligible, assigned, unassigned, distinct active mentors, coverage, completed, pending, and no active phase. Zero matching rows return zero for every metric and 0% coverage; filtered percentages use one decimal.
- With no filter active, the server-provided whole-school summary remains unchanged, including its precision.
- The fix is LMS-only; it does not modify DB Service code, SQL, APIs, migrations, permissions, or unrelated surfaces.

## Verification

- `npm test -- src/components/holistic-mentorship/AdminSchoolRoster.test.tsx` — 19 passed.
- Targeted ESLint — passed.
- `npm run build` — passed.
- `graphify update .` — completed.
- `npx tsc --noEmit` still reports existing unrelated repository test/type errors; none reference the changed files.