### PR TITLE
ui/Select: default to w-full like ui/Input

### DIFF
--- a/src/app/admin/batches/BatchList.tsx
+++ b/src/app/admin/batches/BatchList.tsx
@@ -147,7 +147,7 @@ export default function BatchList({
           value={selectedProgramId}
           onChange={(e) => handleProgramChange(Number(e.target.value))}
           disabled={loading}
-          className="max-w-md w-full"
+          className="max-w-md"
         >
           {programs.map((program) => (
             <option key={program.id} value={program.id}>

--- a/src/app/admin/centres/CentreGrid.tsx
+++ b/src/app/admin/centres/CentreGrid.tsx
@@ -959,7 +959,7 @@ function FilterSelect<T extends CentreBooleanFilter | CentreSchoolLinkFilter>({
       <Select
         value={value}
         onChange={(event) => onChange(event.target.value as T)}
-        className="mt-1 w-full"
+        className="mt-1"
       >
         {options.map(([code, optionLabel]) => (
           <option key={code} value={code}>

--- a/src/app/admin/schools/SchoolList.tsx
+++ b/src/app/admin/schools/SchoolList.tsx
@@ -154,6 +154,7 @@ export default function SchoolList({ initialSchools }: SchoolListProps) {
           <Select
             value={programFilter}
             onChange={(e) => setProgramFilter(e.target.value === "all" ? "all" : Number(e.target.value))}
+            className="max-w-xs"
           >
             <option value="all">All Programs</option>
             <option value="1">CoE only</option>

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -859,7 +859,6 @@ export default function StaffGrid({
                       value={subjectDraft}
                       onChange={(event) => setSubjectDraft(event.target.value)}
                       aria-label="Subject"
-                      className="w-full"
                     >
                       <option value="">Select Subject…</option>
                       {subjects.map((subject) => (
@@ -879,7 +878,6 @@ export default function StaffGrid({
                         setCreateCentreDraft(event.target.value)
                       }
                       aria-label="Centre"
-                      className="w-full"
                     >
                       <option value="">Select Centre…</option>
                       {centres.map((centre) => (

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -348,7 +348,7 @@ export default function PerformanceTab({ schoolUdise, lockedProgram }: Props) {
               <label className="text-xs font-bold uppercase tracking-wide text-text-muted">
                 Test Grade
               </label>
-              <Select value={selectedTestGrade ?? ""} onChange={handleTestGradeChange}>
+              <Select value={selectedTestGrade ?? ""} onChange={handleTestGradeChange} className="max-w-xs">
                 <option value="">All test grades</option>
                 {availableTestGrades.map((g) => (
                   <option key={g} value={g}>

--- a/src/components/holistic-mentorship/AdminSchoolRoster.tsx
+++ b/src/components/holistic-mentorship/AdminSchoolRoster.tsx
@@ -178,14 +178,14 @@ function RosterFilters({ search, grade, assignment, onSearchChange, onGradeChang
     </label>
     <label className="block text-[11px] font-extrabold uppercase tracking-wide text-text-muted">
       Grade
-      <Select aria-label="Filter by Grade" className="mt-1 w-full" value={grade}
+      <Select aria-label="Filter by Grade" className="mt-1" value={grade}
         onChange={(event) => onGradeChange(event.target.value)}>
         <option value="">All Grades</option><option value="11">Grade 11</option><option value="12">Grade 12</option>
       </Select>
     </label>
     <label className="block text-[11px] font-extrabold uppercase tracking-wide text-text-muted">
       Assignment
-      <Select aria-label="Filter by Assignment" className="mt-1 w-full" value={assignment}
+      <Select aria-label="Filter by Assignment" className="mt-1" value={assignment}
         onChange={(event) => onAssignmentChange(event.target.value as AssignmentFilter)}>
         <option value="all">All Students</option><option value="assigned">Assigned</option><option value="unassigned">Unassigned</option>
       </Select>
@@ -226,7 +226,7 @@ function MentorSelectField({ label, mentors, value, excludedUserId, onChange }: 
     : mentors.filter((mentor) => mentor.userId !== excludedUserId);
   return <label className="block text-sm font-bold text-text-primary">
     {label}
-    <Select aria-label={label} className="mt-1 w-full" value={value}
+    <Select aria-label={label} className="mt-1" value={value}
       onChange={(event) => onChange(event.target.value)}>
       <option value="">Select an eligible Mentor</option>
       {options.map((mentor) => <option key={mentor.userId} value={mentor.userId}>

--- a/src/components/holistic-mentorship/HolisticMentorshipWorkspace.tsx
+++ b/src/components/holistic-mentorship/HolisticMentorshipWorkspace.tsx
@@ -55,7 +55,7 @@ function AdminSelectors({ selectedProgramId, availableProgramIds, academicYear, 
   return <div className="grid gap-3 rounded-md border border-border bg-bg-card p-4 sm:grid-cols-[minmax(0,1fr)_12rem]">
     <label className="block min-w-0 text-[11px] font-extrabold uppercase tracking-wide text-text-muted">
       Program
-      <Select aria-label="Program" className="mt-1 w-full font-normal normal-case tracking-normal"
+      <Select aria-label="Program" className="mt-1 font-normal normal-case tracking-normal"
         value={selectedProgramId} onChange={(event) => onProgramChange(Number(event.target.value))}>
         {availableProgramIds.map((id) => <option key={id} value={id}>
           {id} - {PROGRAM_ID_TO_LABEL[id]}
@@ -64,7 +64,7 @@ function AdminSelectors({ selectedProgramId, availableProgramIds, academicYear, 
     </label>
     <label className="block min-w-0 text-[11px] font-extrabold uppercase tracking-wide text-text-muted">
       Academic Year
-      <Select aria-label="Academic Year" className="mt-1 w-full font-mono font-normal normal-case tracking-normal"
+      <Select aria-label="Academic Year" className="mt-1 font-mono font-normal normal-case tracking-normal"
         value={academicYear} onChange={(event) => onAcademicYearChange(event.target.value)}>
         {academicYears.map((year) => <option key={year}>{year}</option>)}
       </Select>

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -10,7 +10,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <select
         ref={ref}
-        className={`min-h-[44px] ${baseInputClasses} ${className}`}
+        className={`w-full min-h-[44px] ${baseInputClasses} ${className}`}
         {...props}
       />
     );

--- a/src/components/visits/ClassroomObservationContextFields.tsx
+++ b/src/components/visits/ClassroomObservationContextFields.tsx
@@ -195,7 +195,6 @@ function CurriculumField({
       <Select
         value={selectedCurriculumId !== null ? String(selectedCurriculumId) : ""}
         onChange={onChange}
-        className="w-full"
         data-testid="curriculum-select"
       >
         <option value="" disabled>
@@ -251,7 +250,6 @@ function ChapterField({
       <Select
         value={selectedChapterId !== null ? String(selectedChapterId) : ""}
         onChange={onChange}
-        className="w-full"
         data-testid="chapter-select"
         disabled={chapters.length === 0}
       >
@@ -303,7 +301,6 @@ function TopicField({
         <Select
           value={selectedTopicId !== null ? String(selectedTopicId) : ""}
           onChange={onChange}
-          className="w-full"
           data-testid="topic-select"
           disabled={topics.length === 0}
         >

--- a/src/components/visits/ClassroomObservationForm.tsx
+++ b/src/components/visits/ClassroomObservationForm.tsx
@@ -209,7 +209,6 @@ export default function ClassroomObservationForm({
               <Select
                 value={selectedTeacherId !== null ? String(selectedTeacherId) : ""}
                 onChange={handleTeacherChange}
-                className="w-full"
                 data-testid="teacher-select"
               >
                 <option value="" disabled>
@@ -238,7 +237,6 @@ export default function ClassroomObservationForm({
             <Select
               value={selectedGrade ?? ""}
               onChange={handleGradeChange}
-              className="w-full"
               data-testid="grade-select"
             >
               <option value="" disabled>

--- a/src/components/visits/GroupStudentDiscussionForm.tsx
+++ b/src/components/visits/GroupStudentDiscussionForm.tsx
@@ -133,7 +133,6 @@ export default function GroupStudentDiscussionForm({
           value={grade ?? ""}
           onChange={(e) => handleGradeChange(e.target.value)}
           disabled={disabled}
-          className="w-full"
           data-testid="group-student-grade-select"
         >
           <option value="" disabled>


### PR DESCRIPTION
## Summary
Native selects size to their longest option, so every `Select` call site had to remember `className="w-full"`, and the ones that forgot rendered as misaligned form fields (staff Add User modal, 2026-08-13). `Select` now carries `w-full` itself, matching `Input`.

Sweep of the 44 call sites:
- 14 redundant `w-full` overrides removed (visits forms, StaffGrid, CentreGrid, BatchList, and — after merging main on 2026-09-07 — the five holistic-mentorship selects from #289), each confirmed to sit on a `Select`.
- The two filter-bar selects beside fixed-width inputs (SchoolList program filter, PerformanceTab test grade) get `max-w-xs` so the bar does not stretch.
- Everything else already wanted full width.

Visual change only. Closes DEBT D118.

## Test plan
- [x] `vitest run` 261 files green; eslint clean; no non-test tsc errors
- [ ] Glance at /admin/staff filter row and /admin/schools on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxmATXTV3p2sZMJ2NuPLiR
