### PR TITLE
Read cumulative AL from dim_student instead of recomputing the mode

### DIFF
--- a/src/app/api/quiz-analytics/[udise]/cumulative-als/route.test.ts
+++ b/src/app/api/quiz-analytics/[udise]/cumulative-als/route.test.ts
@@ -87,8 +87,7 @@ describe("GET /api/quiz-analytics/[udise]/cumulative-als", () => {
           student_name: "Asha",
           stream: "PCM",
           total_major_tests: 2,
-          al_counts: { M1: 1, M2: 1 },
-          mode_al: "M1",
+          academic_level: "M1",
           progression: [
             { session_id: "t1", academic_level: "M2", marks_scored: 120, max_marks_possible: 300 },
             { session_id: "t2", academic_level: "M1", marks_scored: 210, max_marks_possible: 300 },

--- a/src/components/performance/CumulativeALTable.test.tsx
+++ b/src/components/performance/CumulativeALTable.test.tsx
@@ -21,8 +21,7 @@ const SAMPLE = {
       student_name: "Asha",
       stream: "PCM",
       total_major_tests: 3,
-      al_counts: { M1: 2, M2: 1 },
-      mode_al: "M1",
+      academic_level: "M1",
       progression: [
         { session_id: "s1", academic_level: "M2" },
         { session_id: "s2", academic_level: "M1" },
@@ -34,8 +33,7 @@ const SAMPLE = {
       student_name: "Bilal",
       stream: "PCM",
       total_major_tests: 2,
-      al_counts: { M1: 1, M2: 1 },
-      mode_al: "M1",
+      academic_level: "M1",
       progression: [
         { session_id: "s1", academic_level: "M2" },
         { session_id: "s3", academic_level: "M1" },
@@ -58,8 +56,7 @@ const MIXED_STREAM_SAMPLE = {
       student_name: "Asha",
       stream: "PCM",
       total_major_tests: 2,
-      al_counts: { M1: 1, M2: 1 },
-      mode_al: "M1",
+      academic_level: "M1",
       progression: [
         { session_id: "s1", academic_level: "M2" },
         { session_id: "s2", academic_level: "M1" },
@@ -70,8 +67,7 @@ const MIXED_STREAM_SAMPLE = {
       student_name: "Chen",
       stream: "PCB",
       total_major_tests: 2,
-      al_counts: { B1: 1, B2: 1 },
-      mode_al: "B1",
+      academic_level: "B1",
       progression: [
         { session_id: "c1", academic_level: "B2" },
         { session_id: "c2", academic_level: "B1" },
@@ -101,20 +97,20 @@ describe("CumulativeALTable", () => {
     expect(screen.getByText("Test Two")).toBeInTheDocument();
     expect(screen.getByText("Test Three")).toBeInTheDocument();
 
-    // Mode AL / Latest AL header columns are present
+    // AL / Latest AL header columns are present
     const headers = screen.getAllByRole("columnheader");
-    expect(headers.some((h) => /^Mode AL/.test(h.textContent || ""))).toBe(true);
+    expect(headers.some((h) => /^AL/.test(h.textContent || ""))).toBe(true);
     expect(headers.some((h) => /^Latest AL/.test(h.textContent || ""))).toBe(true);
 
     // Stream group heading (PCM/JEE/Engineering)
     expect(screen.getByRole("heading", { name: /PCM/ })).toBeInTheDocument();
 
     // Asha's row should contain three AL chips for the three tests (M2, M1, M1)
-    // plus the Mode AL (M1) and Latest AL (M1) chips → 5 chips total in the row
+    // plus the AL (M1) and Latest AL (M1) chips → 5 chips total in the row
     const ashaRow = screen.getByText("Asha").closest("tr")!;
     const m1Chips = within(ashaRow).getAllByText("M1");
     const m2Chips = within(ashaRow).getAllByText("M2");
-    expect(m1Chips.length).toBe(4); // s2 cell + s3 cell + mode + latest
+    expect(m1Chips.length).toBe(4); // s2 cell + s3 cell + AL + latest
     expect(m2Chips.length).toBe(1); // s1 cell only
   });
 
@@ -202,7 +198,7 @@ describe("CumulativeALTable", () => {
     render(<CumulativeALTable schoolUdise="12345" grade={11} />);
     await screen.findByText("Asha");
 
-    // Default sort: mode_al desc (Asha and Bilal both M1) → tie broken by tests desc → Asha (3) > Bilal (2)
+    // Default sort: AL desc (Asha and Bilal both M1) → tie broken by tests desc → Asha (3) > Bilal (2)
     let rows = screen.getAllByRole("row");
     expect(rows[1]).toHaveTextContent("Asha");
     expect(rows[2]).toHaveTextContent("Bilal");

--- a/src/components/performance/CumulativeALTable.tsx
+++ b/src/components/performance/CumulativeALTable.tsx
@@ -11,7 +11,7 @@ import type {
 } from "@/types/quiz";
 import {
   AL_DISPLAY_ORDER,
-  AL_RANK,
+  alRank,
   alChipColor,
   alShortLabel as shortLabel,
 } from "@/lib/academic-level";
@@ -187,16 +187,16 @@ export default function CumulativeALTable({ schoolUdise, grade, program, stream,
         case "tests":
           return dir * (a.total_major_tests - b.total_major_tests);
         case "al": {
-          const ar = a.academic_level ? AL_RANK[a.academic_level] ?? -1 : -1;
-          const br = b.academic_level ? AL_RANK[b.academic_level] ?? -1 : -1;
+          const ar = alRank(a.academic_level);
+          const br = alRank(b.academic_level);
           if (ar !== br) return dir * (ar - br);
           return dir * (a.total_major_tests - b.total_major_tests);
         }
         case "latest_al": {
           const al = latestAL(a.progression);
           const bl = latestAL(b.progression);
-          const ar = al ? AL_RANK[al] ?? -1 : -1;
-          const br = bl ? AL_RANK[bl] ?? -1 : -1;
+          const ar = alRank(al);
+          const br = alRank(bl);
           if (ar !== br) return dir * (ar - br);
           return dir * (a.total_major_tests - b.total_major_tests);
         }
@@ -349,7 +349,6 @@ function StreamMatrix({
                 <th
                   className="text-left px-3 py-2 text-xs font-bold uppercase tracking-wide text-text-muted cursor-pointer select-none"
                   onClick={() => toggleSort("al")}
-                  title="Academic Level from the warehouse (dim_student) — mode of the student's last three major tests"
                 >
                   AL{sortIndicator("al")}
                 </th>
@@ -401,7 +400,7 @@ function StreamMatrix({
                           {shortLabel(row.academic_level)}
                         </span>
                       ) : (
-                        <span className="text-xs text-text-muted" title="Not levelled in the warehouse yet">—</span>
+                        <span className="text-xs text-text-muted">—</span>
                       )}
                     </td>
                     <td className="px-3 py-2">

--- a/src/components/performance/CumulativeALTable.tsx
+++ b/src/components/performance/CumulativeALTable.tsx
@@ -41,7 +41,7 @@ function streamGroupLabel(canonical: string | null): string {
   return STREAM_DISPLAY[canonical] || canonical.toUpperCase();
 }
 
-type SortKey = "name" | "tests" | "mode_al" | "latest_al";
+type SortKey = "name" | "tests" | "al" | "latest_al";
 type SortDir = "asc" | "desc";
 
 function formatDate(iso: string): string {
@@ -131,7 +131,7 @@ export default function CumulativeALTable({ schoolUdise, grade, program, stream,
   const [data, setData] = useState<CumulativeALData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>("mode_al");
+  const [sortKey, setSortKey] = useState<SortKey>("al");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   useEffect(() => {
@@ -172,7 +172,7 @@ export default function CumulativeALTable({ schoolUdise, grade, program, stream,
     let totalTests = 0;
     for (const s of data.students) {
       totalTests += s.total_major_tests;
-      if (s.mode_al) counts[s.mode_al] = (counts[s.mode_al] || 0) + 1;
+      if (s.academic_level) counts[s.academic_level] = (counts[s.academic_level] || 0) + 1;
     }
     return { counts, totalStudents, totalTests };
   }, [data]);
@@ -186,9 +186,9 @@ export default function CumulativeALTable({ schoolUdise, grade, program, stream,
           return dir * a.student_name.localeCompare(b.student_name);
         case "tests":
           return dir * (a.total_major_tests - b.total_major_tests);
-        case "mode_al": {
-          const ar = a.mode_al ? AL_RANK[a.mode_al] ?? -1 : -1;
-          const br = b.mode_al ? AL_RANK[b.mode_al] ?? -1 : -1;
+        case "al": {
+          const ar = a.academic_level ? AL_RANK[a.academic_level] ?? -1 : -1;
+          const br = b.academic_level ? AL_RANK[b.academic_level] ?? -1 : -1;
           if (ar !== br) return dir * (ar - br);
           return dir * (a.total_major_tests - b.total_major_tests);
         }
@@ -255,7 +255,7 @@ export default function CumulativeALTable({ schoolUdise, grade, program, stream,
           <StatCard label="Students Tracked" value={summary.totalStudents} color="brand-gold" />
           <StatCard label="Major Tests Taken" value={summary.totalTests} color="brand-coral" />
           <StatCard
-            label="Mode AL Distribution"
+            label="AL Distribution"
             value={
               AL_DISPLAY_ORDER
                 .filter((al) => summary.counts[al])
@@ -348,9 +348,10 @@ function StreamMatrix({
                 </th>
                 <th
                   className="text-left px-3 py-2 text-xs font-bold uppercase tracking-wide text-text-muted cursor-pointer select-none"
-                  onClick={() => toggleSort("mode_al")}
+                  onClick={() => toggleSort("al")}
+                  title="Academic Level from the warehouse (dim_student) — mode of the student's last three major tests"
                 >
-                  Mode AL{sortIndicator("mode_al")}
+                  AL{sortIndicator("al")}
                 </th>
                 <th
                   className="text-left px-3 py-2 text-xs font-bold uppercase tracking-wide text-text-muted cursor-pointer select-none"
@@ -393,14 +394,14 @@ function StreamMatrix({
                       {row.total_major_tests}
                     </td>
                     <td className="px-3 py-2">
-                      {row.mode_al ? (
+                      {row.academic_level ? (
                         <span
-                          className={`inline-flex items-center px-2 py-0.5 text-xs font-bold uppercase tracking-wide rounded border ${alChipColor(row.mode_al)}`}
+                          className={`inline-flex items-center px-2 py-0.5 text-xs font-bold uppercase tracking-wide rounded border ${alChipColor(row.academic_level)}`}
                         >
-                          {shortLabel(row.mode_al)}
+                          {shortLabel(row.academic_level)}
                         </span>
                       ) : (
-                        <span className="text-xs text-text-muted">—</span>
+                        <span className="text-xs text-text-muted" title="Not levelled in the warehouse yet">—</span>
                       )}
                     </td>
                     <td className="px-3 py-2">

--- a/src/lib/academic-level.ts
+++ b/src/lib/academic-level.ts
@@ -6,6 +6,11 @@
 //
 // M and B tiers are parallel stream-specific scales — M for engineering (JEE),
 // B for medical (NEET) — not two rungs of one ladder.
+//
+// Two spellings of "not qualified" coexist: per-test rows in the fact table
+// say "Not Qualified", while the per-student dim_student.academic_level (dbt's
+// int_student_academic_level) writes it stream-specifically as M3 / B3. Same
+// tier, same colour.
 
 // Best (top tier) first. Used for legends and distribution charts.
 export const AL_DISPLAY_ORDER = [
@@ -13,6 +18,8 @@ export const AL_DISPLAY_ORDER = [
   "B1",
   "M2",
   "B2",
+  "M3",
+  "B3",
   "Not Qualified",
   "Not Eligible for Academic Level",
 ];
@@ -24,6 +31,8 @@ export const AL_RANK: Record<string, number> = {
   B1: 3,
   M2: 2,
   B2: 2,
+  M3: 1,
+  B3: 1,
   "Not Qualified": 1,
   "Not Eligible for Academic Level": 0,
 };
@@ -47,6 +56,8 @@ export function alChipColor(al: string): string {
     case "M2":
     case "B2":
       return "bg-success-bg/50 text-success/80 border-success/20";
+    case "M3":
+    case "B3":
     case "Not Qualified":
       return "bg-warning-bg text-warning border-warning/30";
     case "Not Eligible for Academic Level":

--- a/src/lib/academic-level.ts
+++ b/src/lib/academic-level.ts
@@ -48,6 +48,13 @@ export function alShortLabel(al: string): string {
   return AL_SHORT_LABEL[al] || al;
 }
 
+// Sort key for an AL that may be null/unknown: unlevelled or unrecognised
+// values rank below every known tier so they sort last.
+export function alRank(al: string | null | undefined): number {
+  if (!al) return -1;
+  return AL_RANK[al] ?? -1;
+}
+
 export function alChipColor(al: string): string {
   switch (al) {
     case "M1":

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -201,19 +201,22 @@ describe("getAvailableGrades / getAvailablePrograms", () => {
 });
 
 describe("getCumulativeALData", () => {
-  it("aggregates AL counts + per-test progression per student, sorts students by mode AL rank", async () => {
-    // Asha (PCM): M1 on s1, M2 on s2, M1 on s3 → al_counts {M1:2, M2:1}, mode M1
-    // Bilal (PCM): M2 on s1, M1 on s2 → al_counts {M1:1, M2:1}, mode M1 (tie broken by rank — M1 > M2)
-    // Chen (PCB): B2 on c1, B1 on c2, B1 on c3 → mode B1
+  it("takes each student's AL from dim_student and builds the per-test progression, sorting by AL rank", async () => {
+    // The per-student AL is whatever dim_student says (student_academic_level),
+    // NOT the mode of the per-test values — Bilal's tests are M2, M1 but the
+    // warehouse levels him M3 (last-three-tests rule upstream), and that wins.
+    // Asha (PCM): tests M1, M2, M1 → dim_student M1
+    // Bilal (PCM): tests M2, M1 → dim_student M3
+    // Chen (PCB): tests B2, B1, B1 → dim_student B1
     const rows = [
-      { student_id: "asha", student_name: "Asha", student_stream: "PCM", session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "M1" },
-      { student_id: "asha", student_name: "Asha", student_stream: "PCM", session_id: "s2", test_name: "T2", start_date: "2025-02-10", test_stream: "pcm", academic_level: "M2" },
-      { student_id: "asha", student_name: "Asha", student_stream: "PCM", session_id: "s3", test_name: "T3", start_date: "2025-03-10", test_stream: "pcm", academic_level: "M1" },
-      { student_id: "bilal", student_name: "Bilal", student_stream: "PCM", session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "M2" },
-      { student_id: "bilal", student_name: "Bilal", student_stream: "PCM", session_id: "s2", test_name: "T2", start_date: "2025-02-10", test_stream: "pcm", academic_level: "M1" },
-      { student_id: "chen", student_name: "Chen", student_stream: "PCB", session_id: "c1", test_name: "C1", start_date: "2025-01-10", test_stream: "pcb", academic_level: "B2" },
-      { student_id: "chen", student_name: "Chen", student_stream: "PCB", session_id: "c2", test_name: "C2", start_date: "2025-02-10", test_stream: "pcb", academic_level: "B1" },
-      { student_id: "chen", student_name: "Chen", student_stream: "PCB", session_id: "c3", test_name: "C3", start_date: "2025-03-10", test_stream: "pcb", academic_level: "B1" },
+      { student_id: "asha", student_name: "Asha", student_stream: "PCM", student_academic_level: "M1", session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "M1" },
+      { student_id: "asha", student_name: "Asha", student_stream: "PCM", student_academic_level: "M1", session_id: "s2", test_name: "T2", start_date: "2025-02-10", test_stream: "pcm", academic_level: "M2" },
+      { student_id: "asha", student_name: "Asha", student_stream: "PCM", student_academic_level: "M1", session_id: "s3", test_name: "T3", start_date: "2025-03-10", test_stream: "pcm", academic_level: "M1" },
+      { student_id: "bilal", student_name: "Bilal", student_stream: "PCM", student_academic_level: "M3", session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "M2" },
+      { student_id: "bilal", student_name: "Bilal", student_stream: "PCM", student_academic_level: "M3", session_id: "s2", test_name: "T2", start_date: "2025-02-10", test_stream: "pcm", academic_level: "M1" },
+      { student_id: "chen", student_name: "Chen", student_stream: "PCB", student_academic_level: "B1", session_id: "c1", test_name: "C1", start_date: "2025-01-10", test_stream: "pcb", academic_level: "B2" },
+      { student_id: "chen", student_name: "Chen", student_stream: "PCB", student_academic_level: "B1", session_id: "c2", test_name: "C2", start_date: "2025-02-10", test_stream: "pcb", academic_level: "B1" },
+      { student_id: "chen", student_name: "Chen", student_stream: "PCB", student_academic_level: "B1", session_id: "c3", test_name: "C3", start_date: "2025-03-10", test_stream: "pcb", academic_level: "B1" },
     ];
     mocks.mockQueryFn.mockResolvedValueOnce([rows]);
 
@@ -231,21 +234,52 @@ describe("getCumulativeALData", () => {
     const byId: Record<string, (typeof result.students)[number]> = {};
     for (const r of result.students) byId[r.student_id] = r;
 
-    expect(byId.asha.al_counts).toEqual({ M1: 2, M2: 1 });
     expect(byId.asha.total_major_tests).toBe(3);
-    expect(byId.asha.mode_al).toBe("M1");
+    expect(byId.asha.academic_level).toBe("M1");
     expect(byId.asha.stream).toBe("PCM");
     expect(byId.asha.progression.map((p) => p.academic_level)).toEqual(["M1", "M2", "M1"]);
 
-    expect(byId.bilal.mode_al).toBe("M1"); // tie broken by rank (M1 > M2)
+    // Warehouse value wins over any app-side mode of the per-test ALs.
+    expect(byId.bilal.academic_level).toBe("M3");
     expect(byId.bilal.progression.map((p) => p.academic_level)).toEqual(["M2", "M1"]);
 
-    expect(byId.chen.mode_al).toBe("B1");
+    expect(byId.chen.academic_level).toBe("B1");
     expect(byId.chen.progression.map((p) => p.academic_level)).toEqual(["B2", "B1", "B1"]);
 
-    // Mode AL rank ordering: B1, M1 are tier 3 (tie) → tie broken by total tests desc
-    // asha (3 tests) and chen (3 tests) before bilal (2 tests)
-    expect(result.students[result.students.length - 1].student_id).toBe("bilal");
+    // Rank ordering: M1/B1 (tier 3) → tie broken by total tests desc → then M3 (tier 1)
+    expect(result.students.map((s) => s.student_id)).toEqual(["asha", "chen", "bilal"]);
+    expect(result.students[0]).not.toHaveProperty("al_counts");
+    expect(result.students[0]).not.toHaveProperty("mode_al");
+  });
+
+  it("keeps students the warehouse has not levelled yet, with a null AL, sorted last", async () => {
+    // Dev has three M1 tests but no dim_student AL (post-hook not run / new
+    // student). We must not invent an AL for him from the per-test values.
+    const rows = [
+      { student_id: "dev", student_name: "Dev", student_stream: "PCM", student_academic_level: null, session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "M1" },
+      { student_id: "dev", student_name: "Dev", student_stream: "PCM", student_academic_level: null, session_id: "s2", test_name: "T2", start_date: "2025-02-10", test_stream: "pcm", academic_level: "M1" },
+      { student_id: "esha", student_name: "Esha", student_stream: "PCM", student_academic_level: "Not Eligible for Academic Level", session_id: "s1", test_name: "T1", start_date: "2025-01-10", test_stream: "pcm", academic_level: "Not Eligible for Academic Level" },
+    ];
+    mocks.mockQueryFn.mockResolvedValueOnce([rows]);
+
+    const { getCumulativeALData } = await import("./bigquery");
+    const result = await getCumulativeALData("11223344", 11);
+
+    expect(result.students.map((s) => s.student_id)).toEqual(["esha", "dev"]);
+    expect(result.students[1].academic_level).toBeNull();
+    expect(result.students[1].total_major_tests).toBe(2);
+  });
+
+  it("joins dim_student for the per-student AL instead of recomputing it", async () => {
+    mocks.mockQueryFn.mockResolvedValueOnce([[]]);
+
+    const { getCumulativeALData } = await import("./bigquery");
+    await getCumulativeALData("11223344", 11);
+
+    const sql = mocks.mockQueryFn.mock.calls[0][0].query;
+    expect(sql).toContain("production_dbt_final.dim_student");
+    expect(sql).toContain("ds.academic_level) AS student_academic_level");
+    expect(sql).toContain("ds.pk_student_id = f.fk_student_id");
   });
 
   it("excludes unsubmitted attempts from the AL matrix", async () => {
@@ -293,7 +327,7 @@ describe("getCumulativeALData", () => {
     expect(call.query).toContain("mock_test");
     expect(call.query).toContain("part_test");
     expect(call.query).toContain("full_syllabus_test");
-    expect(call.query).toContain("LOWER(section) = 'overall'");
+    expect(call.query).toContain("LOWER(f.section) = 'overall'");
     expect(call.query).toContain("LOWER(student_stream) = @stream");
     expect(call.query).toContain("session_id IS NOT NULL");
     expect(call.params).toMatchObject({ stream: "pcm", program: "JNV", grade: 11 });

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -263,9 +263,17 @@ function alRank(al: string | null | undefined): number {
 }
 
 /**
- * Per-student AL summary + per-test AL progression across all major-test
- * formats, in chronological order. Mode AL is the AL value that appears most
- * often for the student (ties broken by tier: M1/B1 > M2/B2 > NQ > NE).
+ * Per-student AL + per-test AL progression across all major-test formats, in
+ * chronological order.
+ *
+ * The per-student AL is NOT recomputed here — it is read from
+ * dim_student.academic_level, which dbt fills from int_student_academic_level
+ * (mode of the last three major tests per stream, Advanced tests excluded,
+ * "Not Qualified" expressed as M3/B3). Reading the canonical column keeps this
+ * table in step with every other consumer of dim_student and means rule
+ * changes land here without an app change. It is NULL for students the dbt
+ * model has not levelled yet; we surface that as null rather than falling
+ * back to an app-side estimate that would silently disagree with the warehouse.
  */
 export async function getCumulativeALData(
   udise: string,
@@ -287,33 +295,46 @@ export async function getCumulativeALData(
   if (testGrade != null) params.testGrade = testGrade;
 
   // One row per (student, session) — gives us both the test list (for the
-  // matrix columns) and per-student AL points.
+  // matrix columns) and per-test AL points. The student's own AL comes from
+  // dim_student via the join; the MERGE that writes it matches on
+  // pk_student_id, so every academic-year row of a student carries the same
+  // value and picking the current-year row is safe.
   const sql = `
     SELECT
-      fk_student_id AS student_id,
-      ANY_VALUE(student_full_name) AS student_name,
-      ANY_VALUE(student_stream) AS student_stream,
-      session_id,
-      ANY_VALUE(test_name) AS test_name,
-      MIN(start_date) AS start_date,
-      ANY_VALUE(test_stream) AS test_stream,
-      ANY_VALUE(academic_level) AS academic_level,
-      ANY_VALUE(marks_scored) AS marks_scored,
-      ANY_VALUE(max_marks_possible) AS max_marks_possible
-    FROM ${FACT_TABLE}
-    WHERE student_school_udise_code = @udise
-      AND student_grade = @grade
-      AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
-      AND LOWER(section) = 'overall'
-      AND test_format IN (${formatList})
-      AND academic_level IN (${alList})
-      AND fk_student_id IS NOT NULL
-      AND session_id IS NOT NULL
+      f.fk_student_id AS student_id,
+      ANY_VALUE(f.student_full_name) AS student_name,
+      ANY_VALUE(f.student_stream) AS student_stream,
+      ANY_VALUE(ds.academic_level) AS student_academic_level,
+      f.session_id,
+      ANY_VALUE(f.test_name) AS test_name,
+      MIN(f.start_date) AS start_date,
+      ANY_VALUE(f.test_stream) AS test_stream,
+      ANY_VALUE(f.academic_level) AS academic_level,
+      ANY_VALUE(f.marks_scored) AS marks_scored,
+      ANY_VALUE(f.max_marks_possible) AS max_marks_possible
+    FROM ${FACT_TABLE} f
+    LEFT JOIN (
+      SELECT pk_student_id, ANY_VALUE(academic_level) AS academic_level
+      FROM ${DIM_STUDENT_TABLE}
+      WHERE student_school_udise_code = @udise
+        AND student_grade = @grade
+        AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
+        AND academic_level IS NOT NULL
+      GROUP BY pk_student_id
+    ) ds ON ds.pk_student_id = f.fk_student_id
+    WHERE f.student_school_udise_code = @udise
+      AND f.student_grade = @grade
+      AND f.academic_year = '${CURRENT_ACADEMIC_YEAR}'
+      AND LOWER(f.section) = 'overall'
+      AND f.test_format IN (${formatList})
+      AND f.academic_level IN (${alList})
+      AND f.fk_student_id IS NOT NULL
+      AND f.session_id IS NOT NULL
       ${SUBMITTED_ONLY}
       ${programFilter}
       ${streamFilter}
       ${testGradeFilter}
-    GROUP BY fk_student_id, session_id
+    GROUP BY f.fk_student_id, f.session_id
     ORDER BY start_date ASC
   `;
 
@@ -322,6 +343,7 @@ export async function getCumulativeALData(
     student_id: string;
     student_name: string | null;
     student_stream: string | null;
+    student_academic_level: string | null;
     session_id: string;
     test_name: string;
     start_date: string;
@@ -345,7 +367,7 @@ export async function getCumulativeALData(
       student_id: string;
       student_name: string;
       student_stream: string | null;
-      al_counts: Record<string, number>;
+      academic_level: string | null;
       progression: ProgressionEntry[];
     }
   >();
@@ -370,10 +392,9 @@ export async function getCumulativeALData(
       student_id: r.student_id,
       student_name: r.student_name || r.student_id,
       student_stream: r.student_stream,
-      al_counts: {} as Record<string, number>,
+      academic_level: r.student_academic_level ?? null,
       progression: [] as ProgressionEntry[],
     };
-    existing.al_counts[r.academic_level] = (existing.al_counts[r.academic_level] || 0) + 1;
     existing.progression.push({
       session_id: r.session_id,
       academic_level: r.academic_level,
@@ -382,6 +403,8 @@ export async function getCumulativeALData(
     });
     if (!existing.student_name && r.student_name) existing.student_name = r.student_name;
     if (!existing.student_stream && r.student_stream) existing.student_stream = r.student_stream;
+    if (!existing.academic_level && r.student_academic_level)
+      existing.academic_level = r.student_academic_level;
     studentMap.set(r.student_id, existing);
   }
 
@@ -392,19 +415,6 @@ export async function getCumulativeALData(
 
   const students: CumulativeALRow[] = [];
   for (const v of studentMap.values()) {
-    let modeAl: string | null = null;
-    let modeCount = 0;
-    let modeRank = -1;
-    let total = 0;
-    for (const [al, count] of Object.entries(v.al_counts)) {
-      total += count;
-      const rank = alRank(al);
-      if (count > modeCount || (count === modeCount && rank > modeRank)) {
-        modeAl = al;
-        modeCount = count;
-        modeRank = rank;
-      }
-    }
     // Sort each student's progression by the global chronological order.
     v.progression.sort(
       (a, b) =>
@@ -416,17 +426,17 @@ export async function getCumulativeALData(
       student_id: v.student_id,
       student_name: v.student_name,
       stream: canonical ? streamDisplayLabel(canonical) : null,
-      total_major_tests: total,
-      al_counts: v.al_counts,
-      mode_al: modeAl,
+      total_major_tests: v.progression.length,
+      academic_level: v.academic_level,
       progression: v.progression,
     });
   }
 
-  // Sort students by mode AL rank desc, then by total tests desc, then name.
+  // Sort students by AL rank desc (unlevelled students last), then by total
+  // tests desc, then name.
   students.sort((a, b) => {
-    const ar = alRank(a.mode_al);
-    const br = alRank(b.mode_al);
+    const ar = alRank(a.academic_level);
+    const br = alRank(b.academic_level);
     if (ar !== br) return br - ar;
     if (a.total_major_tests !== b.total_major_tests)
       return b.total_major_tests - a.total_major_tests;

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -9,7 +9,7 @@ import type {
   StudentQuestionRow,
 } from "@/types/quiz";
 import { CURRENT_ACADEMIC_YEAR } from "@/lib/constants";
-import { AL_RANK } from "@/lib/academic-level";
+import { alRank } from "@/lib/academic-level";
 
 let bigQueryClient: BigQuery | null = null;
 
@@ -257,11 +257,6 @@ export async function getBatchOverviewData(
   };
 }
 
-function alRank(al: string | null | undefined): number {
-  if (!al) return -1;
-  return AL_RANK[al] ?? -1;
-}
-
 /**
  * Per-student AL + per-test AL progression across all major-test formats, in
  * chronological order.
@@ -296,9 +291,11 @@ export async function getCumulativeALData(
 
   // One row per (student, session) — gives us both the test list (for the
   // matrix columns) and per-test AL points. The student's own AL comes from
-  // dim_student via the join; the MERGE that writes it matches on
-  // pk_student_id, so every academic-year row of a student carries the same
-  // value and picking the current-year row is safe.
+  // dim_student via the join, keyed on student id alone: the dim row's
+  // denormalised school/grade can lag the fact rows, so filtering on them here
+  // would drop levelled students. A student can have more than one current-year
+  // dim row (the dbt MERGE also matches on enrollment_user_id / apaar_id), so
+  // pick deterministically with MAX rather than ANY_VALUE.
   const sql = `
     SELECT
       f.fk_student_id AS student_id,
@@ -314,11 +311,9 @@ export async function getCumulativeALData(
       ANY_VALUE(f.max_marks_possible) AS max_marks_possible
     FROM ${FACT_TABLE} f
     LEFT JOIN (
-      SELECT pk_student_id, ANY_VALUE(academic_level) AS academic_level
+      SELECT pk_student_id, MAX(academic_level) AS academic_level
       FROM ${DIM_STUDENT_TABLE}
-      WHERE student_school_udise_code = @udise
-        AND student_grade = @grade
-        AND academic_year = '${CURRENT_ACADEMIC_YEAR}'
+      WHERE academic_year = '${CURRENT_ACADEMIC_YEAR}'
         AND academic_level IS NOT NULL
       GROUP BY pk_student_id
     ) ds ON ds.pk_student_id = f.fk_student_id
@@ -392,7 +387,7 @@ export async function getCumulativeALData(
       student_id: r.student_id,
       student_name: r.student_name || r.student_id,
       student_stream: r.student_stream,
-      academic_level: r.student_academic_level ?? null,
+      academic_level: r.student_academic_level,
       progression: [] as ProgressionEntry[],
     };
     existing.progression.push({
@@ -403,8 +398,6 @@ export async function getCumulativeALData(
     });
     if (!existing.student_name && r.student_name) existing.student_name = r.student_name;
     if (!existing.student_stream && r.student_stream) existing.student_stream = r.student_stream;
-    if (!existing.academic_level && r.student_academic_level)
-      existing.academic_level = r.student_academic_level;
     studentMap.set(r.student_id, existing);
   }
 

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -57,9 +57,10 @@ export interface CumulativeALRow {
   student_name: string;
   stream: string | null;
   total_major_tests: number;
-  // Counts of each AL value across major tests for this student.
-  al_counts: Record<string, number>;
-  mode_al: string | null;
+  // The student's canonical AL from dim_student.academic_level (dbt-computed:
+  // mode of the last three major tests per stream; M3/B3 = not qualified).
+  // Null when the warehouse has not levelled the student yet.
+  academic_level: string | null;
   // Per-test AL points in chronological order. Useful when summarising trend
   // (most recent vs earliest) without consulting the test list.
   progression: ProgressionEntry[];


### PR DESCRIPTION
## What

The Performance tab's **Cumulative AL** table computed each student's AL in app code as the mode of their per-test ALs across every major test this year. The warehouse already holds the canonical per-student value in `dim_student.academic_level`, written by dbt's `int_student_academic_level` (mode of the **last three** major tests per stream, Advanced tests excluded, not-qualified written as **M3 / B3**).

This PR reads that column via a `LEFT JOIN` in `getCumulativeALData`, so the LMS agrees with every other consumer of dim_student and picks up rule changes without an app change.

## Changes

- `src/lib/bigquery.ts` — fact query LEFT JOINs a dim_student subquery (current year, keyed on student id only, `MAX(academic_level)` per student). Mode computation removed. Fact columns qualified with `f.`.
- `src/types/quiz.ts` — `CumulativeALRow.mode_al` → `academic_level`; `al_counts` dropped (only tests read it).
- `src/lib/academic-level.ts` — M3/B3 added to display order, rank (tier 1, same as "Not Qualified") and chip colour. Shared with Student Results, so its legend gains two chips.
- `CumulativeALTable.tsx` — header "Mode AL" → "AL" with a source tooltip; tile "AL Distribution"; unlevelled students show "—" and sort last.
- Tests updated; new tests assert the warehouse value wins over the per-test mode, null AL sorts last, and the join is present.

## Behaviour changes to be aware of (inherited from dbt, not introduced here)

- **CLAT / CA students show "—"**: dbt only levels `engineering` / `medical` test streams. At UDISE 1104262 grade 11, 156 of 259 students with major tests are CLAT/CA-only; they used to show NE.
- **Ties break toward the worse tier**: dbt orders tied frequencies by string (`final_academic_level DESC`), so M2 beats M1 and M3 beats M2. The old app-side mode broke ties toward the better tier. Roughly 6,700 student-stream pairs on 2025-26 data differ between the two rules, so some students will visibly drop a tier on rollout.
- **Dual-stream students get the engineering AL**: `academic_level = COALESCE(eng, med)`, so a student in the medical matrix can carry an M-tier chip.
- If the dbt post-hook has not yet back-filled the column after a `dim_student` rebuild, every student shows "—" until it does. There is deliberately no fallback to the old app-side mode.

## Verification

- `vitest`: 44 tests pass across the affected suites; `eslint` clean; no new `tsc` errors in changed files.
- The generated SQL was run against BigQuery for UDISE 1104262 grade 11 and returns sensible per-student ALs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

