### PR TITLE
Show partially-correct answers as their own status in the question drill-down

### DIFF
--- a/src/components/performance/StudentResultsTable.tsx
+++ b/src/components/performance/StudentResultsTable.tsx
@@ -26,11 +26,13 @@ type QStatus = "idle" | "loading" | "loaded" | "error";
 
 const STATUS_LABEL: Record<StudentQuestionRow["status"], string> = {
   correct: "Correct",
+  partial: "Partially correct",
   wrong: "Wrong",
   skipped: "Skipped",
 };
 const STATUS_CLASS: Record<StudentQuestionRow["status"], string> = {
   correct: "text-accent",
+  partial: "text-warning",
   wrong: "text-danger",
   skipped: "text-text-muted",
 };

--- a/src/lib/bigquery.test.ts
+++ b/src/lib/bigquery.test.ts
@@ -446,21 +446,23 @@ describe("getTestQuestionLevelData", () => {
 });
 
 describe("getStudentQuestionLevelData", () => {
-  it("maps is_answered/is_correct to correct/wrong/skipped status", async () => {
+  it("maps is_answered/is_correct/is_partially_correct to correct/partial/wrong/skipped status", async () => {
     const rows = [
       // answered + correct -> correct
-      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q1", position_index: 0, is_answered: 1, is_correct: 1 },
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q1", position_index: 0, is_answered: 1, is_correct: 1, is_partially_correct: 0 },
       // answered + incorrect -> wrong
-      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q2", position_index: 1, is_answered: 1, is_correct: 0 },
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Kinematics", chapter_id: "c-kin", question_id: "q2", position_index: 1, is_answered: 1, is_correct: 0, is_partially_correct: 0 },
       // not answered -> skipped (is_correct irrelevant)
-      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Optics", chapter_id: "c-opt", question_id: "q3", position_index: 2, is_answered: 0, is_correct: 0 },
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Optics", chapter_id: "c-opt", question_id: "q3", position_index: 2, is_answered: 0, is_correct: 0, is_partially_correct: 0 },
+      // answered, not fully correct, but credited under partial marking -> partial (NOT wrong)
+      { enrollment_user_id: 368592, subject: "Physics", chapter_name: "Optics", chapter_id: "c-opt", question_id: "q4", position_index: 3, is_answered: 1, is_correct: 0, is_partially_correct: 1 },
     ];
     mocks.mockQueryFn.mockResolvedValueOnce([rows]);
 
     const { getStudentQuestionLevelData } = await import("./bigquery");
     const result = await getStudentQuestionLevelData("11223344", 12, "sess-1");
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(result[0]).toMatchObject({
       enrollment_user_id: "368592", // stringified for client-side matching
       chapter_id: "c-kin",
@@ -470,6 +472,7 @@ describe("getStudentQuestionLevelData", () => {
     });
     expect(result[1].status).toBe("wrong");
     expect(result[2].status).toBe("skipped");
+    expect(result[3].status).toBe("partial");
   });
 
   it("groups by enrollment_user_id and binds filter params", async () => {

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -560,7 +560,8 @@ export async function getStudentQuestionLevelData(
       question_id,
       ANY_VALUE(question_position_index) AS position_index,
       MAX(CAST(is_answered AS INT64)) AS is_answered,
-      MAX(is_correct) AS is_correct
+      MAX(is_correct) AS is_correct,
+      MAX(CAST(is_partially_correct AS INT64)) AS is_partially_correct
     FROM ${FACT_QUESTION_LEVEL_TABLE}
     WHERE student_school_udise_code = @udise
       AND student_grade = @grade
@@ -583,6 +584,7 @@ export async function getStudentQuestionLevelData(
     position_index: number | string | null;
     is_answered: number | string | null;
     is_correct: number | string | null;
+    is_partially_correct: number | string | null;
   }
 
   const toInt = (v: number | string | null | undefined): number => {
@@ -595,11 +597,16 @@ export async function getStudentQuestionLevelData(
   return (rows as RawRow[]).map((r) => {
     const answered = toInt(r.is_answered) > 0;
     const correct = toInt(r.is_correct) === 1;
+    // Partial marking (JEE Advanced multi-correct): answered, not fully correct,
+    // but credited — its own bucket, not "wrong", matching the report's counts.
+    const partial = toInt(r.is_partially_correct) === 1;
     const status: StudentQuestionRow["status"] = !answered
       ? "skipped"
       : correct
         ? "correct"
-        : "wrong";
+        : partial
+          ? "partial"
+          : "wrong";
     return {
       enrollment_user_id: String(r.enrollment_user_id ?? ""),
       chapter_id: r.chapter_id || null,

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -216,7 +216,9 @@ export interface StudentQuestionRow {
   chapter_name: string;
   question_id: string;
   position_index: number | null;
-  status: "correct" | "wrong" | "skipped";
+  // "partial" = answered and credited under partial marking (JEE Advanced) —
+  // neither fully correct nor wrong.
+  status: "correct" | "partial" | "wrong" | "skipped";
 }
 
 export interface StudentQuestionLevelData {


### PR DESCRIPTION
Companion to the etl-next/reporting fix for partially-correct counting (a CoE Lucknow student's report showed Wrong = 7 in the headline and 10 in the chapter row; the 3 partially-correct answers were being counted as wrong at chapter level and shown nowhere).

The LMS Deep Dive chapter/student counts come from the report doc and fix themselves once the fact and doc carry the aligned numbers. The **question drill-down** is BQ-direct and had the same blind spot: any answered, not-fully-correct question rendered as "Wrong".

- `bigquery.ts` — read `is_partially_correct` from `fact_student_test_results_question_level`; status becomes `partial` when answered, not correct, and partially credited.
- `types/quiz.ts` — `StudentQuestionRow.status` gains `"partial"`.
- `StudentResultsTable.tsx` — label "Partially correct", warning colour.
- Test extended with a partial row (must be `partial`, not `wrong`).

Tests: bigquery + performance component suites 88/88. ESLint clean. (`tsc` reports pre-existing `vi`/`beforeEach` global errors in `BatchList.test.tsx`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)