### PR TITLE
Combined reports: show only the latest run, keep last good download during rebuilds

### DIFF
--- a/src/components/performance/CombinedReportPanel.test.tsx
+++ b/src/components/performance/CombinedReportPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { visibleJobs, type Job } from "./CombinedReportPanel";
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    job_id: overrides.job_id ?? "job-1",
+    status: "done",
+    student_count: 41,
+    matched_count: 40,
+    missing_count: 1,
+    error: null,
+    download_url: "https://example.com/report.pdf",
+    created_at: "2026-08-21T18:22:39+05:30",
+    updated_at: "2026-08-21T18:25:00+05:30",
+    retry_count: 0,
+    ...overrides,
+  };
+}
+
+describe("visibleJobs", () => {
+  it("shows only the newest finished report, hiding superseded downloads", () => {
+    const jobs = [
+      makeJob({ job_id: "old-1", created_at: "2026-08-17T21:48:26+05:30" }),
+      makeJob({ job_id: "new", created_at: "2026-08-21T18:22:39+05:30" }),
+      makeJob({ job_id: "old-2", created_at: "2026-08-21T14:43:58+05:30" }),
+    ];
+
+    expect(visibleJobs(jobs).map((j) => j.job_id)).toEqual(["new"]);
+  });
+
+  it("keeps the last good report downloadable while a regenerate is in flight", () => {
+    const jobs = [
+      makeJob({ job_id: "prev-done", created_at: "2026-08-21T18:22:39+05:30" }),
+      makeJob({ job_id: "older-done", created_at: "2026-08-17T21:48:26+05:30" }),
+      makeJob({
+        job_id: "rebuild",
+        status: "processing",
+        download_url: null,
+        created_at: "2026-08-22T10:00:00+05:30",
+      }),
+    ];
+
+    expect(visibleJobs(jobs).map((j) => j.job_id)).toEqual(["rebuild", "prev-done"]);
+  });
+
+  it("keeps the last good report next to a failed rebuild", () => {
+    const jobs = [
+      makeJob({ job_id: "prev-done", created_at: "2026-08-21T18:22:39+05:30" }),
+      makeJob({
+        job_id: "failed",
+        status: "errored",
+        error: "boom",
+        download_url: null,
+        created_at: "2026-08-22T10:00:00+05:30",
+      }),
+    ];
+
+    expect(visibleJobs(jobs).map((j) => j.job_id)).toEqual(["failed", "prev-done"]);
+  });
+
+  it("shows a lone in-flight or failed job when nothing has finished yet", () => {
+    const jobs = [
+      makeJob({
+        job_id: "first-run",
+        status: "queued",
+        download_url: null,
+        created_at: "2026-08-22T10:00:00+05:30",
+      }),
+    ];
+
+    expect(visibleJobs(jobs).map((j) => j.job_id)).toEqual(["first-run"]);
+  });
+
+  it("returns nothing for no jobs", () => {
+    expect(visibleJobs([])).toEqual([]);
+  });
+});

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 type JobStatus = "queued" | "started" | "processing" | "done" | "errored";
 
-interface Job {
+export interface Job {
   job_id: string;
   status: JobStatus;
   student_count: number | null;
@@ -48,6 +48,25 @@ const STATUS_LABEL: Record<JobStatus, string> = {
 function formatTime(iso: string): string {
   const d = new Date(iso);
   return isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function createdAtMs(job: Job): number {
+  const t = new Date(job.created_at).getTime();
+  return isNaN(t) ? 0 : t;
+}
+
+// The rows worth showing: every regenerate produces a full replacement PDF, so
+// older finished runs are superseded — listing them invites downloading a stale
+// report. Show the newest run (whatever its state), plus the newest finished
+// report when the newest run isn't it, so the last good PDF stays downloadable
+// while a rebuild is queued/processing or after it fails.
+export function visibleJobs(jobs: Job[]): Job[] {
+  const sorted = [...jobs].sort((a, b) => createdAtMs(b) - createdAtMs(a));
+  const latest = sorted[0];
+  if (!latest) return [];
+  if (latest.status === "done") return [latest];
+  const latestDone = sorted.find((job) => job.status === "done");
+  return latestDone ? [latest, latestDone] : [latest];
 }
 
 export default function CombinedReportPanel({
@@ -213,7 +232,7 @@ export default function CombinedReportPanel({
         </p>
       ) : (
         <ul className="divide-y divide-border">
-          {jobs.map((job) => (
+          {visibleJobs(jobs).map((job) => (
             <li
               key={job.job_id}
               className="py-2 flex items-center justify-between gap-3 flex-wrap"

--- a/src/components/performance/CombinedReportPanel.tsx
+++ b/src/components/performance/CombinedReportPanel.tsx
@@ -55,11 +55,9 @@ function createdAtMs(job: Job): number {
   return isNaN(t) ? 0 : t;
 }
 
-// The rows worth showing: every regenerate produces a full replacement PDF, so
-// older finished runs are superseded — listing them invites downloading a stale
-// report. Show the newest run (whatever its state), plus the newest finished
-// report when the newest run isn't it, so the last good PDF stays downloadable
-// while a rebuild is queued/processing or after it fails.
+// Each regenerate fully replaces the PDF, so show only the newest run — plus
+// the newest finished one while a rebuild is in flight or failed, so the last
+// good download doesn't vanish.
 export function visibleJobs(jobs: Job[]): Job[] {
   const sorted = [...jobs].sort((a, b) => createdAtMs(b) - createdAtMs(a));
   const latest = sorted[0];


### PR DESCRIPTION
## Why

The Combined student reports panel lists every generation job ever run. After a few regenerates that's several stacked "Ready … Download" rows for the same test, and every regenerate produces a full replacement PDF — so all but the newest are superseded, and the extra rows invite downloading a stale report.

## What

- New `visibleJobs()` in `CombinedReportPanel.tsx`: render the newest run only.
- While a rebuild is queued/processing — or after it fails — also keep the newest finished report's row, so the last good PDF stays downloadable instead of disappearing mid-regenerate.
- Polling and the Generate/Regenerate button logic still consider all jobs (unchanged); only the rendered list narrows.
- Unit tests for the selection rule (5 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)