### PR TITLE
fix(search): resolve centre confinement first via a MATERIALIZED CTE

### DIFF
--- a/src/app/api/students/search/route.test.ts
+++ b/src/app/api/students/search/route.test.ts
@@ -120,9 +120,15 @@ describe("GET /api/students/search", () => {
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     // Scoped to seat centres via the membership view, so search results and the
     // roster the user can actually open agree.
-    expect(sql).toContain("JOIN centre_students cs ON cs.user_id = u.id");
+    expect(sql).toContain("FROM centre_students cs");
     expect(sql).toContain("cs.centre_id = ANY($3::int[])");
+    expect(sql).toContain("JOIN scoped ON scoped.user_id = u.id");
     expect(params).toEqual(["%test%", CURRENT_ACADEMIC_YEAR, [8, 11]]);
+    // The scope is resolved first as a MATERIALIZED CTE — without it the planner
+    // drives from the ILIKEs over every user and a no-match term runs 40s on
+    // prod (past the 15s statement_timeout). The CTE must precede the SELECT.
+    expect(sql).toMatch(/^\s*WITH scoped AS MATERIALIZED \(/);
+    expect(sql.indexOf("WITH scoped")).toBeLessThan(sql.indexOf("SELECT DISTINCT"));
     // The school-code predicate must NOT also be applied — it would be the wider
     // scope, and leaving it in invites reading this as school-scoped.
     expect(sql).not.toContain("sch.code = ANY");
@@ -140,6 +146,7 @@ describe("GET /api/students/search", () => {
 
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("cs.centre_id = ANY($3::int[])");
+    expect(sql).toContain("JOIN scoped ON scoped.user_id = u.id");
     expect(params).toEqual(["%test%", CURRENT_ACADEMIC_YEAR, [8]]);
   });
 });

--- a/src/app/api/students/search/route.ts
+++ b/src/app/api/students/search/route.ts
@@ -67,6 +67,7 @@ export async function GET(request: NextRequest) {
   // own. Only these composed fragments are constant SQL — every value stays a
   // bound parameter.
   const params: unknown[] = [searchPattern, CURRENT_ACADEMIC_YEAR];
+  let scopeCte = "";
   let scopeJoin = "";
   const scopeConditions = [schoolScope];
 
@@ -74,17 +75,31 @@ export async function GET(request: NextRequest) {
     // centre_students is the membership source of truth this task added, and the
     // same one the centre roster page reads — so search results and the roster a
     // confined user can actually open cannot disagree.
+    //
+    // Resolved FIRST, in a MATERIALIZED CTE. Joined inline, the planner started
+    // from the five ILIKEs over every user (~570k) and probed the view's batch
+    // attribution per candidate; a term with a match let LIMIT 20 stop it early,
+    // a term with none ran to the end — 40s on prod for one centre, past the
+    // 15s statement_timeout, so the search 500'd. Pinning the seat centres'
+    // students (a few hundred rows) as the driving set makes the search a scan
+    // over them: 0.24s for one centre, 0.45s with every active centre in scope.
+    // MATERIALIZED is load-bearing — inlined, PG is back to the flat plan.
     params.push(confinement.centreIds);
-    scopeJoin = `JOIN centre_students cs ON cs.user_id = u.id
-        AND cs.academic_year = $2
-        AND cs.centre_id = ANY($${params.length}::int[])`;
+    scopeCte = `WITH scoped AS MATERIALIZED (
+        SELECT DISTINCT cs.user_id
+        FROM centre_students cs
+        WHERE cs.academic_year = $2
+          AND cs.centre_id = ANY($${params.length}::int[])
+      )`;
+    scopeJoin = "JOIN scoped ON scoped.user_id = u.id";
   } else if (schoolCodes !== "all") {
     params.push(schoolCodes);
     scopeConditions.push(`sch.code = ANY($${params.length})`);
   }
 
   const results = await query<StudentSearchResult>(
-    `SELECT DISTINCT
+    `${scopeCte}
+      SELECT DISTINCT
         u.id as user_id,
         u.first_name,
         u.last_name,


### PR DESCRIPTION
Follow-up to #227 — af_lms#309 item 1.

## Problem
`/api/students/search` for a centre-confined user joined `centre_students` inline. The planner drove the query from the five `ILIKE`s over every user (~570k) and probed the view's batch attribution per candidate. A term with a match let `LIMIT 20` stop it early; a term with **no** match ran to the end — **40.4s on prod** for one centre (JNV Nellore CoE), past the 15s `statement_timeout`, so the endpoint 500'd. Staging, with less data, planned it differently and never showed it.

## Fix
Resolve the seat centres' students first in a `WITH scoped AS MATERIALIZED (…)` CTE and join the rest onto it. `MATERIALIZED` is load-bearing — inlined, PG is back to the flat plan. Parameter positions are unchanged and the CTE is empty for non-confined users, so their query is byte-identical.

## Measured on prod (same no-match term)
| | one centre | all 55 active centres |
|---|---|---|
| before | 40.4s | — |
| after | 0.24s | 0.45s |

The matching term returns the same 15 rows as before.

## Tests
`route.test.ts` now asserts the CTE precedes the `SELECT` and the scoped join is present in both confined cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd19T3wHa7zZGLQMZ1sAdG
