### PR TITLE
Pin NODE_ENV and TZ in vitest config so the local suite matches CI

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 
+// Freeze the timezone before any Date is constructed in a worker. Date-only
+// strings ("2011-03-20") parse as UTC midnight, so formatting them in a
+// UTC-behind zone (America/New_York) yields the previous day and the
+// DOB/formatDate assertions fail on a clean checkout. Production users are in
+// IST, so tests assert the IST-observed behaviour.
+process.env.TZ = "Asia/Kolkata";
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -10,6 +17,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    // Vitest only defaults NODE_ENV to "test" when the shell hasn't set it, so
+    // a shell exporting NODE_ENV=development silently turns ~25 tests red
+    // (Toast renders inline only under NODE_ENV==="test"). Pin it.
+    env: { NODE_ENV: "test" },
     setupFiles: ["./src/test-setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     exclude: ["node_modules", "e2e"],


### PR DESCRIPTION
## Summary
Two environment leaks made the unit suite untrustworthy as a pre-push gate on a clean checkout:

- **NODE_ENV**: vitest only defaults it to `test` when the shell has not set it. A shell exporting `NODE_ENV=development` turned 25 tests red locally (Toast renders inline only under `NODE_ENV==="test"`) while CI stayed green. `test.env` now pins it.
- **TZ**: date-only strings (`"2011-03-20"`) parse as UTC midnight, so `formatDate` and the StudentTable DOB assertions rendered the previous day in any UTC-behind zone. `process.env.TZ` is frozen to `Asia/Kolkata` before the workers fork. Production users are in IST, so the tests assert the IST-observed behaviour.

Config-only change; no test or source file touched. Closes DEBT D58 and D131.

## Test plan
- [x] `NODE_ENV=development TZ=America/New_York npx vitest run`: before 27 failed / 9 files, after 262 files, 3554 tests pass.
- [x] Plain `npx vitest run` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxmATXTV3p2sZMJ2NuPLiR