### PR TITLE
admin: hide mutation controls from read-only admins on all grids

### DIFF
--- a/src/app/admin/batches/BatchList.test.tsx
+++ b/src/app/admin/batches/BatchList.test.tsx
@@ -481,3 +481,11 @@ describe("BatchList — save edit", () => {
     expect(screen.getByText("unknown_stream")).toBeInTheDocument();
   });
 });
+
+describe("BatchList read-only viewer (D116)", () => {
+  it("replaces every Edit button with a Read-only marker", () => {
+    render(<BatchList {...defaultProps} viewerReadOnly />);
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("Read-only").length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/admin/batches/BatchList.tsx
+++ b/src/app/admin/batches/BatchList.tsx
@@ -25,6 +25,8 @@ interface BatchListProps {
   initialBatches: Batch[];
   programs: Program[];
   initialProgramId: number;
+  /** Admin (Read Only) viewer: hide the Edit control (the API 403s the write anyway). */
+  viewerReadOnly?: boolean;
 }
 
 const STREAM_OPTIONS = [
@@ -52,6 +54,7 @@ export default function BatchList({
   initialBatches,
   programs,
   initialProgramId,
+  viewerReadOnly = false,
 }: BatchListProps) {
   const [batches, setBatches] = useState(initialBatches);
   const [selectedProgramId, setSelectedProgramId] = useState(initialProgramId);
@@ -295,6 +298,8 @@ export default function BatchList({
                             Cancel
                           </Button>
                         </div>
+                      ) : viewerReadOnly ? (
+                        <span className="text-xs text-gray-400">Read-only</span>
                       ) : (
                         <Button
                           variant="ghost"

--- a/src/app/admin/batches/page.test.tsx
+++ b/src/app/admin/batches/page.test.tsx
@@ -3,10 +3,11 @@ import { render, screen } from "@testing-library/react";
 
 // ---- mocks (hoisted) ----
 
-const { mockGetServerSession, mockIsAdmin, mockRedirect, mockFetch } =
+const { mockGetServerSession, mockIsAdmin, mockGetUserPermission, mockRedirect, mockFetch } =
   vi.hoisted(() => ({
     mockGetServerSession: vi.fn(),
     mockIsAdmin: vi.fn(),
+    mockGetUserPermission: vi.fn(),
     mockRedirect: vi.fn((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     }),
@@ -16,7 +17,7 @@ const { mockGetServerSession, mockIsAdmin, mockRedirect, mockFetch } =
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
-vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
+vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin, getUserPermission: mockGetUserPermission }));
 vi.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -150,5 +151,31 @@ describe("BatchManagementPage (server component)", () => {
     const batchList = screen.getByTestId("batch-list");
     const props = JSON.parse(batchList.getAttribute("data-props")!);
     expect(props.initialBatches).toEqual([]);
+  });
+});
+
+describe("BatchManagementPage read-only admin (D116)", () => {
+  it("passes viewerReadOnly to BatchList when the admin's permission is read_only", async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    mockIsAdmin.mockResolvedValue(true);
+    mockGetUserPermission.mockResolvedValue({ role: "admin", read_only: true });
+    mockFetch.mockResolvedValue({ ok: false });
+
+    render(await BatchManagementPage());
+
+    const props = JSON.parse(screen.getByTestId("batch-list").getAttribute("data-props")!);
+    expect(props.viewerReadOnly).toBe(true);
+  });
+
+  it("passes viewerReadOnly=false for a read/write admin", async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    mockIsAdmin.mockResolvedValue(true);
+    mockGetUserPermission.mockResolvedValue({ role: "admin", read_only: false });
+    mockFetch.mockResolvedValue({ ok: false });
+
+    render(await BatchManagementPage());
+
+    const props = JSON.parse(screen.getByTestId("batch-list").getAttribute("data-props")!);
+    expect(props.viewerReadOnly).toBe(false);
   });
 });

--- a/src/app/admin/batches/page.tsx
+++ b/src/app/admin/batches/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { isAdmin } from "@/lib/permissions";
+import { getUserPermission, isAdmin } from "@/lib/permissions";
 import Link from "next/link";
 import BatchList from "./BatchList";
 
@@ -58,6 +58,14 @@ export default async function BatchManagementPage() {
   }
 
   const admin = await isAdmin(session.user.email);
+
+  // Read-only admins may look but not touch: the API already 403s their
+
+  // writes (forWrite guards); this hides the controls too (D116).
+
+  const permission = await getUserPermission(session.user.email);
+
+  const viewerReadOnly = !!permission?.read_only;
   if (!admin) {
     redirect("/dashboard");
   }
@@ -99,6 +107,7 @@ export default async function BatchManagementPage() {
           initialBatches={batches}
           programs={programs}
           initialProgramId={DEFAULT_PROGRAM_ID}
+          viewerReadOnly={viewerReadOnly}
         />
       </main>
     </div>

--- a/src/app/admin/centres/CentreGrid.test.tsx
+++ b/src/app/admin/centres/CentreGrid.test.tsx
@@ -578,3 +578,22 @@ describe("CentreGrid", () => {
     expect(screen.getByRole("heading", { name: "New Centre" })).toBeInTheDocument();
   });
 });
+
+describe("CentreGrid read-only viewer (D116)", () => {
+  it("hides New Centre and the per-card Edit controls", () => {
+    render(
+      <CentreGrid
+        initialRows={rows}
+        initialSummary={summary}
+        initialFilters={filters}
+        initialPagination={{ page: 1, limit: 25, totalRows: rows.length, totalPages: 1 }}
+        optionSets={optionSets}
+        viewerReadOnly
+      />
+    );
+    expect(screen.queryByRole("button", { name: "New Centre" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    // The list itself still renders for read-only admins.
+    expect(screen.getByText(rows[0].name)).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/centres/CentreGrid.tsx
+++ b/src/app/admin/centres/CentreGrid.tsx
@@ -47,6 +47,8 @@ interface CentreGridProps {
     totalPages: number;
   };
   optionSets: CentreOptionSet[];
+  /** Admin (Read Only) viewer: hide New/Edit controls (the API 403s the writes anyway). */
+  viewerReadOnly?: boolean;
 }
 
 type EditMode = "create" | "edit";
@@ -95,6 +97,7 @@ export default function CentreGrid({
   initialFilters,
   initialPagination,
   optionSets,
+  viewerReadOnly = false,
 }: CentreGridProps) {
   const [rows, setRows] = useState(initialRows);
   const [summary, setSummary] = useState(initialSummary);
@@ -423,10 +426,12 @@ export default function CentreGrid({
             Manage Centre records and their School links.
           </p>
         </div>
-        <Button size="sm" onClick={openCreate}>
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          New Centre
-        </Button>
+        {!viewerReadOnly && (
+          <Button size="sm" onClick={openCreate}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            New Centre
+          </Button>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
@@ -606,7 +611,7 @@ export default function CentreGrid({
                 row={row}
                 expanded={expandedIds.has(row.id)}
                 onToggle={() => toggleExpanded(row.id)}
-                onEdit={() => openEdit(row)}
+                onEdit={viewerReadOnly ? undefined : () => openEdit(row)}
               />
             ))}
           </ul>
@@ -1132,7 +1137,8 @@ function CentreCard({
   row: CentreListRow;
   expanded: boolean;
   onToggle: () => void;
-  onEdit: () => void;
+  /** Absent for read-only viewers: the card renders without an Edit control. */
+  onEdit?: () => void;
 }) {
   return (
     <li>
@@ -1216,12 +1222,14 @@ function CentreCard({
             </div>
           </div>
 
-          <div className="mt-3 flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={onEdit}>
-              <Edit2 className="h-4 w-4" aria-hidden="true" />
-              Edit
-            </Button>
-          </div>
+          {onEdit && (
+            <div className="mt-3 flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={onEdit}>
+                <Edit2 className="h-4 w-4" aria-hidden="true" />
+                Edit
+              </Button>
+            </div>
+          )}
         </div>
 
         {expanded && (

--- a/src/app/admin/centres/page.test.tsx
+++ b/src/app/admin/centres/page.test.tsx
@@ -4,12 +4,14 @@ import { render, screen } from "@testing-library/react";
 const {
   mockGetServerSession,
   mockIsAdmin,
+  mockGetUserPermission,
   mockRedirect,
   mockGetCentreList,
   mockGetCentreOptionSets,
 } = vi.hoisted(() => ({
   mockGetServerSession: vi.fn(),
   mockIsAdmin: vi.fn(),
+  mockGetUserPermission: vi.fn(),
   mockRedirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
@@ -20,7 +22,7 @@ const {
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
-vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
+vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin, getUserPermission: mockGetUserPermission }));
 vi.mock("@/lib/centres", () => ({
   getCentreList: mockGetCentreList,
   getCentreOptionSets: mockGetCentreOptionSets,

--- a/src/app/admin/centres/page.tsx
+++ b/src/app/admin/centres/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
+import { getUserPermission, isAdmin } from "@/lib/permissions";
 import { getCentreList, getCentreOptionSets } from "@/lib/centres";
 import CentreGrid from "./CentreGrid";
 
@@ -21,6 +21,14 @@ export default async function CentresPage({ searchParams }: CentresPageProps = {
   }
 
   const admin = await isAdmin(session.user.email);
+
+  // Read-only admins may look but not touch: the API already 403s their
+
+  // writes (forWrite guards); this hides the controls too (D116).
+
+  const permission = await getUserPermission(session.user.email);
+
+  const viewerReadOnly = !!permission?.read_only;
   if (!admin) {
     redirect("/dashboard");
   }
@@ -74,6 +82,7 @@ export default async function CentresPage({ searchParams }: CentresPageProps = {
             initialFilters={centresResult.filters}
             initialPagination={centresResult.pagination}
             optionSets={optionSetsResult.optionSets}
+            viewerReadOnly={viewerReadOnly}
           />
         ) : (
           <div className="rounded-md border border-danger/30 bg-danger-bg p-4 text-sm text-danger">

--- a/src/app/admin/schools/SchoolList.test.tsx
+++ b/src/app/admin/schools/SchoolList.test.tsx
@@ -544,3 +544,12 @@ describe("SchoolList", () => {
     });
   });
 });
+
+describe("SchoolList read-only viewer (D116)", () => {
+  it("replaces every Edit button with a Read-only marker", () => {
+    render(<SchoolList initialSchools={sampleSchools} viewerReadOnly />);
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("Read-only").length).toBe(sampleSchools.length);
+    expect(screen.getByText("Delhi Public School")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/schools/SchoolList.tsx
+++ b/src/app/admin/schools/SchoolList.tsx
@@ -13,6 +13,8 @@ interface School {
 
 interface SchoolListProps {
   initialSchools: School[];
+  /** Admin (Read Only) viewer: hide the Edit control (the API 403s the write anyway). */
+  viewerReadOnly?: boolean;
 }
 
 const PROGRAM_LABELS: Record<number, string> = {
@@ -33,7 +35,7 @@ const PROGRAMS = [
   { id: 64, name: "NVS", description: "NVS program" },
 ];
 
-export default function SchoolList({ initialSchools }: SchoolListProps) {
+export default function SchoolList({ initialSchools, viewerReadOnly = false }: SchoolListProps) {
   const [schools, setSchools] = useState(initialSchools);
   const [editingSchool, setEditingSchool] = useState<School | null>(null);
   const [selectedPrograms, setSelectedPrograms] = useState<number[]>([]);
@@ -217,13 +219,17 @@ export default function SchoolList({ initialSchools }: SchoolListProps) {
                   )}
                 </td>
                 <td className="whitespace-nowrap px-3 py-4 text-sm">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => openEditModal(school)}
-                  >
-                    Edit
-                  </Button>
+                  {viewerReadOnly ? (
+                    <span className="text-xs text-gray-400">Read-only</span>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => openEditModal(school)}
+                    >
+                      Edit
+                    </Button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/app/admin/schools/page.test.tsx
+++ b/src/app/admin/schools/page.test.tsx
@@ -3,10 +3,11 @@ import { render, screen } from "@testing-library/react";
 
 // ---- mocks (hoisted) ----
 
-const { mockGetServerSession, mockIsAdmin, mockRedirect, mockQuery } =
+const { mockGetServerSession, mockIsAdmin, mockGetUserPermission, mockRedirect, mockQuery } =
   vi.hoisted(() => ({
     mockGetServerSession: vi.fn(),
     mockIsAdmin: vi.fn(),
+    mockGetUserPermission: vi.fn(),
     mockRedirect: vi.fn((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     }),
@@ -16,7 +17,7 @@ const { mockGetServerSession, mockIsAdmin, mockRedirect, mockQuery } =
 vi.mock("next-auth", () => ({ getServerSession: mockGetServerSession }));
 vi.mock("@/lib/auth", () => ({ authOptions: {} }));
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
-vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin }));
+vi.mock("@/lib/permissions", () => ({ isAdmin: mockIsAdmin, getUserPermission: mockGetUserPermission }));
 vi.mock("@/lib/db", () => ({ query: mockQuery }));
 vi.mock("next/link", () => ({
   __esModule: true,
@@ -123,5 +124,19 @@ describe("SchoolsPage (server component)", () => {
     const schoolList = screen.getByTestId("school-list");
     const props = JSON.parse(schoolList.getAttribute("data-props")!);
     expect(props.initialSchools).toEqual([]);
+  });
+});
+
+describe("SchoolsPage read-only admin (D116)", () => {
+  it("passes viewerReadOnly to SchoolList when the admin's permission is read_only", async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    mockIsAdmin.mockResolvedValue(true);
+    mockGetUserPermission.mockResolvedValue({ role: "admin", read_only: true });
+    mockQuery.mockResolvedValue(mockSchools);
+
+    render(await SchoolsPage());
+
+    const props = JSON.parse(screen.getByTestId("school-list").getAttribute("data-props")!);
+    expect(props.viewerReadOnly).toBe(true);
   });
 });

--- a/src/app/admin/schools/page.tsx
+++ b/src/app/admin/schools/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { isAdmin } from "@/lib/permissions";
+import { getUserPermission, isAdmin } from "@/lib/permissions";
 import { query } from "@/lib/db";
 import Link from "next/link";
 import SchoolList from "./SchoolList";
@@ -31,6 +31,14 @@ export default async function SchoolsPage() {
   }
 
   const admin = await isAdmin(session.user.email);
+
+  // Read-only admins may look but not touch: the API already 403s their
+
+  // writes (forWrite guards); this hides the controls too (D116).
+
+  const permission = await getUserPermission(session.user.email);
+
+  const viewerReadOnly = !!permission?.read_only;
   if (!admin) {
     redirect("/dashboard");
   }
@@ -65,7 +73,7 @@ export default async function SchoolsPage() {
       </header>
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <SchoolList initialSchools={schools} />
+        <SchoolList initialSchools={schools} viewerReadOnly={viewerReadOnly} />
       </main>
     </div>
   );

--- a/src/app/admin/staff/StaffGrid.test.tsx
+++ b/src/app/admin/staff/StaffGrid.test.tsx
@@ -744,3 +744,20 @@ describe("StaffGrid", () => {
     });
   });
 });
+
+describe("StaffGrid read-only viewer (D116)", () => {
+  it("hides Add User and every row Edit control, showing a Read-only marker instead", () => {
+    render(
+      <StaffGrid
+        initialRows={ROWS}
+        initialSummary={SUMMARY}
+        initialFilters={FILTERS}
+        viewerReadOnly
+      />
+    );
+    expect(screen.queryByLabelText("Add user")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Edit /)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Read-only").length).toBe(ROWS.length);
+    expect(screen.getByText("Read-only view of centre staff and their seats.")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/staff/StaffGrid.tsx
+++ b/src/app/admin/staff/StaffGrid.tsx
@@ -21,6 +21,8 @@ interface StaffGridProps {
   initialRows: StaffRosterRow[];
   initialSummary: StaffRosterSummary;
   initialFilters: StaffRosterFilters;
+  /** Admin (Read Only) viewer: hide Add/Edit controls (the API 403s the writes anyway). */
+  viewerReadOnly?: boolean;
 }
 
 interface CentreOptionItem {
@@ -171,6 +173,7 @@ export default function StaffGrid({
   initialRows,
   initialSummary,
   initialFilters,
+  viewerReadOnly = false,
 }: StaffGridProps) {
   const [rows, setRows] = useState(initialRows);
   const [summary, setSummary] = useState(initialSummary);
@@ -602,12 +605,15 @@ export default function StaffGrid({
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-text-muted">
-          Add centre staff (teachers &amp; PMs) and seat them here — no separate
-          permissions step.
+          {viewerReadOnly
+            ? "Read-only view of centre staff and their seats."
+            : "Add centre staff (teachers & PMs) and seat them here — no separate permissions step."}
         </p>
-        <Button onClick={openAddModal} aria-label="Add user" className="shrink-0">
-          <Plus className="mr-1 h-4 w-4" /> Add User
-        </Button>
+        {!viewerReadOnly && (
+          <Button onClick={openAddModal} aria-label="Add user" className="shrink-0">
+            <Plus className="mr-1 h-4 w-4" /> Add User
+          </Button>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
@@ -804,14 +810,18 @@ export default function StaffGrid({
                   </div>
                   {/* Every row is editable — pending_teacher opens the
                       create-teacher flow; others open the edit/seat modal. */}
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => openModal(row)}
-                    aria-label={`Edit ${row.name || row.email}`}
-                  >
-                    <Edit2 className="mr-1 h-4 w-4" /> Edit
-                  </Button>
+                  {viewerReadOnly ? (
+                    <span className="text-xs text-gray-400">Read-only</span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => openModal(row)}
+                      aria-label={`Edit ${row.name || row.email}`}
+                    >
+                      <Edit2 className="mr-1 h-4 w-4" /> Edit
+                    </Button>
+                  )}
                 </div>
               </Card>
             ))}

--- a/src/app/admin/staff/page.tsx
+++ b/src/app/admin/staff/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { authOptions } from "@/lib/auth";
-import { isAdmin } from "@/lib/permissions";
+import { getUserPermission, isAdmin } from "@/lib/permissions";
 import { getStaffRoster } from "@/lib/staff-admin";
 import StaffGrid from "./StaffGrid";
 
@@ -21,6 +21,14 @@ export default async function StaffPage({ searchParams }: StaffPageProps = {}) {
   }
 
   const admin = await isAdmin(session.user.email);
+
+  // Read-only admins may look but not touch: the API already 403s their
+
+  // writes (forWrite guards); this hides the controls too (D116).
+
+  const permission = await getUserPermission(session.user.email);
+
+  const viewerReadOnly = !!permission?.read_only;
   if (!admin) {
     redirect("/dashboard");
   }
@@ -71,6 +79,7 @@ export default async function StaffPage({ searchParams }: StaffPageProps = {}) {
             initialRows={rosterResult.rows}
             initialSummary={rosterResult.summary}
             initialFilters={rosterResult.filters}
+            viewerReadOnly={viewerReadOnly}
           />
         ) : (
           <div className="rounded-md border border-danger/30 bg-danger-bg p-4 text-sm text-danger">


### PR DESCRIPTION
## Summary
Admin (Read Only) landed with #275, but only `/admin/users` hid its controls. StaffGrid, CentreGrid, SchoolList and BatchList still rendered Add/New/Edit for read-only admins and let them hit a 403 from the API.

- Each admin page resolves `getUserPermission` and passes `viewerReadOnly={!!permission?.read_only}` to its grid, the same shape `UserList` already takes.
- Grids hide the entry points (Add User / New Centre / row Edit) and show a grey "Read-only" marker in the action cell. Filters, search, pagination and expand/collapse are untouched. Since the modals cannot be opened, their inner Save/Vacate/Exit buttons never render for read-only viewers.
- `CentreCard.onEdit` becomes optional so the card renders without an Edit control.

Closes DEBT D116.

## Test plan
- [x] 7 new tests: one read-only render test per grid, plus page-level tests on batches and schools asserting the prop follows `read_only`
- [x] Full suite 265 files / 3709 tests green; eslint clean; no non-test tsc errors
- [ ] Log in as a read-only admin on staging and check /admin/staff, /admin/centres, /admin/schools, /admin/batches show no Add/Edit controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxmATXTV3p2sZMJ2NuPLiR