### PR TITLE
Centre the Download button's label

### DIFF
--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -243,7 +243,7 @@ export default function CombinedReportPanel({
                     href={job.download_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="px-3 py-1.5 min-h-[36px] text-xs font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent hover:opacity-90"
+                    className="inline-flex items-center justify-center px-3 py-1.5 min-h-[36px] text-xs font-bold uppercase tracking-wide rounded-lg bg-accent text-text-on-accent hover:opacity-90"
                   >
                     Download
                   </a>


### PR DESCRIPTION
The Download label sits high in its button rather than centred.

## Cause

Download is an `<a>`, and an anchor is inline: `min-h-[36px]` grows the box but nothing centres the text inside it, so `py-1.5` alone leaves the label riding high.

Regenerate and Retry are `<button>`s, which centre their content natively — which is why only this one control looked wrong despite sharing the same utility classes.

## Fix

`inline-flex items-center justify-center` on the anchor. Verified this is the only anchor in `src/` carrying a `min-h-` without flex centring, so there is nothing else to sweep.

tsc and eslint clean; 108 tests pass across `components/performance` and the quiz-analytics routes.