### PR TITLE
Fix Holistic Notes autosave conflict for empty drafts

### DIFF
--- a/src/lib/holistic-notes.test.ts
+++ b/src/lib/holistic-notes.test.ts
@@ -229,6 +229,32 @@ describe("Holistic Post-Session Notes", () => {
     expect(update?.[1]).toEqual(["501", 4, "draft", 10]);
   });
 
+  it("lets the same Mentor continue an empty draft at its current revision", async () => {
+    const client = { query: vi.fn()
+      .mockResolvedValueOnce({ rows: [{ mapping_id: "300", mentor_user_id: "9", phase_revision: 5, phase_state: "open" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "91" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "501", author_user_id: "9", state: "draft", revision: 2, has_answers: false }] })
+      .mockResolvedValueOnce({ rows: [{ revision: 3 }] })
+      .mockResolvedValue({ rows: [] }) };
+    mockWithTransaction.mockImplementation(async (work) => work(client as never));
+
+    await expect(saveHolisticNotes({
+      programId: 1,
+      mode: "draft",
+      studentId: 41,
+      phaseId: 73,
+      schoolId: 4,
+      academicYear: "2026-2027",
+      actorUserId: 9,
+      expectedRevision: 2,
+      answers: [{ questionId: 91, answer: "A weekly plan" }],
+    })).resolves.toEqual({ ok: true, changed: true, revision: 3 });
+    const update = client.query.mock.calls.find(([sql]) =>
+      String(sql).includes("UPDATE holistic_mentorship_post_session_notes")
+    );
+    expect(update?.[1]).toEqual(["501", 2, "draft", 9]);
+  });
+
   it("corrects the author's submitted Notes without another Submit", async () => {
     const client = { query: vi.fn()
       .mockResolvedValueOnce({ rows: [{ mapping_id: "300", mentor_user_id: "9", phase_revision: 5, phase_state: "open" }] })

--- a/src/lib/holistic-notes.ts
+++ b/src/lib/holistic-notes.ts
@@ -151,13 +151,14 @@ async function loadExistingNotes(
   return found.rows[0] ?? null;
 }
 
-function claimsErasedDraft(existing: ExistingNotes | null, mode: NotesInput["mode"]): boolean {
-  return !!existing && existing.state === "draft" && existing.has_answers === false && mode === "draft";
+function claimsErasedDraft(existing: ExistingNotes | null, input: NotesInput): boolean {
+  return !!existing && existing.state === "draft" && existing.has_answers === false &&
+    input.mode === "draft" && Number(existing.author_user_id) !== input.actorUserId;
 }
 
 function validateAuthor(existing: ExistingNotes | null, input: NotesInput): HolisticNotesResult | null {
   if (!existing || Number(existing.author_user_id) === input.actorUserId ||
-      claimsErasedDraft(existing, input.mode)) return null;
+      claimsErasedDraft(existing, input)) return null;
   return { ok: false, status: 403, error: "Forbidden" };
 }
 
@@ -232,7 +233,7 @@ function validateExisting(
   questionIds: Set<number>,
   input: NotesInput
 ): HolisticNotesResult | null {
-  const revision = claimsErasedDraft(existing, input.mode) ? 0 : existingRevision(existing);
+  const revision = claimsErasedDraft(existing, input) ? 0 : existingRevision(existing);
   if (revision !== input.expectedRevision) {
     return notesConflict(revision);
   }
@@ -250,7 +251,7 @@ async function upsertNotes(
   input: NotesInput
 ): Promise<{ notesId: number; revision: number }> {
   if (existing) {
-    const expectedDatabaseRevision = claimsErasedDraft(existing, input.mode)
+    const expectedDatabaseRevision = claimsErasedDraft(existing, input)
       ? existing.revision
       : input.expectedRevision;
     const updated = await client.query<{ revision: number }>(


### PR DESCRIPTION
## Context

A Holistic Mentor writes Post-Session Notes after a mentoring conversation. The LMS saves these Notes as a draft while the Mentor types. Each save uses a revision number to prevent one browser session from overwriting a newer draft.

## Problem

A valid draft can have revision 2 and no saved answers. When the same Mentor typed a new answer, the page sent revision 2. The server incorrectly treated the draft as an erased draft from a former Mentor. It changed the expected revision to 0 and returned this error:

`409 Notes changed; reload the latest version`

Reloading the page or changing devices could not fix the error.

## What This PR Changes

- A zero-answer draft is treated as an erased draft only when a different Mentor owns it.
- The original Mentor continues to use the stored draft revision.
- A replacement Mentor can still claim an erased draft with revision 0.
- A regression test covers a same-Mentor draft at revision 2 with no saved answers.

## Expected Result

When the original Mentor types in an empty revision-2 draft, the save succeeds and creates revision 3. Real stale revisions still return a conflict. The replacement-Mentor behavior does not change.

## Verification

We reproduced the production data shape in the local database with synthetic Student content: an active Holistic Mentor-Mentee Mapping, an open Holistic Phase, five Post-Session Questions, and a same-author draft at revision 2 with no answers.

- Current `main` returned the exact 409 error with `currentRevision: 0`.
- This branch saved the answer and returned revision 3.
- The follow-up read showed the saved answer and an editable draft at revision 3.
- Focused Holistic Mentorship tests: 35 passed.
- Full unit suite: 3,411 passed and 3 skipped.
- Lint: 0 errors.
- Production build: passed.
- GitHub CI: passed.

## Scope

This is an AF LMS change only. It does not need a database migration, a DB Service change, or a production data update.