### PR TITLE
fix(cms): redirect test PDFs via S3 instead of proxying through Amplify

### DIFF
--- a/src/app/api/cms/test-pdf/route.test.ts
+++ b/src/app/api/cms/test-pdf/route.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  requireCmsServiceAccess: vi.fn(),
+  buildTransientKey: vi.fn(),
+  uploadTransientObject: vi.fn(),
+  presignDocumentPage: vi.fn(),
+}));
+
+vi.mock("@/lib/cms-service", () => ({
+  requireCmsServiceAccess: mocks.requireCmsServiceAccess,
+}));
+vi.mock("@/lib/s3", () => ({
+  buildTransientKey: mocks.buildTransientKey,
+  uploadTransientObject: mocks.uploadTransientObject,
+  presignDocumentPage: mocks.presignDocumentPage,
+}));
+
+import { GET } from "./route";
+
+const CMS = { url: "https://cms.test", token: "cms-token" };
+const SIGNED_URL = "https://bucket.s3.ap-south-1.amazonaws.com/k?X-Amz-Signature=sig";
+const PDF_BYTES = new TextEncoder().encode("%PDF-1.4 fake");
+
+function req(query: string) {
+  return new NextRequest(`https://lms.test/api/cms/test-pdf?${query}`);
+}
+
+function cmsOk(headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    arrayBuffer: async () => PDF_BYTES.buffer.slice(0),
+    text: async () => "",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  mocks.requireCmsServiceAccess.mockResolvedValue({ ok: true, cms: CMS });
+  mocks.buildTransientKey.mockReturnValue("lms-documents/tmp/cms-test-pdf/uuid.pdf");
+  mocks.uploadTransientObject.mockResolvedValue(undefined);
+  mocks.presignDocumentPage.mockResolvedValue(SIGNED_URL);
+});
+
+describe("GET /api/cms/test-pdf", () => {
+  it("returns the access response when the caller is not allowed", async () => {
+    const denied = new Response(null, { status: 401 });
+    mocks.requireCmsServiceAccess.mockResolvedValue({ ok: false, response: denied });
+
+    const res = await GET(req("testId=7"));
+
+    expect(res.status).toBe(401);
+    expect(mocks.uploadTransientObject).not.toHaveBeenCalled();
+  });
+
+  it("400s without a testId", async () => {
+    const res = await GET(req("type=questions"));
+    expect(res.status).toBe(400);
+  });
+
+  it("stages the PDF in S3 and redirects to a presigned URL instead of returning the bytes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      cmsOk({ "content-disposition": 'inline; filename="paper.pdf"' })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await GET(req("testId=7&type=questions"));
+
+    // The CMS is called with the service bearer token.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cms.test/api/service/test-pdf?id=7&type=questions",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer cms-token" },
+      })
+    );
+
+    // The bytes go to a transient key, never back through this response.
+    expect(mocks.buildTransientKey).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "cms-test-pdf", extension: "pdf" })
+    );
+    const upload = mocks.uploadTransientObject.mock.calls[0][0];
+    expect(upload.s3Key).toBe("lms-documents/tmp/cms-test-pdf/uuid.pdf");
+    expect(upload.contentType).toBe("application/pdf");
+    expect(Buffer.isBuffer(upload.body)).toBe(true);
+    expect(upload.body.toString()).toBe("%PDF-1.4 fake");
+
+    expect(mocks.presignDocumentPage).toHaveBeenCalledWith({
+      s3Key: "lms-documents/tmp/cms-test-pdf/uuid.pdf",
+      ttlSeconds: 300,
+      responseContentType: "application/pdf",
+      responseContentDisposition: 'inline; filename="paper.pdf"',
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(SIGNED_URL);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-type")).not.toBe("application/pdf");
+  });
+
+  // The motivating bug: Amplify's Lambda caps SSR responses at ~5.7MB, so any paper bigger
+  // than that 504'd when proxied. Pin that a PDF well over the cap never enters this route's
+  // response body — it goes to S3 whole, and the browser gets only a redirect.
+  it("never carries a >6MB PDF in the response body", async () => {
+    const eightMb = 8 * 1024 * 1024;
+    const big = new Uint8Array(eightMb);
+    big.set(new TextEncoder().encode("%PDF-1.4"), 0);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ...cmsOk(),
+        arrayBuffer: async () => big.buffer,
+      })
+    );
+
+    const res = await GET(req("testId=7"));
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(SIGNED_URL);
+    // A redirect has no payload; the bytes must not have come back through Lambda.
+    expect(res.body).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+
+    const upload = mocks.uploadTransientObject.mock.calls[0][0];
+    expect(upload.body.byteLength).toBe(eightMb);
+    expect(upload.body.subarray(0, 8).toString()).toBe("%PDF-1.4");
+  });
+
+  it("uses a fresh key per request", async () => {
+    mocks.buildTransientKey.mockRestore();
+    const { buildTransientKey } = await vi.importActual<typeof import("@/lib/s3")>("@/lib/s3");
+    process.env.S3_DOCS_PREFIX = "lms-documents";
+    mocks.buildTransientKey.mockImplementation(buildTransientKey);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(cmsOk()));
+
+    await GET(req("testId=7"));
+    await GET(req("testId=7"));
+
+    const [a, b] = mocks.uploadTransientObject.mock.calls.map((c) => c[0].s3Key as string);
+    expect(a).toMatch(/^lms-documents\/tmp\/cms-test-pdf\/[0-9a-f-]{36}\.pdf$/);
+    expect(a).not.toBe(b);
+  });
+
+  it("forces an attachment disposition when download=1", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        cmsOk({ "content-disposition": 'inline; filename="paper.pdf"' })
+      )
+    );
+
+    await GET(req("testId=7&download=1"));
+
+    expect(mocks.presignDocumentPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseContentDisposition: 'attachment; filename="paper.pdf"',
+      })
+    );
+  });
+
+  it("defaults the filename when the CMS sends no disposition", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(cmsOk()));
+
+    await GET(req("testId=7"));
+
+    expect(mocks.presignDocumentPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseContentDisposition: 'inline; filename="test.pdf"',
+      })
+    );
+  });
+
+  it("passes a CMS failure status through without touching S3", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        text: async () => "no such test",
+      })
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(req("testId=7"));
+
+    expect(res.status).toBe(404);
+    expect(mocks.uploadTransientObject).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("502s when the CMS is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(req("testId=7"));
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Failed to reach CMS" });
+    errSpy.mockRestore();
+  });
+
+  it("502s (no redirect) when staging in S3 fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(cmsOk()));
+    mocks.uploadTransientObject.mockRejectedValue(new Error("AccessDenied"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(req("testId=7"));
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Failed to stage PDF" });
+    expect(res.headers.get("location")).toBeNull();
+    expect(mocks.presignDocumentPage).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/src/app/api/cms/test-pdf/route.ts
+++ b/src/app/api/cms/test-pdf/route.ts
@@ -1,13 +1,28 @@
+import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCmsServiceAccess } from "@/lib/cms-service";
+import {
+  buildTransientKey,
+  presignDocumentPage,
+  uploadTransientObject,
+} from "@/lib/s3";
 
 // On-demand PDF for a new-CMS test, so session details can offer question/answer PDFs the
-// same way legacy sessions do — but generated fresh by the CMS rather than stored. Proxies
-// the CMS service-PDF route (bearer-authed) and streams the bytes back. Nothing is stored;
-// the PDF always reflects the current test. See task lms-cms-tests.
+// same way legacy sessions do — but generated fresh by the CMS rather than stored. Fetches
+// the CMS service-PDF route (bearer-authed) and hands the bytes to the browser. The PDF
+// always reflects the current test. See task lms-cms-tests.
+//
+// The bytes are NOT returned from this route. Amplify caps SSR responses at ~5.7MB and does
+// not stream API routes, so a larger paper 504'd with no useful error. Instead the PDF is
+// staged as a transient S3 object (lifecycle-expired after a day) and the browser is
+// redirected to a short-lived presigned URL. Lambda's outbound side has no such cap.
+//
 // Only the two variants we surface (legacy showed Question + Solution): the question paper
 // and the answer key. The CMS also supports questions_with_answers, not exposed here.
 const PDF_TYPES = ["questions", "answers"];
+
+// Long enough to survive a slow click-through, short enough that a leaked link is useless.
+const PRESIGN_TTL_SECONDS = 300;
 
 // fallow-ignore-next-line complexity
 export async function GET(request: NextRequest) {
@@ -55,9 +70,10 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Stream the PDF straight through, preserving the CMS-supplied filename. With
-  // download=1, force an attachment so the browser saves instead of rendering inline.
-  const body = await response.arrayBuffer();
+  // Preserve the CMS-supplied filename. With download=1, force an attachment so the
+  // browser saves instead of rendering inline. The disposition rides on the presigned URL
+  // (response-content-disposition) because <a download> is ignored cross-origin.
+  const body = Buffer.from(await response.arrayBuffer());
   let disposition =
     response.headers.get("content-disposition") ?? `inline; filename="test.pdf"`;
   if (download) {
@@ -66,11 +82,33 @@ export async function GET(request: NextRequest) {
       disposition = `attachment; ${disposition.replace(/^[^;]*;\s*/, "")}`;
     }
   }
-  return new NextResponse(body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": disposition,
-    },
+
+  const s3Key = buildTransientKey({
+    kind: "cms-test-pdf",
+    id: randomUUID(),
+    extension: "pdf",
   });
+  let signedUrl: string;
+  try {
+    await uploadTransientObject({
+      s3Key,
+      body,
+      contentType: "application/pdf",
+    });
+    signedUrl = await presignDocumentPage({
+      s3Key,
+      ttlSeconds: PRESIGN_TTL_SECONDS,
+      responseContentType: "application/pdf",
+      responseContentDisposition: disposition,
+    });
+  } catch (err) {
+    console.error("Failed to stage CMS PDF in S3:", err);
+    return NextResponse.json({ error: "Failed to stage PDF" }, { status: 502 });
+  }
+
+  // 302 (not 307) so the redirect is a plain GET regardless of how it was reached, and
+  // no-store so nothing caches a URL that dies in five minutes.
+  const redirect = NextResponse.redirect(signedUrl, 302);
+  redirect.headers.set("Cache-Control", "no-store");
+  return redirect;
 }

--- a/src/lib/s3.test.ts
+++ b/src/lib/s3.test.ts
@@ -12,6 +12,8 @@ import {
   uploadDocumentPages,
   deleteDocumentObjects,
   presignDocumentPage,
+  buildTransientKey,
+  uploadTransientObject,
   S3UploadError,
   __resetS3ClientForTesting,
 } from "./s3";
@@ -231,5 +233,56 @@ describe("presignDocumentPage", () => {
     });
 
     expect(url).toContain("response-content-type=application");
+  });
+
+  it("passes ResponseContentDisposition into the signed URL when provided", async () => {
+    const url = await presignDocumentPage({
+      s3Key: "test-prefix/tmp/cms-test-pdf/u.pdf",
+      ttlSeconds: 300,
+      responseContentDisposition: 'attachment; filename="paper.pdf"',
+    });
+
+    expect(url).toContain("response-content-disposition=attachment");
+    expect(url).toContain("paper.pdf");
+  });
+});
+
+describe("transient objects", () => {
+  it("buildTransientKey nests under <prefix>/tmp/ so the lifecycle rule can expire it", () => {
+    expect(
+      buildTransientKey({ kind: "cms-test-pdf", id: "abc-123", extension: "pdf" }),
+    ).toBe("test-prefix/tmp/cms-test-pdf/abc-123.pdf");
+  });
+
+  it("uploadTransientObject PUTs the bytes with the given content type", async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+    const body = Buffer.from("%PDF");
+
+    await uploadTransientObject({
+      s3Key: "test-prefix/tmp/cms-test-pdf/abc.pdf",
+      body,
+      contentType: "application/pdf",
+    });
+
+    const calls = s3Mock.commandCalls(PutObjectCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toMatchObject({
+      Bucket: "test-bucket",
+      Key: "test-prefix/tmp/cms-test-pdf/abc.pdf",
+      ContentType: "application/pdf",
+    });
+    expect(calls[0].args[0].input.Body).toBe(body);
+  });
+
+  it("uploadTransientObject propagates S3 errors so the route can fail instead of redirecting", async () => {
+    s3Mock.on(PutObjectCommand).rejects(new Error("AccessDenied"));
+
+    await expect(
+      uploadTransientObject({
+        s3Key: "test-prefix/tmp/cms-test-pdf/abc.pdf",
+        body: Buffer.from("x"),
+        contentType: "application/pdf",
+      }),
+    ).rejects.toThrow("AccessDenied");
   });
 });

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -136,10 +136,14 @@ export async function uploadDocumentPages(opts: {
 
 // Sign a short-lived GET URL for a single S3 key. Used by the viewer route
 // to hand the browser a direct link without proxying bytes through Lambda.
+// `responseContentDisposition` is how a cross-origin link forces a save: the
+// `download` attribute on <a> is ignored for cross-origin hrefs, so the
+// attachment disposition has to come from S3 itself.
 export async function presignDocumentPage(opts: {
   s3Key: string;
   ttlSeconds: number;
   responseContentType?: string;
+  responseContentDisposition?: string;
 }): Promise<string> {
   return getSignedUrl(
     client(),
@@ -149,8 +153,43 @@ export async function presignDocumentPage(opts: {
       ...(opts.responseContentType
         ? { ResponseContentType: opts.responseContentType }
         : {}),
+      ...(opts.responseContentDisposition
+        ? { ResponseContentDisposition: opts.responseContentDisposition }
+        : {}),
     }),
     { expiresIn: opts.ttlSeconds },
+  );
+}
+
+// --- Transient objects -------------------------------------------------------
+//
+// Bounce storage for bytes we must not proxy through Amplify's Lambda: SSR
+// responses cap at ~5.7MB and API routes can't stream, so anything bigger
+// (CMS-generated test PDFs, for one) 504s if we return it directly. Instead the
+// route stages the bytes here, presigns a GET and 302s the browser to it.
+//
+// Everything under <prefix>/tmp/ is expired by a bucket lifecycle rule after a
+// day. Nothing here is a record; never reference a transient key from the DB.
+export function buildTransientKey(opts: {
+  kind: string;
+  id: string;
+  extension: string;
+}): string {
+  return `${prefix()}/tmp/${opts.kind}/${opts.id}.${opts.extension}`;
+}
+
+export async function uploadTransientObject(opts: {
+  s3Key: string;
+  body: Buffer;
+  contentType: string;
+}): Promise<void> {
+  await client().send(
+    new PutObjectCommand({
+      Bucket: bucket(),
+      Key: opts.s3Key,
+      Body: opts.body,
+      ContentType: opts.contentType,
+    }),
   );
 }
 


### PR DESCRIPTION
## Problem

Downloading a CMS-generated question/answer PDF from session details 504'd whenever the paper was over ~6 MB. `/api/cms/test-pdf` proxied the bytes back through Amplify's SSR Lambda, which caps responses at ~5.7 MB and does not stream API routes.

## Fix

The route still fetches the PDF from the CMS with the service token, but instead of returning it:

1. uploads it to a transient S3 key, `lms-documents/tmp/cms-test-pdf/<uuid>.pdf`
2. presigns a 5-minute GET with `response-content-disposition` carrying the CMS filename (and `attachment` when `download=1`, since `<a download>` is ignored cross-origin)
3. returns a `302` to that URL with `Cache-Control: no-store`

S3 failure returns a 502 rather than redirecting to a missing key. Lambda's outbound side has no size cap, so paper size no longer matters.

Same pattern already used by the student-document page route.

## Infra (done)

- Bucket lifecycle rule `ExpireLmsTransientObjectsAfter1Day` added on `avantifellows-documents`, scoped to prefix `lms-documents/tmp/` (expiry 1 day, noncurrent versions 1 day, abort multipart 1 day). Existing 90-day rule untouched.
- IAM user `af-lms-s3` already allows PutObject on `lms-documents/*`; no change.
- Amplify `main`/`staging` both have `S3_DOCS_PREFIX=lms-documents`, matching the rule.

## Tests

- 13 new tests. Route: auth denial, missing testId, happy path, fresh key per request, download=1, default filename, CMS 404 pass-through, CMS unreachable, S3 failure, and an 8 MB PDF producing a bodiless redirect.
- `npx vitest run`: 266 files, 3716 passed, 3 skipped. ESLint and tsc clean on changed files.
- Not exercised against a real CMS locally; please verify on staging with a large paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zbRFvbWjJWs6jeTfPraYr
