### PR TITLE
fix(dashboard): list only JNV schools on the JNV NVS Schools tab

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -555,6 +555,52 @@ describe("DashboardPage (server component)", () => {
     }
   });
 
+  // --- School visibility scope per tab ---
+
+  // Only JNV schools have NVS-attributed students. Centre-linked non-JNV schools
+  // (EMRS, RSMS, the Maharashtra coaching centres…) showed on this tab as
+  // permanent 0-student cards; their home is the Centres tab.
+  it("lists only JNV schools on the JNV NVS tab", async () => {
+    setupPM();
+
+    const jsx = await DashboardPage({
+      searchParams: Promise.resolve({ view: "jnv-nvs" }),
+    });
+    render(jsx);
+
+    const [listSql] = mockQuery.mock.calls[0] as [string];
+    const [countSql] = mockQuery.mock.calls[1] as [string];
+    for (const sql of [listSql, countSql]) {
+      expect(sql).toContain("s.af_school_category = 'JNV'");
+      expect(sql).not.toContain("FROM centres c WHERE c.school_id = s.id");
+    }
+  });
+
+  // The header's scope count on the Centres tab still counts centre-linked
+  // schools, so a Punjab CoE PM with no JNV school does not read "0 school(s)".
+  it("keeps centre-linked schools in the header count on the Centres tab", async () => {
+    mockGetServerSession.mockResolvedValue(teacherSession);
+    mockGetUserPermission.mockResolvedValue(teacherPermission);
+    mockGetProgramContextSync.mockReturnValue(defaultProgramContext);
+    mockGetFeatureAccess.mockReturnValue({ canView: false, canEdit: false });
+    mockGetAccessibleSchoolCodes.mockResolvedValue(["SC001", "SC002"]);
+    mockQuery
+      .mockResolvedValueOnce([]) // centre counts
+      .mockResolvedValueOnce([]) // schools
+      .mockResolvedValueOnce([{ total: "2" }]); // count
+
+    const jsx = await DashboardPage({
+      searchParams: Promise.resolve({ view: "centres" }),
+    });
+    render(jsx);
+
+    const schoolCalls = mockQuery.mock.calls.slice(1) as [string][];
+    expect(schoolCalls).toHaveLength(2);
+    for (const [sql] of schoolCalls) {
+      expect(sql).toContain("FROM centres c WHERE c.school_id = s.id AND c.is_active");
+    }
+  });
+
   // --- Permission level subtitle ---
 
   it("shows 'Admin access' for level 4", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -92,10 +92,23 @@ function schoolQueryPlan(codes: string[] | "all", searchPattern: string | null, 
   };
 }
 
+// Which schools a dashboard query may see.
+//  - "jnv":           JNV schools only. The JNV NVS Schools tab is the scope of
+//                     NVS-attributed students, and only JNV schools have any;
+//                     the ten non-JNV centre-linked schools (EMRS, RSMS, GPUC,
+//                     RGNV, the Maharashtra coaching centres) rendered there as
+//                     permanent 0-student cards. They belong on the Centres tab,
+//                     where their centre card already lists them.
+//  - "centre-linked": JNV plus any school linked to an active centre — the
+//                     header's "your scope" count on the Centres tab, which
+//                     must keep counting a Punjab CoE PM's schools.
+type SchoolScope = "jnv" | "centre-linked";
+
 async function getSchools(
   codes: string[] | "all",
-  search?: string,
-  page: number = 1
+  search: string | undefined,
+  page: number,
+  schoolScope: SchoolScope,
 ): Promise<SchoolsResult> {
   const searchPattern = search ? `%${search}%` : null;
   const offset = (page - 1) * SCHOOLS_PER_PAGE;
@@ -110,10 +123,11 @@ async function getSchools(
   // work was almost entirely wasted. MATERIALIZED is load-bearing: without it
   // PG inlines the CTE and we are back to the flat plan.
   //
-  // School visibility scope: the historical JNV set PLUS any school linked to an
-  // active centre. Centre-linked covers the non-JNV centre rollout (Punjab CoE
-  // meritorious / EMRS / Karnataka) without disturbing JNV. Centre-driven, not a
-  // category allowlist — new centre types light up by linking a centre.
+  // School visibility scope: the historical JNV set, PLUS — for "centre-linked"
+  // — any school linked to an active centre. Centre-linked covers the non-JNV
+  // centre rollout (Punjab CoE meritorious / EMRS / Karnataka) without
+  // disturbing JNV. Centre-driven, not a category allowlist — new centre types
+  // light up by linking a centre. See SchoolScope for which tab wants which.
   //
   // Dedup stopgap: a stale bulk import left a second JNV row (null udise_code,
   // 0 students) for ~190 schools, so they double-listed. Exclude a row only when
@@ -126,13 +140,16 @@ async function getSchools(
   // matches JNV rows, and every JNV row is in `visible` by the first scope
   // branch, so the result is identical (verified against prod — both forms
   // return the same 688 ids, zero difference either way).
+  const centreLinkedClause = schoolScope === "centre-linked"
+    ? "OR EXISTS (SELECT 1 FROM centres c WHERE c.school_id = s.id AND c.is_active)"
+    : "";
   const visibleSchoolsCte = `
     WITH visible AS MATERIALIZED (
       SELECT s.id, s.code, s.name, s.district, s.state, s.region,
              s.udise_code, s.af_school_category
       FROM school s
       WHERE s.af_school_category = 'JNV'
-         OR EXISTS (SELECT 1 FROM centres c WHERE c.school_id = s.id AND c.is_active)
+         ${centreLinkedClause}
     )`;
 
   // Aliased `visible` AS s so the shared schoolQueryPlan predicates (s.name,
@@ -352,7 +369,7 @@ async function loadDashboardData({
       ),
       // No searchQuery: on this tab the term filters CENTRES, while this count is
       // the header's "your scope" figure and drives no pagination here.
-      getSchools(schoolCodes, undefined, currentPage),
+      getSchools(schoolCodes, undefined, currentPage, "centre-linked"),
     ]);
     return {
       schools: [],
@@ -364,7 +381,7 @@ async function loadDashboardData({
   }
 
   const [{ schools, totalCount }, recentVisits] = await Promise.all([
-    getSchools(schoolCodes, searchQuery, currentPage),
+    getSchools(schoolCodes, searchQuery, currentPage, "jnv"),
     hasPMAccess ? getRecentVisits(email) : Promise.resolve([] as Visit[]),
   ]);
   // NVS-attributed counts, not whole-school — keeps this tab disjoint from Centres.


### PR DESCRIPTION
Follow-up to #227 — af_lms#309 item 2.

## Problem
The JNV NVS Schools tab reused the dashboard-wide visibility scope, *JNV OR linked to an active centre*. That scope predates the tabs: it was how the non-JNV centre rollout (Punjab CoE meritorious, EMRS, Karnataka) reached the single school grid. Once that grid became the NVS tab, ten non-JNV schools sat there as permanent 0-student cards — EMRS Bhopal/Kundra, RSMS Bathinda/SAS Nagar, GPUC Shimoga, RGNV Raipur, and the four Maharashtra coaching centres. Only JNV schools have NVS-attributed students; their home is the Centres tab, whose centre cards already list them.

## Fix
`getSchools` takes the scope explicitly:
- `"jnv"` for the NVS tab's list and count
- `"centre-linked"` for the header's scope figure on the Centres tab, which must keep counting a Punjab CoE PM's schools

The school detail page and student search keep their own wider predicates — no access is removed.

## Behaviour note
A non-seated PM whose schools are all non-JNV centre-linked now sees an empty NVS tab with "0 school(s)" in the header; the Centres tab shows their real count. Follows from the design; flagging in case we'd rather default such users to the Centres tab.

## Tests
Two added in `page.test.tsx`: the NVS tab's list/count SQL excludes the centre-linked clause; the Centres tab's header count keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd19T3wHa7zZGLQMZ1sAdG
