### PR TITLE
Let ops regenerate a combined report

### DIFF
--- a/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
+++ b/src/app/api/quiz-analytics/[udise]/combined-reports/route.ts
@@ -78,6 +78,7 @@ export async function POST(
     grade?: number;
     program?: string;
     stream?: string;
+    regenerate?: boolean;
   };
   try {
     body = await request.json();
@@ -90,12 +91,15 @@ export async function POST(
 
   try {
     // Gate before doing any work: the session must have closed, and this test
-    // must not already have a finished or in-flight report.
+    // must not already have an in-flight report. An existing finished report
+    // only blocks unless the caller explicitly asked to regenerate.
     const [window, existingJobs] = await Promise.all([
       getSessionWindow(body.session_id),
       listCombinedReportJobs(body.session_id, auth.school.code),
     ]);
-    const eligibility = evaluateGenerationEligibility(window, existingJobs);
+    const eligibility = evaluateGenerationEligibility(window, existingJobs, {
+      regenerate: body.regenerate === true,
+    });
     if (!eligibility.allowed && eligibility.reason) {
       return NextResponse.json(
         {

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -116,7 +116,7 @@ export default function CombinedReportPanel({
     };
   }, [jobs, refresh]);
 
-  const generate = async () => {
+  const generate = async (regenerate = false) => {
     setSubmitting(true);
     setError(null);
     try {
@@ -129,6 +129,7 @@ export default function CombinedReportPanel({
           grade,
           program,
           stream,
+          ...(regenerate ? { regenerate: true } : {}),
         }),
       });
       if (!res.ok) {
@@ -154,6 +155,10 @@ export default function CombinedReportPanel({
     }
   };
 
+  // A finished report is the one blocked state ops can act on: the data behind it
+  // may have been fixed since, so offer a deliberate rebuild rather than a dead end.
+  const alreadyGenerated = blockedReason === "already_generated";
+
   return (
     <div className="bg-bg-card-alt border border-border rounded-lg p-4 space-y-3">
       <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -166,18 +171,22 @@ export default function CombinedReportPanel({
           </p>
         </div>
         <button
-          onClick={generate}
-          disabled={submitting || loading || !canGenerate}
-          title={blockedMessage ?? undefined}
+          onClick={() => generate(alreadyGenerated)}
+          disabled={submitting || loading || (!canGenerate && !alreadyGenerated)}
+          title={alreadyGenerated ? undefined : blockedMessage ?? undefined}
           className="px-4 py-2 min-h-[44px] text-xs md:text-sm font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent shadow-sm transition-colors hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {submitting ? "Starting…" : "Generate combined report"}
+          {submitting
+            ? "Starting…"
+            : alreadyGenerated
+              ? "Regenerate"
+              : "Generate combined report"}
         </button>
       </div>
 
       {/* Not an error — the ordinary state of a test that is still open, or one
           whose report has already been produced. */}
-      {!loading && blockedMessage && (
+      {!loading && blockedMessage && !alreadyGenerated && (
         <div className="p-2 bg-bg-card border border-border text-text-muted rounded text-xs">
           {blockedMessage}
           {blockedReason === "session_not_ended" && sessionEndTime && (

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -158,6 +158,10 @@ export default function CombinedReportPanel({
   // A finished report is the one blocked state ops can act on: the data behind it
   // may have been fixed since, so offer a deliberate rebuild rather than a dead end.
   const alreadyGenerated = blockedReason === "already_generated";
+  // Keep the label on "Regenerate" while the rebuild is in flight — it flips to
+  // job_in_progress the moment the job is queued, and reverting the wording
+  // mid-run reads as the button having reset.
+  const hasFinishedReport = jobs.some((j) => j.status === "done");
 
   return (
     <div className="bg-bg-card-alt border border-border rounded-lg p-4 space-y-3">
@@ -178,7 +182,7 @@ export default function CombinedReportPanel({
         >
           {submitting
             ? "Starting…"
-            : alreadyGenerated
+            : hasFinishedReport
               ? "Regenerate"
               : "Generate combined report"}
         </button>

--- a/src/lib/combined-report-eligibility.test.ts
+++ b/src/lib/combined-report-eligibility.test.ts
@@ -140,4 +140,30 @@ describe("evaluateGenerationEligibility", () => {
       evaluateGenerationEligibility(open, [{ status: "done" }]),
     ).toEqual({ allowed: false, reason: "session_not_ended" });
   });
+
+  it("allows a deliberate regenerate over a finished report", () => {
+    // The once-per-test rule stops accidental duplicates; it must not make a
+    // report built before an upstream data fix permanently unfixable.
+    const jobs = [{ status: "done" }];
+    expect(evaluateGenerationEligibility(ended, jobs).allowed).toBe(false);
+    expect(
+      evaluateGenerationEligibility(ended, jobs, { regenerate: true }).allowed,
+    ).toBe(true);
+  });
+
+  it("still refuses a regenerate while another job is in flight", () => {
+    // Two workers rendering the same session would race on the same S3 key.
+    const jobs = [{ status: "processing" }];
+    const v = evaluateGenerationEligibility(ended, jobs, { regenerate: true });
+    expect(v.allowed).toBe(false);
+    expect(v.reason).toBe("job_in_progress");
+  });
+
+  it("still refuses a regenerate while the session is open", () => {
+    const v = evaluateGenerationEligibility(open, [{ status: "done" }], {
+      regenerate: true,
+    });
+    expect(v.allowed).toBe(false);
+    expect(v.reason).toBe("session_not_ended");
+  });
 });

--- a/src/lib/combined-report-eligibility.ts
+++ b/src/lib/combined-report-eligibility.ts
@@ -102,12 +102,18 @@ const ACTIVE_STATUSES = new Set(["queued", "started", "processing"]);
 export function evaluateGenerationEligibility(
   window: SessionWindow,
   jobs: JobLike[],
+  // Set when the caller is deliberately asking for a fresh copy. The
+  // once-per-test rule exists to stop accidental duplicate PDFs, not to make a
+  // report permanently unfixable: a PDF built before an upstream data fix stays
+  // wrong forever otherwise, and the underlying reports are regenerated
+  // independently of these jobs.
+  { regenerate = false }: { regenerate?: boolean } = {},
 ): { allowed: boolean; reason?: GenerationBlockedReason } {
   if (!window.hasEnded) return { allowed: false, reason: "session_not_ended" };
   if (jobs.some((j) => ACTIVE_STATUSES.has(j.status))) {
     return { allowed: false, reason: "job_in_progress" };
   }
-  if (jobs.some((j) => j.status === "done")) {
+  if (!regenerate && jobs.some((j) => j.status === "done")) {
     return { allowed: false, reason: "already_generated" };
   }
   return { allowed: true };
@@ -118,5 +124,5 @@ export const BLOCKED_MESSAGE: Record<GenerationBlockedReason, string> = {
     "This test is still open. The combined report can be generated once the session end time has passed.",
   job_in_progress: "A combined report for this test is already being generated.",
   already_generated:
-    "A combined report has already been generated for this test.",
+    "A combined report already exists for this test. Use Regenerate to build a fresh copy.",
 };


### PR DESCRIPTION
Reported from the Performance tab: a test with an existing report shows a **disabled** "Generate combined report" button, the message *"A combined report has already been generated for this test"*, and **no way to regenerate**.

## The dead end

`already_generated` fires on any `done` job and **nothing ever clears it** — not new students, not fixed data. `Retry` only renders for `errored` jobs, so a successful job has no path forward.

That matters because the underlying student reports are regenerated **independently** of these jobs. A combined PDF built before an upstream fix keeps being served from S3, stale, forever.

Live example: the Adilabad AIAT-02 PDF (job ran 18 Aug 04:46) has 80 pages for 40 students — page 1 is the summary, page 2 is the "Chapter-wise Performance Analysis" heading above an **empty table**, because the chapter facts still had NULL priority and JSON-formatted names at that moment. The docs were fixed on 20 Aug; the PDF cannot be rebuilt.

**159 of 165** distinct (session, school) reports are stale by that definition.

## Changes

- `POST` accepts `regenerate: true`
- the panel's primary button becomes **Regenerate** once a report exists
- the info banner is suppressed when the button already says Regenerate — it was repeating the same sentence directly under a disabled control

## The accident guard is intact

`regenerate` only overrides `already_generated`. A regenerate is still refused when:

- **another job is in flight** — two workers rendering the same session would race on the same S3 key
- **the session is still open** — the PR #269 rule, unchanged

Both are covered by tests.

## Verification

- 3 tests added; 19 pass in the eligibility suite
- Confirmed the new tests fail if the `!regenerate &&` guard is removed
- **1,301 tests pass** across `src/lib`, `components/performance` and the quiz-analytics routes
- `tsc --noEmit` and `eslint` clean

## Separately

The 159 stale reports still need rebuilding — I can trigger those server-side rather than making ops click through each one, since the staleness was our bug.