### PR TITLE
Performance missing in Bangalore South

### DIFF
--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -309,6 +309,7 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
       // runs; throw there too so the overall result is null.
       mocks.mockSend
         .mockRejectedValueOnce(new Error("DynamoDB timeout"))
+        .mockRejectedValueOnce(new Error("DynamoDB timeout"))
         .mockRejectedValueOnce(new Error("DynamoDB timeout"));
 
       const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -321,11 +322,12 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
       expect(result).toBeNull();
     });
 
-    it("returns null when both GSI and fallback come back empty", async () => {
+    it("returns null when the GSI and both partition scans come back empty", async () => {
       mocks.mockQuery.mockResolvedValueOnce([makeStudent()]);
       mocks.mockSend
         .mockResolvedValueOnce({ Items: [] }) // gsi
-        .mockResolvedValueOnce({ Items: [] }); // fallback
+        .mockResolvedValueOnce({ Items: [] }) // filtered partition scan
+        .mockResolvedValueOnce({ Items: [] }); // unfiltered partition scan
 
       const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { getTestDeepDiveFromDynamo } = await importModule();
@@ -333,6 +335,107 @@ describe("getTestDeepDiveFromDynamo (v2)", () => {
       consoleWarn.mockRestore();
 
       expect(result).toBeNull();
+    });
+
+    // Regression: a school rename leaves the v2 docs stamped with the OLD name
+    // (they are never re-stamped), so both school-scoped reads return nothing
+    // and every historical test 404s. The unfiltered partition scan recovers
+    // them; the identifier intersection still scopes to this school's roster.
+    it("recovers docs via an unfiltered partition scan when the school name has drifted", async () => {
+      const { QueryCommand } = await import("@aws-sdk/lib-dynamodb");
+      const qcMock = QueryCommand as unknown as { mock: { calls: unknown[][] } };
+      const callsBefore = qcMock.mock.calls.length;
+
+      mocks.mockQuery.mockResolvedValueOnce([makeStudent()]);
+      mocks.mockSend
+        .mockResolvedValueOnce({ Items: [] }) // gsi: nothing under the new name
+        .mockResolvedValueOnce({ Items: [] }) // filtered scan: filter excludes them
+        .mockResolvedValueOnce({ Items: [makeV2Doc({ school: "JNV Ramanagara" })] });
+
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo(
+        "school-1",
+        "JNV Bangalore South",
+        10,
+        "sess-1"
+      );
+      consoleWarn.mockRestore();
+
+      expect(result).not.toBeNull();
+      expect(result?.students).toHaveLength(1);
+      expect(mocks.mockSend).toHaveBeenCalledTimes(3);
+
+      const thisRunCalls = qcMock.mock.calls.slice(callsBefore);
+      const lastCall = thisRunCalls[thisRunCalls.length - 1][0] as {
+        IndexName?: string;
+        FilterExpression?: string;
+        KeyConditionExpression: string;
+        ExpressionAttributeValues: Record<string, unknown>;
+      };
+      expect(lastCall.IndexName).toBeUndefined();
+      expect(lastCall.KeyConditionExpression).toBe("session_id = :sid");
+      // The point of the tier: no school predicate at all.
+      expect(lastCall.FilterExpression).toBeUndefined();
+      expect(lastCall.ExpressionAttributeValues).toEqual({ ":sid": "sess-1" });
+    });
+
+    it("warns with both names when it recovers docs by ignoring the school name", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([makeStudent()]);
+      mocks.mockSend
+        .mockResolvedValueOnce({ Items: [] })
+        .mockResolvedValueOnce({ Items: [] })
+        .mockResolvedValueOnce({ Items: [makeV2Doc({ school: "JNV Ramanagara" })] });
+
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      await getTestDeepDiveFromDynamo("school-1", "JNV Bangalore South", 10, "sess-1");
+
+      const recoveryWarning = consoleWarn.mock.calls
+        .map((c) => String(c[0]))
+        .find((m) => m.includes("ignoring the school name"));
+      consoleWarn.mockRestore();
+
+      expect(recoveryWarning).toBeDefined();
+      // Both sides of the mismatch must be in the log, or the next person has
+      // to re-derive the rename from scratch.
+      expect(recoveryWarning).toContain("JNV Bangalore South");
+      expect(recoveryWarning).toContain("JNV Ramanagara");
+    });
+
+    // An unfiltered scan must not leak another school's students into this
+    // school's deep dive — the roster intersection is what keeps it correct.
+    it("does not leak other schools' docs when the unfiltered scan runs", async () => {
+      mocks.mockQuery.mockResolvedValueOnce([makeStudent()]);
+      mocks.mockSend
+        .mockResolvedValueOnce({ Items: [] })
+        .mockResolvedValueOnce({ Items: [] })
+        .mockResolvedValueOnce({
+          Items: [
+            makeV2Doc({ school: "JNV Ramanagara" }),
+            makeV2Doc({
+              school: "JNV Some Other School",
+              user_id: "other-u",
+              student_id: "other-stu",
+              apaar_id: "other-apaar",
+            }),
+          ],
+        });
+
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { getTestDeepDiveFromDynamo } = await importModule();
+      const result = await getTestDeepDiveFromDynamo(
+        "school-1",
+        "JNV Bangalore South",
+        10,
+        "sess-1"
+      );
+      consoleWarn.mockRestore();
+
+      // Only the roster student survives the identifier intersection.
+      expect(result?.students).toHaveLength(1);
+      expect(result?.students[0].student_name).toBe("Alice Smith");
+      expect(result?.students[0].enrollment_user_id).toBe("enrollment-u1");
     });
   });
 

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -138,6 +138,9 @@ interface V2ReportHeader {
 interface V2ReportDoc {
   session_id: string;
   user_id: string;
+  // Partition key of the school_session_index GSI, stamped from BigQuery at
+  // write time and never re-stamped — so it can lag a school rename.
+  school?: string;
   student_id?: string;
   apaar_id?: string;
   report_header?: V2ReportHeader;
@@ -341,6 +344,37 @@ export async function getTestDeepDiveFromDynamo(
       `[deep-dive] gsi returned 0 docs for school="${schoolName}" session=${sessionId} — falling back to filtered partition scan`
     );
     allDocs = await getAllReportsForSession(sessionId, schoolName);
+  }
+  // Last resort: drop the school filter entirely. Both tiers above match the
+  // doc's `school` attribute by EXACT string equality against the Postgres
+  // name, so any drift between the two makes every test for that school 404
+  // with "No results available for this test yet" — no error, no log, just an
+  // empty page for every historical test at once.
+  //
+  // A school RENAME is the way this happens in practice: report docs are
+  // stamped with the school name at write time and never re-stamped, so
+  // renaming a school in Postgres orphans every doc written before it. This is
+  // not hypothetical — school 532 (udise 29320810110) was renamed
+  // "JNV Ramanagara" -> "JNV Bangalore South" on 2026-09-04 and every test up
+  // to that date went blank, while tests written after it kept working.
+  //
+  // Scoping by school is only an optimisation here: the identifier
+  // intersection below already restricts docs to this school's roster, so
+  // reading the unfiltered partition is no less correct — it just costs a
+  // second partition read. We only pay it on a path that is otherwise a
+  // guaranteed 404, which makes it a strict improvement.
+  if (allDocs.length === 0) {
+    allDocs = await getAllReportsForSession(sessionId);
+    if (allDocs.length > 0) {
+      const docSchools = [
+        ...new Set(allDocs.map((d) => d.school).filter(Boolean)),
+      ];
+      console.warn(
+        `[deep-dive] recovered ${allDocs.length} doc(s) for session=${sessionId} only after ignoring the school name: ` +
+          `Postgres says "${schoolName}" but the docs carry ${JSON.stringify(docSchools)}. ` +
+          `This is the school-rename failure mode — re-run the etl-next v2 report flow for this school so the docs are re-stamped.`
+      );
+    }
   }
   if (allDocs.length === 0) return null;
 


### PR DESCRIPTION
# Performance missing in Bangalore South

Fixes the Performance tab showing "No results available for this test yet" for every historical
test at JNV Bangalore South. Root cause is a school rename orphaning the report docs the deep dive
reads.

## The bug

The Performance tab's per-test deep dive is the only DynamoDB-backed route on the page: it reads
`student_quiz_reports_v2` and finds a school's docs by matching the doc's `school` attribute with
**exact string equality** against the school name in Postgres (both the `school_session_index` GSI
query and its fallback partition scan). There is no BigQuery fallback.

Report docs are stamped with the school name **at write time and never re-stamped**. So renaming a
school in Postgres orphans every doc written before the rename: both school-scoped reads return
nothing, `getTestDeepDiveFromDynamo` returns `null`, and the page shows

> No results available for this test yet. Please check back in a few hours.

for *every historical test at once* — with no error, no log, and no way to tell it apart from a
precompute that genuinely hasn't run yet.

## This actually happened

School 532 (code 49095, udise 29320810110) was renamed **`JNV Ramanagara` → `JNV Bangalore South`
at 2026-09-04 05:31:53** — same id, same code, same UDISE. Every JNV Bangalore South test up to
that date went blank; the one test written after it (11P5, 2026-09-07) kept working.

Verified from BigQuery time travel, which dates the rename precisely:

```sql
SELECT student_school, COUNT(*)
FROM `avantifellows.production_dbt_final.fact_student_test_results_overall`
  FOR SYSTEM_TIME AS OF TIMESTAMP '2026-09-02 00:00:00 UTC'
WHERE student_school_udise_code = '29320810110'
GROUP BY 1
-- → JNV Ramanagara (1670 rows).  Same query today → JNV Bangalore South (same 1670 rows).
```

Two things made this hard to diagnose, and are worth knowing next time:

- **The Combined Student Reports card on the same page stayed READY throughout.** That pipeline
  posts an explicit student id list to the reporting engine and never filters on school name, so a
  rename doesn't touch it. **A READY combined report next to a 404-ing deep dive is the tell that
  the docs exist and the school name is what's wrong** — not that the precompute is missing.
- Its "29 of 30 students" also cleared the roster path: 30 is the same
  `getSchoolRoster` + `filterActiveRosterStudents` output the deep dive uses.

## The change

Adds a last-resort third tier: when both school-scoped reads come back empty, scan the session
partition **unfiltered** and let the existing roster identifier intersection scope the docs.

That intersection (`student_id` / `apaar_id` / `user_id` against the school's roster) is what makes
the result correct in the first place — scoping by school name is only an optimisation. So dropping
the school predicate is **no less correct**; it costs one extra partition read, and only on a path
that is otherwise a guaranteed 404. There's a test asserting another school's docs still can't leak
in through the unfiltered scan.

On recovery it logs both sides of the mismatch — the Postgres name and the names the docs actually
carry — so the next occurrence is diagnosable from the logs rather than from scratch.

## Scope / follow-up

This is a **read-side stopgap**. The docs themselves are still stamped with the stale name; the
proper fix is to **re-run etl-next's v2 report flow for the affected school** so they get
re-stamped. Worth deciding separately whether a school rename should trigger that automatically —
right now a rename is a silent, retroactive outage of all historical test analytics for that school.

## Tests

- `npx vitest run` — 265 files, 3705 passed, 3 skipped.
- 3 new tests in `src/lib/dynamodb.test.ts`; all 3 fail without the source change (verified by
  stashing it), so they're real regression coverage.
- Two existing tests updated for the extra tier.
- `npx eslint src/lib/dynamodb.ts src/lib/dynamodb.test.ts` — clean.
- `tsc --noEmit` reports no errors in either changed file (the repo has ~2283 pre-existing errors
  across 53 unrelated `*.test` files on this baseline).
